### PR TITLE
oracle: add Oracle Linux oval updater

### DIFF
--- a/oracle/oracle_test.go
+++ b/oracle/oracle_test.go
@@ -1,0 +1,14 @@
+package oracle
+
+import (
+	"os"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+func TestMain(m *testing.M) {
+	log.Logger = zerolog.Nop()
+	os.Exit(m.Run())
+}

--- a/oracle/parser.go
+++ b/oracle/parser.go
@@ -1,0 +1,261 @@
+package oracle
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/quay/claircore"
+	"github.com/quay/claircore/libvuln/driver"
+	ovalhelper "github.com/quay/claircore/pkg/oval"
+
+	"github.com/quay/goval-parser/oval"
+	"github.com/rs/zerolog"
+)
+
+var _ driver.Parser = (*Updater)(nil)
+
+// Parse implements driver.Parser.
+func (u *Updater) Parse(r io.ReadCloser) ([]*claircore.Vulnerability, error) {
+	ctx := u.logger.WithContext(context.Background())
+	// In tests, this takes at least 140 seconds. So, round up on the automatic
+	// timeout.
+	ctx, done := context.WithTimeout(ctx, 5*time.Minute)
+	defer done()
+	return u.ParseContext(ctx, r)
+}
+
+// DistMap is a helper to prevent making thousands of Distribution objects.
+type distMap map[int]*claircore.Distribution
+
+func newDistMap() distMap {
+	return distMap(make(map[int]*claircore.Distribution))
+}
+func (m distMap) Version(v int) *claircore.Distribution {
+	d, ok := m[v]
+	if !ok {
+		d = &claircore.Distribution{}
+		d.VersionID = strconv.Itoa(v)
+		d.Name = "Oracle Linux"
+		d.Version = fmt.Sprintf("%s %s", d.Name, d.VersionID)
+		m[v] = d
+	}
+	return d
+}
+
+// ParseContext is like Parse, but with context.
+func (u *Updater) ParseContext(ctx context.Context, r io.ReadCloser) ([]*claircore.Vulnerability, error) {
+	log := zerolog.Ctx(ctx).With().Str("component", u.Name()).Logger()
+	log.Info().Msg("starting parse")
+	defer r.Close()
+	root := oval.Root{}
+	if err := xml.NewDecoder(r).Decode(&root); err != nil {
+		return nil, fmt.Errorf("oracle: unable to decode OVAL document: %w", err)
+	}
+	log.Debug().Msg("xml decoded")
+
+	db := &db{
+		root:    &root,
+		distMap: newDistMap(),
+	}
+	vs := make([]*claircore.Vulnerability, 0, len(root.Definitions.Definitions))
+
+	for i, def := range root.Definitions.Definitions {
+		if i != 0 && i%1000 == 0 {
+			log.Debug().Msgf("processed %d definitions", i)
+		}
+		// It's likely that we'll have multiple vulnerabilites spawned from once
+		// CVE/definition, so this constructs new records on demand.
+		mkVuln := func() *claircore.Vulnerability {
+			return &claircore.Vulnerability{
+				Updater:     u.Name(),
+				Name:        def.References[0].RefID,
+				Description: strings.TrimSpace(def.Description),
+				Severity:    def.Advisory.Severity,
+				Links:       ovalhelper.Links(def),
+				Package:     &claircore.Package{},
+			}
+		}
+
+		crit, err := walk(&def.Criteria)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, crit := range crit {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			default:
+			}
+			v, err := db.populate(ctx, mkVuln(), crit)
+			if err != nil {
+				return nil, err
+			}
+			if v.Package.Name != "" {
+				vs = append(vs, v)
+			}
+		}
+	}
+
+	log.Info().Msgf("found %d vulnerabilities in %d definitions", len(vs), len(root.Definitions.Definitions))
+	return vs, nil
+}
+
+type db struct {
+	root    *oval.Root
+	distMap distMap
+}
+
+// Walk returns a slice of slices of Criterions that should be AND'd together to
+// determine if a package is vulnerable.
+func walk(root *oval.Criteria) ([][]*oval.Criterion, error) {
+	out := make([][]*oval.Criterion, 0)
+	testRefs := []*oval.Criterion{}
+	var fn func([]*oval.Criterion, *oval.Criteria) error
+	fn = func(stack []*oval.Criterion, cur *oval.Criteria) error {
+		switch cur.Operator {
+		case "AND":
+			for i := range cur.Criterions {
+				c := &cur.Criterions[i]
+				stack = append(stack, c)
+			}
+			if len(cur.Criterias) == 0 {
+				// the current node's Criterions are leaves
+				r := make([]*oval.Criterion, len(stack))
+				copy(r, stack)
+				out = append(out, r)
+			}
+			for _, c := range cur.Criterias {
+				if err := fn(stack, &c); err != nil {
+					return err
+				}
+			}
+		case "OR":
+			// TODO(hank) See if it's valid to have an OR node with criterions
+			// and criterias.
+			if len(cur.Criterions) == 0 {
+				for _, c := range cur.Criterias {
+					if err := fn(stack, &c); err != nil {
+						return err
+					}
+				}
+			}
+			for i := range cur.Criterions {
+				c := &cur.Criterions[i]
+				stack = append(stack, c)
+				for _, c := range cur.Criterias {
+					if err := fn(stack, &c); err != nil {
+						return err
+					}
+				}
+			}
+		default:
+			return fmt.Errorf("oracle: walking oval definition: unknown operator %q", cur.Operator)
+		}
+		return nil
+	}
+
+	return out, fn(testRefs, root)
+}
+
+func (db *db) populate(_ context.Context, v *claircore.Vulnerability, crit []*oval.Criterion) (*claircore.Vulnerability, error) {
+	var rt *oval.RPMInfoTest
+	var obj *oval.RPMInfoObject
+	var state *oval.RPMInfoState
+
+	for _, c := range crit {
+		// First, resolve our test.
+		k, i, err := db.root.Tests.Lookup(c.TestRef)
+		if err != nil {
+			return nil, fmt.Errorf("oracle: dangling ref: %w", err)
+		}
+		if k != "rpminfo_test" {
+			continue
+		}
+		rt = &db.root.Tests.RPMInfoTests[i]
+		if len(rt.ObjectRefs) != 1 {
+			return nil, fmt.Errorf("unsure how to handle multple object references in a test")
+		}
+
+		// Then, resolve the object the test is referencing.
+		objRef := rt.ObjectRefs[0].ObjectRef
+		k, objidx, err := db.root.Objects.Lookup(objRef)
+		if err != nil {
+			return nil, fmt.Errorf("oracle: dangling ref: %w", err)
+		}
+		if k != "rpminfo_object" {
+			continue
+		}
+		obj = &db.root.Objects.RPMInfoObjects[objidx]
+
+		//  If the object is "redhat-release", special case it to pull out
+		//  distro version information, and associte that with the current
+		//  package.
+		switch {
+		case obj == nil:
+			return nil, fmt.Errorf("unable to lookup ref %q (probably programmer error)", objRef)
+		case obj.Name == "oraclelinux-release":
+			var state *oval.RPMInfoState
+			for _, sr := range rt.StateRefs {
+				k, i, err := db.root.States.Lookup(sr.StateRef)
+				if err != nil {
+					return nil, fmt.Errorf("oracle: dangling ref: %w", err)
+				}
+				if k != "rpminfo_state" {
+					// ???
+					continue
+				}
+				state = &db.root.States.RPMInfoStates[i]
+				var ver int
+				switch {
+				case state.RPMVersion != nil:
+					if _, err := fmt.Sscanf(state.RPMVersion.Body, `^%d`, &ver); err != nil {
+						return nil, err
+					}
+				case state.EVR != nil:
+					if _, err := fmt.Sscanf(state.EVR.Body, `0:%d`, &ver); err != nil {
+						return nil, err
+					}
+				}
+				v.Package.Dist = db.distMap.Version(ver)
+			}
+			continue
+		default:
+		}
+
+		// Otherwise, resolve the states referenced in the tests and populate
+		// the package struct in this vulnerability
+		for _, sr := range rt.StateRefs {
+			k, i, err := db.root.States.Lookup(sr.StateRef)
+			if err != nil {
+				return nil, fmt.Errorf("oracle: dangling ref: %w", err)
+			}
+			if k != "rpminfo_state" { // ???
+				continue
+			}
+			state = &db.root.States.RPMInfoStates[i]
+
+			switch {
+			case state.SignatureKeyID != nil:
+				// Skip checking the signing key ID for now. Later we
+				// should use this to associate the package with a
+				// repository.
+				continue
+			case state.EVR != nil:
+				v.Package.Name = obj.Name
+				v.Package.Version = state.EVR.Body
+				v.Package.NameVersion = fmt.Sprintf("%s %s", v.Package.Name, v.Package.Version)
+				v.Package.Kind = "binary"
+			case state.Arch != nil:
+				// ???
+			}
+		}
+	}
+
+	return v, nil
+}

