### PR TITLE
Makefile: use `go mod vendor`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ unit-v:
 local-dev-up:
 	$(docker-compose) up -d claircore-db
 	$(docker) exec -it claircore_claircore-db_1 bash -c 'while ! pg_isready; do echo "waiting for postgres"; sleep 2; done'
+	go mod vendor
 	$(docker-compose) up -d libscanhttp
 	$(docker-compose) up -d libvulnhttp
 

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,7 @@ podman-dev-up:
 		postgres:11
 	podman pod start claircore-dev
 	until podman healthcheck run claircore-database; do sleep 2; done
+	go mod vendor
 	podman create\
 		--pod claircore-dev\
 		--name libscanhttp\
@@ -105,7 +106,7 @@ podman-dev-up:
 		--expose 8080\
 		--volume $$(git rev-parse --show-toplevel)/:/src/claircore/:z\
 		golang:1.13\
-		bash -c 'cd /src/claircore/cmd/libscanhttp; exec go run *'
+		bash -c 'cd /src/claircore/cmd/libscanhttp; exec go run -mod vendor .'
 	podman create\
 		--pod claircore-dev\
 		--name libvulnhttp\
@@ -117,7 +118,7 @@ podman-dev-up:
 		--expose 8081\
 		--volume $$(git rev-parse --show-toplevel)/:/src/claircore/:z\
 		golang:1.13\
-		bash -c 'cd /src/claircore/cmd/libvulnhttp; exec go run *'
+		bash -c 'cd /src/claircore/cmd/libvulnhttp; exec go run -mod vendor .'
 	podman pod start claircore-dev
 
 # TODO(hank) When the latest podman lands with 'generate systemd' support for

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,7 +34,7 @@ services:
     volumes:
       - "./:/src/claircore/"
     command:
-      [ "bash", "-c", "cd /src/claircore/cmd/libscanhttp; go run *" ]
+      [ "bash", "-c", "cd /src/claircore/cmd/libscanhttp; go run -mod vendor ." ]
 
   libvulnhttp:
     image: golang:1.13.0
@@ -49,4 +49,4 @@ services:
     volumes:
       - "./:/src/claircore/"
     command:
-      [ "bash", "-c", "cd /src/claircore/cmd/libvulnhttp; go run *" ]
+      [ "bash", "-c", "cd /src/claircore/cmd/libvulnhttp; go run -mod vendor ." ]


### PR DESCRIPTION
These commits make the development helpers populate a vendor directory and use them, instead of always downloading modules in the container.