### PR TITLE
consolidate initialization to lib construction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,9 +98,7 @@ podman-dev-up:
 		--pod claircore-dev\
 		--name libscanhttp\
 		--env HTTP_LISTEN_ADDR="0.0.0.0:8080"\
-		--env DATASTORE="postgres"\
 		--env CONNECTION_STRING="host=localhost port=5434 user=claircore dbname=claircore sslmode=disable"\
-		--env SCANLOCK="postgres"\
 		--env SCAN_LOCK_RETRY=1\
 		--env LAYER_SCAN_CONCURRENCY=10\
 		--env LOG_LEVEL="debug"\
@@ -112,9 +110,7 @@ podman-dev-up:
 		--pod claircore-dev\
 		--name libvulnhttp\
 		--env HTTP_LISTEN_ADDR="0.0.0.0:8081"\
-		--env DATASTORE="postgres"\
 		--env CONNECTION_STRING="host=localhost port=5434 user=claircore dbname=claircore sslmode=disable"\
-		--env UPDATELOCK="postgres"\
 		--env LOG_LEVEL="debug"\
 		--expose 8081\
 		--volume $$(git rev-parse --show-toplevel)/:/src/claircore/:z\

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,9 +25,7 @@ services:
       - "8080:8080"
     environment:
       HTTP_LISTEN_ADDR: "0.0.0.0:8080"
-      DATASTORE: "postgres"
       CONNECTION_STRING: "host=claircore-db port=5432 user=claircore dbname=claircore sslmode=disable"
-      SCANLOCK: "postgres"
       SCAN_LOCK_RETRY: 1
       LAYER_SCAN_CONCURRENCY: 10
       LOG_LEVEL: "debug"
@@ -42,9 +40,7 @@ services:
       - "8081:8081"
     environment:
       HTTP_LISTEN_ADDR: "0.0.0.0:8081"
-      DATASTORE: "postgres"
       CONNECTION_STRING: "host=claircore-db port=5432 user=claircore dbname=claircore sslmode=disable"
-      UPDATELOCK: "postgres"
       LOG_LEVEL: "debug"
     volumes:
       - "./:/src/claircore/"

--- a/libscan/controllerfactory.go
+++ b/libscan/controllerfactory.go
@@ -1,13 +1,12 @@
 package libscan
 
 import (
-	"fmt"
+	"time"
 
 	"github.com/quay/claircore/internal/scanner"
 	"github.com/quay/claircore/internal/scanner/controller"
 	"github.com/quay/claircore/internal/scanner/fetcher"
 	"github.com/quay/claircore/internal/scanner/layerscanner"
-	"github.com/quay/claircore/pkg/distlock"
 	dlpg "github.com/quay/claircore/pkg/distlock/postgres"
 )
 
