### PR TITLE
plumb ecosystems, fix os-release scanner type

### DIFF
--- a/alpine/ecosystem.go
+++ b/alpine/ecosystem.go
@@ -1,0 +1,27 @@
+package alpine
+
+import (
+	"context"
+
+	"github.com/quay/claircore/dpkg"
+	"github.com/quay/claircore/internal/scanner"
+	"github.com/quay/claircore/osrelease"
+)
+
+// NewEcosystem provides the set of scanners and coalescers for the dpkg ecosystem
+func NewEcosystem(ctx context.Context) *scanner.Ecosystem {
+	return &scanner.Ecosystem{
+		PackageScanners: func(ctx context.Context) ([]scanner.PackageScanner, error) {
+			return []scanner.PackageScanner{&Scanner{}}, nil
+		},
+		DistributionScanners: func(ctx context.Context) ([]scanner.DistributionScanner, error) {
+			return []scanner.DistributionScanner{&osrelease.Scanner{}}, nil
+		},
+		RepositoryScanners: func(ctx context.Context) ([]scanner.RepositoryScanner, error) {
+			return []scanner.RepositoryScanner{}, nil
+		},
+		Coalescer: func(ctx context.Context, store scanner.Store) (scanner.Coalescer, error) {
+			return dpkg.NewCoalescer(store), nil
+		},
+	}
+}

--- a/cmd/libscanhttp/main.go
+++ b/cmd/libscanhttp/main.go
@@ -8,10 +8,12 @@ import (
 	"time"
 
 	"github.com/crgimenes/goconfig"
+	"github.com/quay/claircore/alpine"
 	"github.com/quay/claircore/dpkg"
 	"github.com/quay/claircore/internal/scanner"
 	"github.com/quay/claircore/libscan"
 	libhttp "github.com/quay/claircore/libscan/http"
+	"github.com/quay/claircore/rpm"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
@@ -103,6 +105,8 @@ func confToLibscanOpts(conf Config) *libscan.Opts {
 		ScanLock:   libscan.PostgresSL,
 		Ecosystems: []*scanner.Ecosystem{
 			dpkg.NewEcosystem(context.Background()),
+			alpine.NewEcosystem(context.Background()),
+			rpm.NewEcosystem(context.Background()),
 		},
 	}
 

--- a/internal/scanner/postgres/layerscanned.go
+++ b/internal/scanner/postgres/layerscanned.go
@@ -42,7 +42,7 @@ func layerScanned(ctx context.Context, db *sqlx.DB, hash string, scnr scanner.Ve
 	case "repository":
 		query = selectRepositoryScanArtifact
 	default:
-		return false, fmt.Errorf("received unkown scanner type: %v", scnr.Kind())
+		return false, fmt.Errorf("received unkown scanner type: %v %v %v", scnr.Name(), scnr.Version(), scnr.Kind())
 	}
 
 	err = db.Get(&layerHash, query, hash, scannerID)

--- a/osrelease/scanner.go
+++ b/osrelease/scanner.go
@@ -17,7 +17,7 @@ import (
 const (
 	scannerName    = "os-release"
 	scannerVersion = "0"
-	scannerKind    = "repo"
+	scannerKind    = "distribution"
 )
 
 const fpath = `etc/os-release`

--- a/rpm/ecosystem.go
+++ b/rpm/ecosystem.go
@@ -1,0 +1,27 @@
+package rpm
+
+import (
+	"context"
+
+	"github.com/quay/claircore/dpkg"
+	"github.com/quay/claircore/internal/scanner"
+	"github.com/quay/claircore/osrelease"
+)
+
+// NewEcosystem provides the set of scanners and coalescers for the dpkg ecosystem
+func NewEcosystem(ctx context.Context) *scanner.Ecosystem {
+	return &scanner.Ecosystem{
+		PackageScanners: func(ctx context.Context) ([]scanner.PackageScanner, error) {
+			return []scanner.PackageScanner{&Scanner{}}, nil
+		},
+		DistributionScanners: func(ctx context.Context) ([]scanner.DistributionScanner, error) {
+			return []scanner.DistributionScanner{&osrelease.Scanner{}}, nil
+		},
+		RepositoryScanners: func(ctx context.Context) ([]scanner.RepositoryScanner, error) {
+			return []scanner.RepositoryScanner{}, nil
+		},
+		Coalescer: func(ctx context.Context, store scanner.Store) (scanner.Coalescer, error) {
+			return dpkg.NewCoalescer(store), nil
+		},
+	}
+}


### PR DESCRIPTION
PR plumbs ecosystems into libscan test http servers. 
Fixes the os-release scanner type to 'distribution'