--- a/oracle/parser.go
+++ b/oracle/parser.go
@@ -193,7 +193,7 @@ func (db *db) populate(_ context.Context, v *claircore.Vulnerability, crit []*ov
 		}
 		obj = &db.root.Objects.RPMInfoObjects[objidx]
 
-		//  If the object is "redhat-release", special case it to pull out
+		//  If the object is "oraclelinux-release", special case it to pull out
 		//  distro version information, and associte that with the current
 		//  package.
 		switch {

--- a/oracle/parser_test.go
+++ b/oracle/parser_test.go
@@ -1,0 +1,172 @@
+package oracle
+
+import (
+	"context"
+	"encoding/xml"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/quay/claircore/test/log"
+
+	"github.com/quay/goval-parser/oval"
+)
+
+func TestParse(t *testing.T) {
+	t.Parallel()
+	l := log.TestLogger(t)
+	ctx := l.WithContext(context.Background())
+	u, err := NewUpdater()
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Open("testdata/com.oracle.elsa-2018.xml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vs, err := u.ParseContext(ctx, f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("found %d vulnerabilities", len(vs))
+	if got, want := len(vs), 3128; got != want {
+		t.Fatalf("got: %d vulnerabilities, want: %d vulnerabilities", got, want)
+	}
+}
+
+// TestWalk tests the recursive criterion walker.
+func TestWalk(t *testing.T) {
+	t.Parallel()
+	want := []string{
+		`Oracle Linux 7 is installed AND 389-ds-base is earlier than 0:1.3.5.10-11.el7 AND 389-ds-base is signed with the Oracle Linux 7 key`,
+		`Oracle Linux 7 is installed AND 389-ds-base-libs is earlier than 0:1.3.5.10-11.el7 AND 389-ds-base-libs is signed with the Oracle Linux 7 key`,
+		`Oracle Linux 7 is installed AND 389-ds-base-snmp is earlier than 0:1.3.5.10-11.el7 AND 389-ds-base-snmp is signed with the Oracle Linux 7 key`,
+		`Oracle Linux 7 is installed AND 389-ds-base-devel is earlier than 0:1.3.5.10-11.el7 AND 389-ds-base-devel is signed with the Oracle Linux 7 key`,
+	}
+	c, err := walk(&ovalDef.Criteria)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := make([]string, len(c))
+	for i, cs := range c {
+		b := strings.Builder{}
+		for i, c := range cs {
+			if i != 0 {
+				b.WriteString(" AND ")
+			}
+			b.WriteString(c.Comment)
+		}
+		got[i] = b.String()
+		t.Log(b.String())
+	}
+	if got, want := len(got), len(want); got != want {
+		t.Fatalf("got: len(got) == %d, want: len(got) == %d", got, want)
+	}
+	for i := range want {
+		if got, want := got[i], want[i]; got != want {
+			t.Fatalf("got: %q, want: %q", got, want)
+		}
+	}
+}
+
+var ovalDef = oval.Definition{XMLName: xml.Name{Space: "http://oval.mitre.org/XMLSchema/oval-definitions-5", Local: "definition"},
+	ID:    "oval:com.oracle.elsa:def:20162594",
+	Class: "patch",
+	Title: "\nELSA-2016-2594:  389-ds-base security, bug fix, and enhancement update (MODERATE)\n",
+	Affecteds: []oval.Affected{
+		{XMLName: xml.Name{Space: "http://oval.mitre.org/XMLSchema/oval-definitions-5", Local: "affected"},
+			Family:    "unix",
+			Platforms: []string{"Oracle Linux 7"}}},
+	References: []oval.Reference{
+		{XMLName: xml.Name{Space: "http://oval.mitre.org/XMLSchema/oval-definitions-5", Local: "reference"},
+			Source: "elsa",
+			RefID:  "ELSA-2016-2594",
+			RefURL: "http://linux.oracle.com/errata/ELSA-2016-2594.html"},
+		{XMLName: xml.Name{Space: "http://oval.mitre.org/XMLSchema/oval-definitions-5", Local: "reference"},
+			Source: "CVE",
+			RefID:  "CVE-2016-4992",
+			RefURL: "http://linux.oracle.com/cve/CVE-2016-4992.html"},
+		{XMLName: xml.Name{Space: "http://oval.mitre.org/XMLSchema/oval-definitions-5", Local: "reference"},
+			Source: "CVE",
+			RefID:  "CVE-2016-5405",
+			RefURL: "http://linux.oracle.com/cve/CVE-2016-5405.html"},
+		{XMLName: xml.Name{Space: "http://oval.mitre.org/XMLSchema/oval-definitions-5", Local: "reference"},
+			Source: "CVE",
+			RefID:  "CVE-2016-5416",
+			RefURL: "http://linux.oracle.com/cve/CVE-2016-5416.html"}},
+	Description: "\n[1.3.5.10-11]\n- Release 1.3.5.10-11\n- Resolves: bug 1321124 - Replication changelog can incorrectly skip over updates\n\n[1.3.5.10-10]\n- Release 1.3.5.10-10\n- Resolves: bug 1370300 - set proper update status to replication agreement in case of failure (DS 48957)\n- Resolves: bug 1209094 - Allow logging of rejected changes (DS 48969)\n\n[1.3.5.10-9]\n- Release 1.3.5.10-9\n- Resolves: bug 1364190 - Change example in /etc/sysconfig/dirsrv to use tcmalloc (DS 48950)\n- Resolves: bug 1366828 - audit on failure doesn't work if attribute nsslapd-auditlog-logging-enabled is NOT enabled (DS 48958)\n- Resolves: bug 1368520 - Crash in import_wait_for_space_in_fifo() (DS 48960)\n- Resolves: bug 1368956 - man page of ns-accountstatus.pl shows redundant entries for -p port option\n- Resolves: bug 1369537 - passwordMinAge attribute doesn't limit the minimum age of the password (DS 48967)\n- Resolves: bug 1369570 - cleanallruv changelog cleaning incorrectly impacts all backend (DS 48964)\n- Resolves: bug 1369425 - ACI behaves erratically (DS 48972)\n- Resolves: bug 1370300 - set proper update status to replication agreement in case of failure (DS 48957)\n- Resolves: bug 1209094 - Allow logging of rejected changes (DS 48969)\n- Resolves: bug 1371283 - Server Side Sorting crashes the server. (DS 48970)\n- Resolves: bug 1371284 - Disabling CLEAR password storage scheme will crash server when setting a password (DS 48975)\n\n[1.3.5.10-8]\n- Release 1.3.5.10-8\n- Resolves: bug 1321124 - Replication changelog can incorrectly skip over updates (DS 48954)\n- Resolves: bug 1364190 - Change example in /etc/sysconfig/dirsrv to use tcmalloc (DS 48950)\n- Resolves: bug 1366561 - ns-accountstatus.pl giving error even 'No such object (32)' (DS 48956)\n\n[1.3.5.10-7]\n- Release 1.3.5.10-7\n- Resolves: bug 1316580 - dirsrv service doesn't ask for pin when pin.txt is missing (DS 48450)\n- Resolves: bug 1360976 - fixing a compiler warning\n\n[1.3.5.10-6]\n- Release 1.3.5.10-6\n- Resolves: bug 1326077 - Page result search should return empty cookie if there is no returned entry (DS 48928)\n- Resolves: bug 1360447 - nsslapd-workingdir is empty when ns-slapd is started by systemd (DS 48939)\n- Resolves: bug 1360327 - remove-ds.pl deletes an instance even if wrong prefix was specified (DS 48934)\n- Resolves: bug 1349815 - DS logs have warning:ancestorid not indexed for all CS subsystems (DS 48940)\n- Resolves: bug 1329061 - 389-ds-base-1.3.4.0-29.el7_2 'hang' (DS 48882)\n- Resolves: bug 1360976 - EMBARGOED CVE-2016-5405 389-ds-base: Password verification vulnerable to timing attack\n- Resolves: bug 1361134 - When fine-grained policy is applied, a sub-tree has a priority over a user while changing password (DS 48943)\n- Resolves: bug 1361321 - Duplicate collation entries (DS 48936)\n- Resolves: bug 1316580 - dirsrv service doesn't ask for pin when pin.txt is missing (DS 48450)\n- Resolves: bug 1350799 - CVE-2016-4992 389-ds-base: Information disclosure via repeat\n\n[1.3.5.10-5]\n- Release 1.3.5.10-5\n- Resolves: bug 1333184 - (389-ds-base-1.3.5) Fixing coverity issues. (DS 48919)\n\n[1.3.5.10-4]\n- Release 1.3.5.10-4\n- Resolves: bug 1209128 - [RFE] Add a utility to get the status of Directory Server instances (DS 48144)\n- Resolves: bug 1333184 - (389-ds-base-1.3.5) Fixing coverity issues. (DS 48919)\n- Resolves: bug 1350799 - CVE-2016-4992 389-ds-base: Information disclosure via repeat\n- Resolves: bug 1354660 - flow control in replication also blocks receiving results (DS 48767)\n- Resolves: bug 1356261 - Fixup tombstone task needs to set proper flag when updating (DS 48924)\n- Resolves: bug 1355760 - ns-slapd crashes during the deletion of backend (DS 48922)\n- Resolves: bug 1353629 - DS shuts down automatically if dnaThreshold is set to 0 in a MMR setup (DS 48916)\n- Resolves: bug 1355879 - nunc-stans: ns-slapd crashes during startup with SIGILL on AMD Opteron 280 (DS 48925)\n\n[1.3.5.10-3]\n- Release 1.3.5.10-3\n- Resolves: bug 1354374 - Fixing the tarball version in the sources file.\n\n[1.3.5.10-2]\n- Release 1.3.5.10-2\n- Resolves: bug 1353714 - If a cipher is disabled do not attempt to look it up (DS 48743)\n- Resolves: bug 1353592 - Setup-ds.pl --update fails - regression (DS 48755)\n- Resolves: bug 1353544 - db2bak.pl task enters infinitive loop when bak fs is almost full (DS 48914)\n- Resolves: bug 1354374 - Upgrade to 389-ds-base >= 1.3.5.5 doesn't install 389-ds-base-snmp (DS 48918)\n\n[1.3.5.10-1]\n- Release 1.3.5.10-1\n- Resolves: bug 1333184 - (389-ds-base-1.3.5) Fixing coverity issues. (DS 48905)\n\n[1.3.5.9-1]\n- Release 1.3.5.9-1\n- Resolves: bug 1349571 - Improve MMR replication convergence (DS 48636)\n- Resolves: bug 1304682 - 'stale' automember rule (associated to a removed group) causes discrepancies in the database (DS 48637)\n- Resolves: bug 1314956 - moving an entry cause next on-line init to skip entry has no parent, ending at line 0 of file '(bulk import)' (DS 48755)\n- Resolves: bug 1316731 - syncrepl search returning error 329; plugin sending a bad error code (DS 48904)\n- Resolves: bug 1346741 - ns-slapd crashes during the shutdown after adding attribute with a matching rule  (DS 48891)\n- Resolves: bug 1349577 - Values of dbcachetries/dbcachehits in cn=monitor could overflow. (DS 48899)\n- Resolves: bug 1272682 - nunc-stans: ns-slapd killed by SIGABRT (DS 48898)\n- Resolves: bug 1346043 - repl-monitor displays colors incorrectly for the time lag > 60 min (DS 47538)\n- Resolves: bug 1350632 - ns-slapd shutdown crashes if pwdstorageschema name is from stack. (DS 48902)\n\n[1.3.5.8-1]\n- Release 1.3.5.8-1\n- Resolves: bug 1290101 - proxyauth support does not work when bound as directory  manager (DS 48366)\n\n[1.3.5.7-1]\n- Release 1.3.5.7-1\n- Resolves: bug 1196282 - substring index with nssubstrbegin: 1 is not being used with filters like (attr=x*) (DS 48109)\n- Resolves: bug 1303794 - Import readNSState.py from RichM's repo (DS 48449)\n- Resolves: bug 1290101 - proxyauth support does not work when bound as directory  manager (DS 48366)\n- Resolves: bug 1338872 - Wrong result code display in audit-failure log (DS 48892)\n- Resolves: bug 1346043 - repl-monitor displays colors incorrectly for the time lag > 60 min (DS 47538)\n- Resolves: bug 1346741 - ns-slapd crashes during the shutdown after adding attribute with a matching rule  (DS 48891)\n- Resolves: bug 1347407 - By default aci can be read by anonymous (DS 48354)\n- Resolves: bug 1347412 - cn=SNMP,cn=config entry can be read by anonymous (DS 48893)\n\n[1.3.5.6-1]\n- Release 1.3.5.6-1\n- Resolves: bug 1273549 - [RFE] Improve timestamp resolution in logs (DS 47982)\n- Resolves: bug 1321124 - Replication changelog can incorrectly skip over updates (DS 48766, DS 48636)\n- Resolves: bug 1233926 - 'matching rules' in ACI's 'bind rules not fully evaluated (DS 48234)\n- Resolves: bug 1346165 - 389-ds-base-1.3.5.5-1.el7.x86_64 requires policycoreutils-py\n\n[1.3.5.5-1]\n- Release 1.3.5.5-1\n- Resolves: bug 1018944 - [RFE] Enhance password change tracking (DS 48833)\n- Resolves: bug 1344414 - [RFE] adding pre/post extop ability (DS 48880)\n- Resolves: bug 1303794 - Import readNSState.py from RichM's repo (DS 48449)\n- Resolves: bug 1257568 - /usr/lib64/dirsrv/libnunc-stans.so is owned by both -libs and -devel (DS 48404)\n- Resolves: bug 1314956 - moving an entry cause next on-line init to skip entry has no parent, ending at line 0 of file '(bulk import)' (DS 48755)\n- Resolves: bug 1342609 - At startup DES to AES password conversion causes timeout in start script (DS 48862)\n- Resolves: bug 1316328 - search returns no entry when OR filter component contains non readable attribute (DS 48275)\n- Resolves: bug 1280456 - setup-ds should detect if port is already defined (DS 48336)\n- Resolves: bug 1312557 - dirsrv service fails to start when nsslapd-listenhost is configured (DS 48747)\n- Resolves: bug 1326077 - Page result search should return empty cookie if there is no returned entry (DS 48752)\n- Resolves: bug 1340307 - Running db2index with no options breaks replication (DS 48854)\n- Resolves: bug 1337195 - Regression introduced in matching rules by DS 48746 (DS 48844)\n- Resolves: bug 1335492 - Modifier's name is not recorded in the audit log with modrdn and moddn operations (DS 48834)\n- Resolves: bug 1316741 - ldctl should support -H with ldap uris (DS 48754)\n\n[1.3.5.4-1]\n- release 1.3.5.4-1\n- Resolves: bug 1334455 - db2ldif is not taking into account multiple suffixes or backends (DS 48828)\n- Resolves: bug 1241563 - The 'repl-monitor' web page does not display 'year' in date. (DS 48220)\n- Resolves: bug 1335618 - Server ram sanity checks work in isolation (DS 48617)\n- Resolves: bug 1333184 - (389-ds-base-1.3.5) Fixing coverity issues. (DS 48837)\n\n[1.3.5.3-1]\n- release 1.3.5.3-1\n- Resolves: bug 1209128 - [RFE] Add a utility to get the status of Directory Server instances (DS 48144)\n- Resolves: bug 1332533 - ns-accountstatus.pl gives error message on execution along with results. (DS 48815)\n- Resolves: bug 1332709 - password history is not updated when an admin resets the password (DS 48813)\n- Resolves: bug 1333184 - (389-ds-base-1.3.5) Fixing coverity issues. (DS 48822)\n- Resolves: bug 1333515 - Enable DS to offer weaker DH params in NSS  (DS 48798)\n\n[1.3.5.2-1]\n- release 1.3.5.2-1\n- Resolves: bug 1270020 - Rebase 389-ds-base to 1.3.5 in RHEL-7.3\n- Resolves: bug 1288229 - many attrlist_replace errors in connection with cleanallruv (DS 48283)\n- Resolves: bug 1315893 - License tag does not match actual license of code (DS 48757)\n- Resolves: bug 1320715 - DES to AES password conversion fails if a backend is empty (DS 48777)\n- Resolves: bug 190862  - [RFE] Default password syntax settings don't work with fine-grained policies (DS 142)\n- Resolves: bug 1018944 - [RFE] Enhance password change tracking (DS 548)\n- Resolves: bug 1143066 - The dirsrv user/group should be created in rpm %pre, and ideally with fixed uid/gid (DS 48285)\n- Resolves: bug 1153758 - [RFE] Support SASL/GSSAPI when ns-slapd is behind a load-balancer (DS 48332)\n- Resolves: bug 1160902 - search, matching rules and filter error 'unsupported type 0xA9' (DS 48016)\n- Resolves: bug 1186512 - High memory fragmentation observed in ns-slapd; OOM-Killer invoked (DS 48377, 48129)\n- Resolves: bug 1196282 - substring index with nssubstrbegin: 1 is not being used with filters like (attr=x*) (DS 48109)\n- Resolves: bug 1209094 - [RFE] Allow logging of rejected changes (DS 48145, 48280)\n- Resolves: bug 1209128 - [RFE] Add a utility to get the status of Directory Server instances (DS 48144)\n- Resolves: bug 1210842 - [RFE] Add PIDFile option to systemd service file (DS 47951)\n- Resolves: bug 1223510 - [RFE] it could be nice to have nsslapd-maxbersize default to bigger than 2Mb (DS 48326)\n- Resolves: bug 1229799 - ldclt-bin killed by SIGSEGV (DS 48289)\n- Resolves: bug 1249908 - No validation check for the value for nsslapd-db-locks. (DS 48244)\n- Resolves: bug 1254887 - No man page entry for - option '-u' of dbgen.pl for adding group entries with uniquemembers (DS 48290)\n- Resolves: bug 1255557 - db2index creates index entry from deleted records (DS 48252)\n- Resolves: bug 1258610 - total update request must not be lost (DS 48255)\n- Resolves: bug 1258611 - dna plugin needs to handle binddn groups for authorization (DS 48258)\n- Resolves: bug 1259624 - [RFE] Provide a utility to detect accounts locked due to inactivity (DS 48269)\n- Resolves: bug 1259950 - Add config setting to MemberOf Plugin to add required objectclass got memberOf attribute (DS 48267)\n- Resolves: bug 1266510 - Linked Attributes plug-in - wrong behaviour when adding valid and broken links (DS 48295)\n- Resolves: bug 1266532 - Linked Attributes plug-in - won't update links after MODRDN operation (DS 48294)\n- Resolves: bug 1267750 - pagedresults - when timed out, search results could have been already freed. (DS 48299)\n- Resolves: bug 1269378 - ds-logpipe.py with wrong arguments - python exception in the output (DS 48302)\n- Resolves: bug 1271330 - nunc-stans: Attempt to release connection that is not acquired (DS 48311)\n- Resolves: bug 1272677 - nunc stans: ns-slapd killed by SIGTERM\n- Resolves: bug 1272682 - nunc-stans: ns-slapd killed by SIGABRT\n- Resolves: bug 1273142 - crash in Managed Entry plugin (DS 48312)\n- Resolves: bug 1273549 - [RFE] Improve timestamp resolution in logs (DS 47982)\n- Resolves: bug 1273550 - Deadlock between two MODs on the same entry between entry cache and backend lock (DS 47978)\n- Resolves: bug 1273555 - deadlock in mep delete post op (DS 47976)\n- Resolves: bug 1273584 - lower password history minimum to 1 (DS 48394)\n- Resolves: bug 1275763 - [RFE] add setup-ds.pl option to disable instance specific scripts (DS 47840)\n- Resolves: bug 1276072 - [RFE] Allow RHDS to be setup using a DNS CNAME alias for General.FullMachineName (DS 48328)\n- Resolves: bug 1278567 - SimplePagedResults -- abandon could happen between the abandon check and sending results (DS 48338)\n- Resolves: bug 1278584 - Share nsslapd-threadnumber in the case nunc-stans is enabled, as well. (DS 48339)\n- Resolves: bug 1278755 - deadlock on connection mutex (DS 48341)\n- Resolves: bug 1278987 - Cannot upgrade a consumer to supplier in a multimaster environment (DS 48325)\n- Resolves: bug 1280123 - acl - regression - trailing ', (comma)' in macro matched value is not removed. (DS 48344)\n- Resolves: bug 1290111 - [RFE] Support for rfc3673 '+' to return operational attributes (DS 48363)\n- Resolves: bug 1290141 - With exhausted range, part of DNA shared configuration is deleted after server restart (DS 48362)\n- Resolves: bug 1290242 - SimplePagedResults -- in the search error case, simple paged results slot was not released. (DS 48375)\n- Resolves: bug 1290600 - The 'eq' index does not get updated properly when deleting and re-adding attributes in the same ldapmodify operation (DS 48370)\n- Resolves: bug 1295947 - 389-ds hanging after a few minutes of operation (DS 48406, revert 48338)\n- Resolves: bug 1296310 - ldclt - segmentation fault error while binding (DS 48400)\n- Resolves: bug 1299758 - CVE-2016-0741 389-ds-base: Worker threads do not detect abnormally closed connections causing DoS [rhel-7.3]\n- Resolves: bug 1301097 - logconv.pl displays negative operation speeds (DS 48446)\n- Resolves: bug 1302823 - Crash in slapi_get_object_extension (DS 48536)\n- Resolves: bug 1303641 - heap corruption at schema replication. (DS 48492)\n- Resolves: bug 1307151 - keep alive entries can break replication (DS 48445)\n- Resolves: bug 1310848 - Supplier can skip a failing update, although it should retry. (DS 47788)\n- Resolves: bug 1314557 - change severity of some messages related to 'keep alive' enties (DS 48420)\n- Resolves: bug 1316580 - dirsrv service doesn't ask for pin when pin.txt is missing (DS 48450)\n- Resolves: bug 1316742 - no plugin calls in tombstone purging (DS 48759)\n- Resolves: bug 1319329 - [RFE] add nsslapd-auditlog-logging-enabled: off to template-dse.ldif (DS 48145)\n- Resolves: bug 1320295 - If nsSSL3 is on, even if SSL v3 is not really enabled, a confusing message is logged. (DS 48775)\n- Resolves: bug 1326520 - db2index uses a buffer size derived from dbcachesize (DS 48383)\n- Resolves: bug 1328936 - objectclass values could be dropped on the consumer (DS 48799)\n- Resolves: bug 1287475 - [RFE] response control for password age should be sent by default by RHDS (DS 48369)\n- Resolves: bug 1331343 - Paged results search returns the blank list of entries (DS 48808)\n\n",
+	Advisory: oval.Advisory{XMLName: xml.Name{Space: "http://oval.mitre.org/XMLSchema/oval-definitions-5", Local: "advisory"},
+		Severity: "MODERATE",
+		Cves: []oval.Cve{
+			{XMLName: xml.Name{Space: "http://oval.mitre.org/XMLSchema/oval-definitions-5", Local: "cve"},
+				CveID: "CVE-2016-4992",
+				Href:  "http://linux.oracle.com/cve/CVE-2016-4992.html"},
+			{XMLName: xml.Name{Space: "http://oval.mitre.org/XMLSchema/oval-definitions-5", Local: "cve"},
+				CveID: "CVE-2016-5405",
+				Href:  "http://linux.oracle.com/cve/CVE-2016-5405.html"},
+			{XMLName: xml.Name{Space: "http://oval.mitre.org/XMLSchema/oval-definitions-5", Local: "cve"},
+				CveID: "CVE-2016-5416",
+				Href:  "http://linux.oracle.com/cve/CVE-2016-5416.html"},
+		},
+		Issued: struct {
+			Date string "xml:\"date,attr\""
+		}{Date: "2016-11-09"},
+	},
+	Criteria: oval.Criteria{XMLName: xml.Name{Space: "http://oval.mitre.org/XMLSchema/oval-definitions-5", Local: "criteria"},
+		Operator: "AND",
+		Criterias: []oval.Criteria{
+			{XMLName: xml.Name{Space: "http://oval.mitre.org/XMLSchema/oval-definitions-5", Local: "criteria"},
+				Operator: "OR",
+				Criterias: []oval.Criteria{
+					{XMLName: xml.Name{Space: "http://oval.mitre.org/XMLSchema/oval-definitions-5", Local: "criteria"},
+						Operator: "AND",
+						Criterions: []oval.Criterion{
+							{XMLName: xml.Name{Space: "http://oval.mitre.org/XMLSchema/oval-definitions-5", Local: "criterion"},
+								Negate:  false,
+								TestRef: "oval:com.oracle.elsa:tst:20162594002",
+								Comment: "389-ds-base is earlier than 0:1.3.5.10-11.el7"},
+							{XMLName: xml.Name{Space: "http://oval.mitre.org/XMLSchema/oval-definitions-5", Local: "criterion"},
+								Negate:  false,
+								TestRef: "oval:com.oracle.elsa:tst:20162594003",
+								Comment: "389-ds-base is signed with the Oracle Linux 7 key"}}},
+					{XMLName: xml.Name{Space: "http://oval.mitre.org/XMLSchema/oval-definitions-5", Local: "criteria"},
+						Operator: "AND",
+						Criterions: []oval.Criterion{
+							{XMLName: xml.Name{Space: "http://oval.mitre.org/XMLSchema/oval-definitions-5", Local: "criterion"},
+								Negate:  false,
+								TestRef: "oval:com.oracle.elsa:tst:20162594004",
+								Comment: "389-ds-base-libs is earlier than 0:1.3.5.10-11.el7"},
+							{XMLName: xml.Name{Space: "http://oval.mitre.org/XMLSchema/oval-definitions-5",
+								Local: "criterion"},
+								Negate:  false,
+								TestRef: "oval:com.oracle.elsa:tst:20162594005",
+								Comment: "389-ds-base-libs is signed with the Oracle Linux 7 key"}}},
+					{XMLName: xml.Name{Space: "http://oval.mitre.org/XMLSchema/oval-definitions-5", Local: "criteria"},
+						Operator: "AND",
+						Criterions: []oval.Criterion{
+							{XMLName: xml.Name{Space: "http://oval.mitre.org/XMLSchema/oval-definitions-5", Local: "criterion"},
+								Negate:  false,
+								TestRef: "oval:com.oracle.elsa:tst:20162594006",
+								Comment: "389-ds-base-snmp is earlier than 0:1.3.5.10-11.el7"},
+							{XMLName: xml.Name{Space: "http://oval.mitre.org/XMLSchema/oval-definitions-5", Local: "criterion"},
+								Negate:  false,
+								TestRef: "oval:com.oracle.elsa:tst:20162594007",
+								Comment: "389-ds-base-snmp is signed with the Oracle Linux 7 key"}}},
+					{XMLName: xml.Name{Space: "http://oval.mitre.org/XMLSchema/oval-definitions-5", Local: "criteria"},
+						Operator: "AND",
+						Criterions: []oval.Criterion{
+							{XMLName: xml.Name{Space: "http://oval.mitre.org/XMLSchema/oval-definitions-5",
+								Local: "criterion"},
+								Negate:  false,
+								TestRef: "oval:com.oracle.elsa:tst:20162594008",
+								Comment: "389-ds-base-devel is earlier than 0:1.3.5.10-11.el7"},
+							{XMLName: xml.Name{Space: "http://oval.mitre.org/XMLSchema/oval-definitions-5", Local: "criterion"},
+								Negate:  false,
+								TestRef: "oval:com.oracle.elsa:tst:20162594009",
+								Comment: "389-ds-base-devel is signed with the Oracle Linux 7 key"}}}},
+				Criterions: []oval.Criterion{
+					{XMLName: xml.Name{Space: "http://oval.mitre.org/XMLSchema/oval-definitions-5", Local: "criterion"},
+						Negate:  false,
+						TestRef: "oval:com.oracle.elsa:tst:20162594001",
+						Comment: "Oracle Linux 7 is installed"}}}}}}

--- a/oracle/updater.go
+++ b/oracle/updater.go
@@ -1,0 +1,165 @@
+package oracle
+
+import (
+	"compress/bzip2"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/quay/claircore/libvuln/driver"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+const dbURL = `https://linux.oracle.com/security/oval/com.oracle.elsa-all.xml.bz2`
+
+// Updater implements driver.Updater for Oracle Linux.
+type Updater struct {
+	client *http.Client
+	url    string
+	bzip   bool
+
+	logger *zerolog.Logger // hack until the context-ified interfaces are used
+}
+
+// Option configures the provided Updater.
+type Option func(*Updater) error
+
+// NewUpdater returns an updater configured according to the provided Options.
+func NewUpdater(opts ...Option) (*Updater, error) {
+	u := Updater{
+		client: http.DefaultClient,
+		url:    dbURL,
+		bzip:   true,
+	}
+	for _, o := range opts {
+		if err := o(&u); err != nil {
+			return nil, err
+		}
+	}
+	if u.logger == nil {
+		u.logger = &log.Logger
+	}
+
+	return &u, nil
+}
+
+// WithClient returns an Option that will make the Updater use the specified
+// http.Client, instead of http.DefaultClient.
+func WithClient(c *http.Client) Option {
+	return func(u *Updater) error {
+		u.client = c
+		return nil
+	}
+}
+
+// WithURL overrides the default URL to fetch an OVAL database.
+func WithURL(url string) Option {
+	return func(u *Updater) error {
+		u.bzip = false
+		u.url = url
+		return nil
+	}
+}
+
+// WithLogger sets the default logger.
+//
+// Functions that take a context.Context will use the logger embedded in there
+// instead of the Logger passed in via this Option.
+func WithLogger(l *zerolog.Logger) Option {
+	return func(u *Updater) error {
+		u.logger = l
+		return nil
+	}
+}
+
+var _ driver.Updater = (*Updater)(nil)
+var _ driver.FetcherNG = (*Updater)(nil)
+
+// Name satifies the driver.Updater interface.
+func (u *Updater) Name() string {
+	return "oracle-updater"
+}
+
+type tempfile struct {
+	*os.File
+}
+
+func (t *tempfile) Close() error {
+	if err := t.File.Close(); err != nil {
+		return err
+	}
+	return os.Remove(t.File.Name())
+}
+
+// Fetch satifies the driver.Updater interface.
+func (u *Updater) Fetch() (io.ReadCloser, string, error) {
+	ctx := u.logger.WithContext(context.Background())
+	ctx, done := context.WithTimeout(ctx, time.Minute)
+	defer done()
+	r, hint, err := u.FetchContext(ctx, "")
+	return r, string(hint), err
+}
+
+// FetchContext is like Fetch, but with Context.
+//
+// FetchContext satisfies the driver.FetcherNG interface.
+func (u *Updater) FetchContext(ctx context.Context, hint driver.Fingerprint) (io.ReadCloser, driver.Fingerprint, error) {
+	log := zerolog.Ctx(ctx).With().Str("component", u.Name()).Logger()
+
+	log.Info().Str("database", u.url).Msg("starting fetch")
+	req, err := http.NewRequestWithContext(ctx, "GET", u.url, nil)
+	if err != nil {
+		return nil, hint, fmt.Errorf("oracle: unable to construct request: %w", err)
+	}
+	if hint != "" {
+		log.Debug().Msgf("using hint %q", hint)
+		req.Header.Set("If-Modified-Since", string(hint))
+	}
+	res, err := u.client.Do(req)
+	if err != nil {
+		return nil, hint, fmt.Errorf("oracle: error making request: %w", err)
+	}
+	defer res.Body.Close()
+	switch res.StatusCode {
+	case http.StatusOK:
+	case http.StatusNotModified:
+		log.Info().Msg("unchanged")
+		return nil, hint, driver.Unchanged
+	default:
+		return nil, hint, fmt.Errorf("oracle: error making request: %w", err)
+	}
+	log.Debug().Msg("request ok")
+
+	f, err := ioutil.TempFile("", u.Name()+".")
+	if err != nil {
+		return nil, hint, fmt.Errorf("oracle: unable to open tempfile: %w", err)
+	}
+	log.Debug().Msgf("creating tempfile %q", f.Name())
+
+	var r io.Reader = res.Body
+	if u.bzip {
+		r = bzip2.NewReader(res.Body)
+	}
+	if _, err := io.Copy(f, r); err != nil {
+		return nil, hint, fmt.Errorf("oracle: unable to open tempfile: %w", err)
+	}
+	if n, err := f.Seek(0, io.SeekStart); err != nil || n != 0 {
+		return nil, hint, fmt.Errorf("oracle: unable to seek database to start: at %d, %v", n, err)
+	}
+	log.Debug().Msg("decompressed and buffered database")
+
+	if h := res.Header.Get("Last-Modified"); h != "" {
+		hint = driver.Fingerprint(h)
+	} else {
+		hint = driver.Fingerprint(res.Header.Get("Date"))
+	}
+	log.Debug().Msgf("using new hint %q", hint)
+
+	return &tempfile{f}, hint, nil
+}

--- a/oracle/updater_test.go
+++ b/oracle/updater_test.go
@@ -1,0 +1,37 @@
+package oracle
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/quay/claircore/libvuln/driver"
+	"github.com/quay/claircore/test/log"
+)
+
+func TestFetch(t *testing.T) {
+	ctx := context.Background()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.ServeFile(w, r, "testdata/com.oracle.elsa-2018.xml")
+	}))
+	l := log.TestLogger(t)
+	u, err := NewUpdater(WithLogger(&l), WithURL(srv.URL))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rd, hint, err := u.Fetch()
+	if err != nil {
+		t.Error(err)
+	}
+	t.Logf("got hint %q", hint)
+	if rd != nil {
+		rd.Close()
+	}
+
+	_, fp, err := u.FetchContext(l.WithContext(ctx), driver.Fingerprint(hint))
+	t.Logf("got hint %q", fp)
+	if got, want := err, driver.Unchanged; got != want {
+		t.Errorf("got: %v, want: %v", got, want)
+	}
+}

--- a/test/log/log.go
+++ b/test/log/log.go
@@ -1,0 +1,23 @@
+package log
+
+import (
+	"bufio"
+	"io"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+// TestLogger cross-wires a zerolog.Logger to print to the provided testing.TB.
+//
+// It is very slow.
+func TestLogger(t testing.TB) zerolog.Logger {
+	r, w := io.Pipe()
+	go func() {
+		s := bufio.NewScanner(r)
+		for s.Scan() {
+			t.Log(s.Text())
+		}
+	}()
+	return zerolog.New(zerolog.ConsoleWriter{Out: w, NoColor: true})
+}


### PR DESCRIPTION
This commit fetches and parses the Oracle Linux oval database.

It also wires it into the dev server and adds the ability to run only
specific updaters to the dev server.

It also adds an adapter between testing.TB's logging methods and
zerolog.