@@ -16,18 +15,8 @@ type ControllerFactory func(lib *libscan, opts *Opts) (*controller.Controller, e
 
 // controllerFactory is the default ControllerFactory
 func controllerFactory(lib *libscan, opts *Opts) (*controller.Controller, error) {
-	// add other distributed locking implementations here as they grow
-	var sc distlock.Locker
-	switch opts.ScanLock {
-	case PostgresSL:
-		sc = dlpg.NewLock(lib.db, opts.ScanLockRetry)
-	default:
-		return nil, fmt.Errorf("provided ScanLock opt is unsupported")
-	}
-
-	// add other fetcher implementations here as they grow
-	var ft scanner.Fetcher
-	ft = fetcher.New(lib.client, nil, opts.LayerFetchOpt)
+	sc := dlpg.NewLock(lib.db, time.Duration(opts.ScanLockRetry)*time.Second)
+	ft := fetcher.New(lib.client, nil, opts.LayerFetchOpt)
 
 	// convert libscan.Opts to scanner.Opts
 	sOpts := &scanner.Opts{
@@ -37,9 +26,8 @@ func controllerFactory(lib *libscan, opts *Opts) (*controller.Controller, error)
 		Ecosystems: opts.Ecosystems,
 		Vscnrs:     lib.vscnrs,
 	}
-
-	// add other layer scanner implementations as they grow
 	sOpts.LayerScanner = layerscanner.New(opts.LayerScanConcurrency, sOpts)
+
 	s := controller.New(sOpts)
 	return s, nil
 }

--- a/libscan/controllerfactory.go
+++ b/libscan/controllerfactory.go
@@ -1,8 +1,6 @@
 package libscan
 
 import (
-	"time"
-
 	"github.com/quay/claircore/internal/scanner"
 	"github.com/quay/claircore/internal/scanner/controller"
 	"github.com/quay/claircore/internal/scanner/fetcher"
@@ -15,7 +13,7 @@ type ControllerFactory func(lib *libscan, opts *Opts) (*controller.Controller, e
 
 // controllerFactory is the default ControllerFactory
 func controllerFactory(lib *libscan, opts *Opts) (*controller.Controller, error) {
-	sc := dlpg.NewLock(lib.db, time.Duration(opts.ScanLockRetry)*time.Second)
+	sc := dlpg.NewLock(lib.db, opts.ScanLockRetry)
 	ft := fetcher.New(lib.client, nil, opts.LayerFetchOpt)
 
 	// convert libscan.Opts to scanner.Opts

--- a/libscan/init.go
+++ b/libscan/init.go
@@ -13,30 +13,24 @@ import (
 
 // initialize a scanner.Store given libscan.Opts
 func initStore(ctx context.Context, opts *Opts) (*sqlx.DB, scanner.Store, error) {
-	var store scanner.Store
-	switch opts.DataStore {
-	case Postgres:
-		// we are going to use pgx for more control over connection pool and
-		// and a cleaner api around bulk inserts
-		cfg, err := pgxpool.ParseConfig(opts.ConnString)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to parse ConnString: %v", err)
-		}
-		cfg.MaxConns = 30
-		pool, err := pgxpool.ConnectConfig(ctx, cfg)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to create ConnPool: %v", err)
-		}
-
-		// setup sqlx
-		db, err := sqlx.Open("pgx", opts.ConnString)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to open db: %v", err)
-		}
-
-		store = postgres.NewStore(db, pool)
-		return db, store, nil
-	default:
-		return nil, nil, fmt.Errorf("provided unknown DataStore")
+	// we are going to use pgx for more control over connection pool and
+	// and a cleaner api around bulk inserts
+	cfg, err := pgxpool.ParseConfig(opts.ConnString)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to parse ConnString: %v", err)
 	}
+	cfg.MaxConns = 30
+	pool, err := pgxpool.ConnectConfig(ctx, cfg)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create ConnPool: %v", err)
+	}
+
+	// setup sqlx
+	db, err := sqlx.Open("pgx", opts.ConnString)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to open db: %v", err)
+	}
+
+	store := postgres.NewStore(db, pool)
+	return db, store, nil
 }

