### PR TITLE
Updater: unique constraint size fix

### DIFF
--- a/internal/vulnstore/postgres/bootstrap.sql
+++ b/internal/vulnstore/postgres/bootstrap.sql
@@ -1,4 +1,3 @@
---- Vulnerability
 --- a unique vulnerability indexed by an updater
 CREATE TABLE vuln (
     updater text,
@@ -19,11 +18,13 @@ CREATE TABLE vuln (
     arch text,
     fixed_in_version text,
     --- a tombstone field that will be updated to signify a vulnerability is not stale
-    tombstone text,
-    unique(
+    tombstone text
+);
+CREATE INDEX vuln_lookup_idx on vuln(package_name, dist_version_code_name, dist_name, dist_version_id, dist_version, arch);
+CREATE UNIQUE INDEX vuln_unique_idx on vuln(  
         updater, 
         name, 
-        description, 
+        md5(description), 
         links,
         severity,
         package_name, 
@@ -36,9 +37,7 @@ CREATE TABLE vuln (
         dist_version_id, 
         arch,
         fixed_in_version
-    )
-);
-CREATE INDEX vuln_lookup_idx on vuln(package_name, dist_version_code_name, dist_name, dist_version_id, dist_version, arch);
+    );
 
 --- UpdateHash
 --- a key/value hstore holding the latest update hash for a particular updater

--- a/internal/vulnstore/postgres/putvulnerabilities.go
+++ b/internal/vulnstore/postgres/putvulnerabilities.go
@@ -54,7 +54,7 @@ const (
 					$16)
 	ON conflict (updater,
 				 name,
-				 description,
+				 md5(description),
 				 links,
 				 severity,
 				 package_name,


### PR DESCRIPTION
We want to force unique constraints on vulnerability records to support tombstoning without large amounts of writes and deletes. 

We ran into an issue where the "description" column gets too large for the btree index.

This fix does an md5 hash on the "description" column when evaluating the unique index. The output of the md5 hash is now the index key. 