### PR TITLE
Libscan plumbing

### DIFF
--- a/internal/scanner/defaultscanner/buildimageresult.go
+++ b/internal/scanner/defaultscanner/buildimageresult.go
@@ -7,7 +7,7 @@ import (
 
 func buildImageResult(s *defaultScanner, ctx context.Context) (ScannerState, error) {
 	for _, scnr := range s.PackageScanners {
-		pkgs, err := s.Store.PackagesByLayer(ctx, s.imageLayer.Hash, s.vscnrs)
+		pkgs, err := s.Store.PackagesByLayer(ctx, s.imageLayer.Hash, s.Vscnrs)
 		if err != nil {
 			return Terminal, fmt.Errorf("failed to get packages for image layer %v and scnr %v: %v",
 				s.imageLayer.Hash, scnr, err)

--- a/internal/scanner/defaultscanner/buildlayerresult.go
+++ b/internal/scanner/defaultscanner/buildlayerresult.go
@@ -9,7 +9,7 @@ import (
 // limited by the supplied scanners and populates the result.PackageIntroduced map.
 func buildLayerResult(s *defaultScanner, ctx context.Context) (ScannerState, error) {
 	for _, layer := range s.manifest.Layers {
-		pkgs, err := s.Store.PackagesByLayer(ctx, layer.Hash, s.vscnrs)
+		pkgs, err := s.Store.PackagesByLayer(ctx, layer.Hash, s.Vscnrs)
 		if err != nil {
 			s.logger.Error().Str("state", s.getState().String()).Msgf("failed to obtain packages for layer %v: %v", layer.Hash, err)
 			return Terminal, fmt.Errorf("failed to obtain packages for layer %v: %v", layer.Hash, err)

--- a/internal/scanner/defaultscanner/checkmanifest.go
+++ b/internal/scanner/defaultscanner/checkmanifest.go
@@ -8,7 +8,7 @@ import (
 func checkManifest(s *defaultScanner, ctx context.Context) (ScannerState, error) {
 	// determine if we've seen this manifest and if we've
 	// scanned it with the desired scanners
-	ok, err := s.Store.ManifestScanned(ctx, s.manifest.Hash, s.vscnrs)
+	ok, err := s.Store.ManifestScanned(ctx, s.manifest.Hash, s.Vscnrs)
 	if err != nil {
 		s.logger.Error().Str("state", s.getState().String()).Msgf("failed to determine if manifest has been scanned: %v", err)
 		return Terminal, err

--- a/internal/scanner/defaultscanner/scanfinished.go
+++ b/internal/scanner/defaultscanner/scanfinished.go
@@ -12,7 +12,7 @@ func scanFinished(s *defaultScanner, ctx context.Context) (ScannerState, error) 
 	s.report.Success = true
 	s.logger.Info().Str("state", s.getState().String()).Msg("finishing scan")
 
-	err := s.Store.SetScanFinished(ctx, s.report, s.vscnrs)
+	err := s.Store.SetScanFinished(ctx, s.report, s.Vscnrs)
 	if err != nil {
 		s.logger.Error().Str("state", s.getState().String()).Msgf("failed to finish scan. atttempt a rescan of the manifest: %v", err)
 		return Terminal, fmt.Errorf("failed finish scann. attempt a rescan of the manifest: %v", err)

--- a/internal/scanner/opts.go
+++ b/internal/scanner/opts.go
@@ -4,9 +4,12 @@ import "github.com/quay/claircore/pkg/distlock"
 
 // Opts are options to instantiate a scanner
 type Opts struct {
-	Store           Store
-	ScanLock        distlock.Locker
-	LayerScanner    LayerScanner
-	Fetcher         Fetcher
-	PackageScanners []PackageScanner
+	Store                Store
+	ScanLock             distlock.Locker
+	LayerScanner         LayerScanner
+	Fetcher              Fetcher
+	PackageScanners      []PackageScanner
+	DistributionScanners []DistributionScanner
+	RepositoryScanners   []RepositoryScanner
+	Vscnrs               VersionedScanners
 }

--- a/internal/scanner/versionedscanner.go
+++ b/internal/scanner/versionedscanner.go
@@ -4,6 +4,17 @@ const (
 	Package = "package"
 )
 
+// VersionedScanner can be imbeded into specific scanner types. This allows for methods and functions
+// which only need to compare names and versions of scanners not to require each scanner type as an argument
+type VersionedScanner interface {
+	// unique name of the distribution scanner.
+	Name() string
+	// version of this scanner. this information will be persisted with the scan.
+	Version() string
+	// the kind of scanner. currently only package is implemented
+	Kind() string
+}
+
 // VersionedScanners implements a list with construction methods
 // not concurrency safe
 type VersionedScanners []VersionedScanner
@@ -27,13 +38,53 @@ func (vs VersionedScanners) VStoPS() []PackageScanner {
 	return out
 }
 
-// VersionedScanner can be imbeded into specific scanner types. This allows for methods and functions
-// which only need to compare names and versions of scanners not to require each scanner type as an argument
-type VersionedScanner interface {
-	// unique name of the distribution scanner.
-	Name() string
-	// version of this scanner. this information will be persisted with the scan.
-	Version() string
-	// the kind of scanner. currently only package is implemented
-	Kind() string
+// DStoVS takes an array of DistributionScanners and appends VersionedScanners with
+// VersionScanner types.
+func (vs *VersionedScanners) DStoVS(scnrs []DistributionScanner) {
+	temp := make([]VersionedScanner, 0)
+	for _, scnr := range scnrs {
+		temp = append(temp, scnr)
+	}
+	*vs = temp
+}
+
+// VStoDS returns an array of DistributionScanners
+func (vs VersionedScanners) VStoDS() []DistributionScanner {
+	out := make([]DistributionScanner, len(vs))
+	for _, vscnr := range vs {
+		out = append(out, vscnr.(DistributionScanner))
+	}
+	return out
+}
+
+// RStoVS takes an array of RepositoryScanners and appends VersionedScanners with
+// VersionScanner types.
+func (vs *VersionedScanners) RStoVS(scnrs []RepositoryScanner) {
+	temp := make([]VersionedScanner, 0)
+	for _, scnr := range scnrs {
+		temp = append(temp, scnr)
+	}
+	*vs = temp
+}
+
+// VStoRS returns an array of RepositoryScanners
+func (vs VersionedScanners) VStoRS() []RepositoryScanner {
+	out := make([]RepositoryScanner, len(vs))
+	for _, vscnr := range vs {
+		out = append(out, vscnr.(RepositoryScanner))
+	}
+	return out
+}
+
+// MergeVS takes 0 or more VersionScanners and returns a merged array
+// merging is in order of submitted arrays. if no arrays are submitted
+// an empty array is returned.
+func MergeVS(scnrs ...VersionedScanners) VersionedScanners {
+	out := make([]VersionedScanner, 0)
+	for _, array := range scnrs {
+		for _, scnr := range array {
+			out = append(out, scnr)
+		}
+	}
+	return out
 }

--- a/libscan/factory.go
+++ b/libscan/factory.go
@@ -26,17 +26,6 @@ func scannerFactory(lib *libscan, opts *Opts) (scanner.Scanner, error) {
 		return nil, fmt.Errorf("provided ScanLock opt is unsupported")
 	}
 
-	var pscnrs scanner.VersionedScanners
-	pscnrs.PStoVS(opts.PackageScannerFactory())
-
-	var dscnrs scanner.VersionedScanners
-	dscnrs.DStoVS(opts.DistributionScannerFactory())
-
-	var rscnrs scanner.VersionedScanners
-	rscnrs.RStoVS(opts.RepositoryScannerFactory())
-
-	vscnrs := scanner.MergeVS(pscnrs, dscnrs, rscnrs)
-
 	// add other fetcher implementations here as they grow
 	var ft scanner.Fetcher
 	ft = defaultfetcher.New(lib.client, nil, opts.LayerFetchOpt)
@@ -49,7 +38,8 @@ func scannerFactory(lib *libscan, opts *Opts) (scanner.Scanner, error) {
 		PackageScanners:      opts.PackageScannerFactory(),
 		DistributionScanners: opts.DistributionScannerFactory(),
 		RepositoryScanners:   opts.RepositoryScannerFactory(),
-		Vscnrs:               vscnrs,
+		// this private field is set during libscan construction
+		Vscnrs: lib.vscnrs,
 	}
 
 	// add other layer scanner implementations as they grow

--- a/libscan/factory.go
+++ b/libscan/factory.go
@@ -53,3 +53,15 @@ func packageScannerFactory() []scanner.PackageScanner {
 		dpkg.NewPackageScanner(),
 	}
 }
+
+type DistributionScannerFactory func() []scanner.DistributionScanner
+
+func distributionScannerFactory() []scanner.DistributionScanner {
+	return []scanner.DistributionScanner{}
+}
+
+type RepositoryScannerFactory func() []scanner.RepositoryScanner
+
+func repositoryScannerFactory() []scanner.RepositoryScanner {
+	return []scanner.RepositoryScanner{}
+}

--- a/libscan/libscan.go
+++ b/libscan/libscan.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/jmoiron/sqlx"
 	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 )
 
 // Libscan is an interface exporting the public methods of our library.
@@ -39,8 +38,7 @@ type libscan struct {
 
 // New creates a new instance of Libscan
 func New(ctx context.Context, opts *Opts) (Libscan, error) {
-	logger := log.With().Str("component", "libscan").Logger()
-
+	logger := zerolog.Ctx(ctx).With().Str("component", "libscan").Logger()
 	err := opts.Parse()
 	if err != nil {
 		logger.Error().Msgf("failed to parse opts: %v", err)
@@ -80,6 +78,7 @@ func New(ctx context.Context, opts *Opts) (Libscan, error) {
 	}
 	l.logger.Info().Msg("registered configured scanners")
 
+	l.Opts.vscnrs = vscnrs
 	return l, nil
 }
 

--- a/libscan/libscan.go
+++ b/libscan/libscan.go
@@ -26,19 +26,14 @@ type Libscan interface {
 
 // libscan implements libscan.Libscan interface
 type libscan struct {
-	// client provided configuration options for libscan
+	// holds dependencies for creating a libscan instance
 	*Opts
 	// convenience field for creating scan-time resources that require a database
 	db *sqlx.DB
-	// a Store which will be shared between scanners
+	// a Store which will be shared between scanner instances
 	store scanner.Store
 	// a sharable http client
 	client *http.Client
-	// the factory used to generate a scanner during runtime. default used if not provided in opts
-	scanner ScannerFactory
-	// the factory used to generate package scanners during runtime. default used if not provided in opts
-	packageScanners PackageScannerFactory
-	// a logger with context
 	logger zerolog.Logger
 }
 
@@ -59,18 +54,24 @@ func New(ctx context.Context, opts *Opts) (Libscan, error) {
 	logger.Info().Msg("created database connection")
 
 	l := &libscan{
-		Opts:            opts,
-		db:              db,
-		store:           store,
-		client:          &http.Client{},
-		scanner:         opts.ScannerFactory,
-		packageScanners: opts.PackageScannerFactory,
-		logger:          logger,
+		Opts:   opts,
+		db:     db,
+		store:  store,
+		client: &http.Client{},
+		logger: logger,
 	}
 
 	// register any new scanners.
-	var vscnrs scanner.VersionedScanners
-	vscnrs.PStoVS(l.packageScanners())
+	var pscnrs scanner.VersionedScanners
+	pscnrs.PStoVS(opts.PackageScannerFactory())
+
+	var dscnrs scanner.VersionedScanners
+	dscnrs.DStoVS(opts.DistributionScannerFactory())
+
+	var rscnrs scanner.VersionedScanners
+	rscnrs.RStoVS(opts.RepositoryScannerFactory())
+
+	vscnrs := scanner.MergeVS(pscnrs, dscnrs, rscnrs)
 
 	err = l.store.RegisterScanners(ctx, vscnrs)
 	if err != nil {
@@ -88,7 +89,7 @@ func (l *libscan) Scan(ctx context.Context, manifest *claircore.Manifest) (<-cha
 
 	rc := make(chan *claircore.ScanReport, 1)
 
-	s, err := l.scanner(l, l.Opts)
+	s, err := l.ScannerFactory(l, l.Opts)
 	if err != nil {
 		l.logger.Error().Msgf("scanner factory failed to construct a scanner: %v", err)
 		return nil, fmt.Errorf("scanner factory failed to construct a scanner: %v", err)

--- a/libscan/opts.go
+++ b/libscan/opts.go
@@ -47,6 +47,14 @@ type Opts struct {
 	// provides an alternative method for specifying the package scanners used during libscan runtime
 	// if nil the default factory will be used
 	PackageScannerFactory PackageScannerFactory
+	// provides an alternative method for specifying the distribution scanners used during libscan runtime
+	// if nil the default factory will be used
+	DistributionScannerFactory DistributionScannerFactory
+	// provides an alternative method for specifying the repository scanners used during libscan runtime
+	// if nil the default factory will be used
+	RepositoryScannerFactory RepositoryScannerFactory
+	// Computed after libscan initialization
+	vscnrs scanner.VersionedScanners
 }
 
 func (o *Opts) Parse() error {
@@ -73,6 +81,12 @@ func (o *Opts) Parse() error {
 	}
 	if o.PackageScannerFactory == nil {
 		o.PackageScannerFactory = packageScannerFactory
+	}
+	if o.DistributionScannerFactory == nil {
+		o.DistributionScannerFactory = distributionScannerFactory
+	}
+	if o.RepositoryScannerFactory == nil {
+		o.RepositoryScannerFactory = repositoryScannerFactory
 	}
 
 	// for now force this to Tee to support layer stacking


### PR DESCRIPTION
Rebased ontop of data-model-changes. This PR implements the plumbing necessary for discrete Repository and Distribution scanners. Prior to this both Distribution and Package scanning was a facility of just a PackageScanner. 

A bunch of code cleanup occurred too which reduces the amount of copying between Libscan Opts and Scanner Opts. 