--- a/libscan/opts.go
+++ b/libscan/opts.go
@@ -1,42 +1,27 @@
 package libscan
 
 import (
+	"context"
 	"fmt"
-	"time"
 
+	"github.com/quay/claircore/alpine"
+	"github.com/quay/claircore/dpkg"
 	"github.com/quay/claircore/internal/scanner"
-)
-
-// DataStore tells libscan which backing persistence store to instantiate
-type DataStore string
-
-const (
-	Postgres DataStore = "postgres"
-)
-
-// ScanLock tells libscan which distributed locking implementation to use
-type ScanLock string
-
-const (
-	PostgresSL ScanLock = "postgres"
+	"github.com/quay/claircore/rpm"
 )
 
 const (
-	DefaultScanLockRetry        = 5 * time.Second
+	DefaultScanLockRetry        = 5
 	DefaultLayerScanConcurrency = 10
 	DefaultLayerFetchOpt        = scanner.OnDisk
 )
 
 // Opts are depedencies and options for constructing an instance of libscan
 type Opts struct {
-	// the datastore this instance of libscan will use
-	DataStore DataStore
 	// the connection string for the datastore specified above
 	ConnString string
-	// the type of ScanLock implementation to use. currently postgres is supported
-	ScanLock ScanLock
 	// how often we should try to acquire a lock for scanning a given manifest if lock is taken
-	ScanLockRetry time.Duration
+	ScanLockRetry int
 	// the number of layers to be scanned in parellel.
 	LayerScanConcurrency int
 	// how we store layers we fetch remotely. see LayerFetchOpt type def above for more details
@@ -52,21 +37,12 @@ type Opts struct {
 
 func (o *Opts) Parse() error {
 	// required
-	if o.DataStore == "" {
-		return fmt.Errorf("DataSource not provided")
-	}
 	if o.ConnString == "" {
 		return fmt.Errorf("ConnString not provided")
 	}
-	if o.ScanLock == "" {
-		return fmt.Errorf("ScanLock not provided")
-	}
-	if len(o.Ecosystems) == 0 {
-		return fmt.Errorf("No ecosystems provided. cannot scan manifests")
-	}
 
 	// optional
-	if o.ScanLockRetry == 0 {
+	if (o.ScanLockRetry == 0) || (o.ScanLockRetry < 1) {
 		o.ScanLockRetry = DefaultScanLockRetry
 	}
 	if o.LayerScanConcurrency == 0 {
@@ -75,7 +51,13 @@ func (o *Opts) Parse() error {
 	if o.ControllerFactory == nil {
 		o.ControllerFactory = controllerFactory
 	}
-	// for now force this to Tee to support layer stacking
+	if len(o.Ecosystems) == 0 {
+		o.Ecosystems = []*scanner.Ecosystem{
+			dpkg.NewEcosystem(context.Background()),
+			alpine.NewEcosystem(context.Background()),
+			rpm.NewEcosystem(context.Background()),
+		}
+	}
 	o.LayerFetchOpt = DefaultLayerFetchOpt
 
 	return nil

--- a/libscan/opts.go
+++ b/libscan/opts.go
@@ -3,6 +3,7 @@ package libscan
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/quay/claircore/alpine"
 	"github.com/quay/claircore/dpkg"
@@ -11,7 +12,7 @@ import (
 )
 
 const (
-	DefaultScanLockRetry        = 5
+	DefaultScanLockRetry        = 5 * time.Second
 	DefaultLayerScanConcurrency = 10
 	DefaultLayerFetchOpt        = scanner.OnDisk
 )
@@ -21,7 +22,7 @@ type Opts struct {
 	// the connection string for the datastore specified above
 	ConnString string
 	// how often we should try to acquire a lock for scanning a given manifest if lock is taken
-	ScanLockRetry int
+	ScanLockRetry time.Duration
 	// the number of layers to be scanned in parellel.
 	LayerScanConcurrency int
 	// how we store layers we fetch remotely. see LayerFetchOpt type def above for more details
@@ -42,7 +43,7 @@ func (o *Opts) Parse() error {
 	}
 
 	// optional
-	if (o.ScanLockRetry == 0) || (o.ScanLockRetry < 1) {
+	if (o.ScanLockRetry == 0) || (o.ScanLockRetry < time.Second) {
 		o.ScanLockRetry = DefaultScanLockRetry
 	}
 	if o.LayerScanConcurrency == 0 {

--- a/libvuln/init.go
+++ b/libvuln/init.go
@@ -37,7 +37,7 @@ func initUpdaters(opts *Opts, db *sqlx.DB, store vulnstore.Updater, dC chan cont
 			Updater:       u,
 			Store:         store,
 			Name:          u.Name(),
-			Interval:      time.Duration(opts.UpdateInterval) * time.Minute,
+			Interval:      opts.UpdateInterval,
 			Lock:          pglock.NewLock(db, time.Duration(0)),
 			UpdateOnStart: false,
 		})

--- a/libvuln/init.go
+++ b/libvuln/init.go
@@ -37,7 +37,7 @@ func initUpdaters(opts *Opts, db *sqlx.DB, store vulnstore.Updater, dC chan cont
 			Updater:       u,
 			Store:         store,
 			Name:          u.Name(),
-			Interval:      opts.UpdateInterval,
+			Interval:      time.Duration(opts.UpdateInterval) * time.Minute,
 			Lock:          pglock.NewLock(db, time.Duration(0)),
 			UpdateOnStart: false,
 		})
@@ -75,29 +75,24 @@ func initUpdaters(opts *Opts, db *sqlx.DB, store vulnstore.Updater, dC chan cont
 
 // initStore initializes a vulsntore and returns the underlying db object also
 func initStore(ctx context.Context, opts *Opts) (*sqlx.DB, vulnstore.Store, error) {
-	switch opts.DataStore {
-	case Postgres:
-		// we are going to use pgx for more control over connection pool and
-		// and a cleaner api around bulk inserts
-		cfg, err := pgxpool.ParseConfig(opts.ConnString)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to parse ConnString: %v", err)
-		}
-		// set conn pool size via libvuln.Opts
-		cfg.MaxConns = opts.MaxConnPool
-		pool, err := pgxpool.ConnectConfig(ctx, cfg)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to create ConnPool: %v", err)
-		}
-
-		db, err := sqlx.Open("pgx", opts.ConnString)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to Open db: %v", err)
-		}
-
-		store := postgres.NewVulnStore(db, pool)
-		return db, store, nil
-	default:
-		return nil, nil, fmt.Errorf("provided unknown DataStore")
+	// we are going to use pgx for more control over connection pool and
+	// and a cleaner api around bulk inserts
+	cfg, err := pgxpool.ParseConfig(opts.ConnString)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to parse ConnString: %v", err)
 	}
+	// set conn pool size via libvuln.Opts
+	cfg.MaxConns = opts.MaxConnPool
+	pool, err := pgxpool.ConnectConfig(ctx, cfg)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create ConnPool: %v", err)
+	}
+
+	db, err := sqlx.Open("pgx", opts.ConnString)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to Open db: %v", err)
+	}
+
+	store := postgres.NewVulnStore(db, pool)
+	return db, store, nil
 }

--- a/libvuln/libvuln.go
+++ b/libvuln/libvuln.go
@@ -35,7 +35,7 @@ func New(ctx context.Context, opts *Opts) (Libvuln, error) {
 		return nil, err
 	}
 
-	logger.Info().Msgf("initializing store %v and pool size: %v ", opts.DataStore, opts.MaxConnPool)
+	logger.Info().Msgf("initializing store with pool size: %v ", opts.MaxConnPool)
 	db, vulnstore, err := initStore(ctx, opts)
 	if err != nil {
 		return nil, err

--- a/libvuln/opts.go
+++ b/libvuln/opts.go
@@ -2,65 +2,75 @@ package libvuln
 
 import (
 	"fmt"
-	"time"
 
+	"github.com/quay/claircore/alpine"
+	"github.com/quay/claircore/debian"
 	"github.com/quay/claircore/libvuln/driver"
-)
-
-// DataStore tells libvuln which backing persistence store to instantiate
-type DataStore string
-
-const (
-	Postgres DataStore = "postgres"
-)
-
-// ScanLock tells libscan which distributed locking implementation to use
-type UpdateLock string
-
-const (
-	PostgresSL UpdateLock = "postgres"
+	"github.com/quay/claircore/ubuntu"
 )
 
 const (
-	DefaultUpdateInterval         = 30 * time.Minute
+	DefaultUpdateInterval         = 30
 	DefaultUpdaterInitConcurrency = 10
+	DefaultMaxConnPool            = 100
 )
 
 type Opts struct {
-	// the datastore implementation libvuln should instantiate
-	DataStore DataStore
 	// the maximum size of the connection pool used by the database
 	MaxConnPool int32
 	// the connectiong string to the above data store implementation
 	ConnString string
-	// the update lock (distlock) implementation libvuln should instantiate
-	UpdateLock UpdateLock
+	// the interval in minutes which updaters will update the vulnstore
+	UpdateInterval int
+	// number of updaters ran in parallel while libvuln initializes. use this to tune io/cpu on library start when using many updaters
+	UpdaterInitConcurrency int
 	// returns the matchers to be used during libvuln runtime
 	Matchers []driver.Matcher
 	// returns the updaters to run on an interval
 	Updaters []driver.Updater
-	// the interval at which updaters will update the vulnstore
-	UpdateInterval time.Duration
-	// number of updaters ran in parallel while libscan initializes. use this to tune io/cpu on library start when using many updaters
-	UpdaterInitConcurrency int
+	// a regex string to filter running updaters by
+	Run string
 }
 
 func (o *Opts) Parse() error {
 	// required
-	if o.DataStore == "" {
-		return fmt.Errorf("no store provided")
-	}
 	if o.ConnString == "" {
 		return fmt.Errorf("no connection string provided")
 	}
-	if o.UpdateLock == "" {
-		return fmt.Errorf("not distributed lock provided")
-	}
-	if o.UpdateInterval == 0 {
+
+	// optional
+	if o.UpdateInterval == 0 || o.UpdateInterval < 1 {
 		o.UpdateInterval = DefaultUpdateInterval
 	}
 	if o.UpdaterInitConcurrency == 0 {
 		o.UpdaterInitConcurrency = DefaultUpdaterInitConcurrency
 	}
+	if o.MaxConnPool == 0 {
+		o.MaxConnPool = DefaultMaxConnPool
+	}
+	if len(o.Matchers) == 0 {
+		o.Matchers = []driver.Matcher{
+			&debian.Matcher{},
+			&ubuntu.Matcher{},
+			&alpine.Matcher{},
+		}
+	}
+	if len(o.Updaters) == 0 {
+		var err error
+		o.Updaters, err = updaters()
+		if err != nil {
+			return fmt.Errorf("failed to create default set of updaters: %w", err)
+		}
+	}
+
+	// filter out updaters if regex was passed
+	if o.Run != "" {
+		var err error
+		o.Updaters, err = regexFilter(o.Run, o.Updaters)
+		if err != nil {
+			return fmt.Errorf("regex filtering of updaters failed: %w", err)
+		}
+	}
+
 	return nil
 }

--- a/libvuln/opts.go
+++ b/libvuln/opts.go
@@ -2,6 +2,7 @@ package libvuln
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/quay/claircore/alpine"
 	"github.com/quay/claircore/debian"
@@ -10,7 +11,7 @@ import (
 )
 
 const (
-	DefaultUpdateInterval         = 30
+	DefaultUpdateInterval         = 30 * time.Minute
 	DefaultUpdaterInitConcurrency = 10
 	DefaultMaxConnPool            = 100
 )
@@ -21,7 +22,7 @@ type Opts struct {
 	// the connectiong string to the above data store implementation
 	ConnString string
 	// the interval in minutes which updaters will update the vulnstore
-	UpdateInterval int
+	UpdateInterval time.Duration
 	// number of updaters ran in parallel while libvuln initializes. use this to tune io/cpu on library start when using many updaters
 	UpdaterInitConcurrency int
 	// returns the matchers to be used during libvuln runtime
@@ -39,7 +40,7 @@ func (o *Opts) Parse() error {
 	}
 
 	// optional
-	if o.UpdateInterval == 0 || o.UpdateInterval < 1 {
+	if o.UpdateInterval == 0 || o.UpdateInterval < time.Minute {
 		o.UpdateInterval = DefaultUpdateInterval
 	}
 	if o.UpdaterInitConcurrency == 0 {

--- a/libvuln/updaters.go
+++ b/libvuln/updaters.go
@@ -1,4 +1,4 @@
-package main
+package libvuln
 
 import (
 	"fmt"


### PR DESCRIPTION
Refactors most initialization logic back into each library. It began to leak a bit. 
Various refactoring to retrofit in ClairV4.
Removal of to-soon-abstraction on DataStore and dist lock types. 