### PR TITLE
Ubuntu Matching

### DIFF
--- a/ubuntu/matcher.go
+++ b/ubuntu/matcher.go
@@ -7,6 +7,11 @@ import (
 	version "github.com/knqyf263/go-deb-version"
 )
 
+const (
+	OSReleaseID   = "ubuntu"
+	OSReleaseName = "Ubuntu"
+)
+
 var _ driver.Matcher = (*Matcher)(nil)
 
 type Matcher struct{}
@@ -17,9 +22,9 @@ func (*Matcher) Filter(record *claircore.IndexRecord) bool {
 	}
 
 	switch {
-	case record.Distribution.DID == "ubuntu":
+	case record.Distribution.DID == OSReleaseID:
 		return true
-	case record.Distribution.Name == "Ubuntu":
+	case record.Distribution.Name == OSReleaseName:
 		return true
 	default:
 		return false
@@ -28,7 +33,7 @@ func (*Matcher) Filter(record *claircore.IndexRecord) bool {
 
 func (*Matcher) Query() []driver.MatchExp {
 	return []driver.MatchExp{
-		driver.PackageDistributionVersionCodeName,
+		driver.PackageDistributionVersion,
 	}
 }
 
@@ -37,8 +42,20 @@ func (*Matcher) Vulnerable(record *claircore.IndexRecord, vuln *claircore.Vulner
 		return true
 	}
 
-	v1, _ := version.NewVersion(record.Package.Version)
-	v2, _ := version.NewVersion(vuln.FixedInVersion)
+	v1, err := version.NewVersion(record.Package.Version)
+	if err != nil {
+		return false
+	}
+
+	v2, err := version.NewVersion(vuln.FixedInVersion)
+	if err != nil {
+		return false
+	}
+
+	if v2.String() == "0" {
+		return true
+	}
+
 	if v1.LessThan(v2) {
 		return true
 	}

--- a/ubuntu/releases.go
+++ b/ubuntu/releases.go
@@ -1,5 +1,9 @@
 package ubuntu
 
+import (
+	"github.com/quay/claircore"
+)
+
 type Release string
 
 const (
@@ -20,4 +24,96 @@ var AllReleases = map[Release]struct{}{
 	Precise: struct{}{},
 	Trusty:  struct{}{},
 	Xenial:  struct{}{},
+}
+var ReleaseToVersionID = map[Release]string{
+	Artful:  "17.10",
+	Bionic:  "18.04",
+	Cosmic:  "18.10",
+	Disco:   "19.04",
+	Precise: "12.04",
+	Trusty:  "14.04",
+	Xenial:  "16.04",
+}
+
+var artfulDist = &claircore.Distribution{
+	Name:            "Ubuntu",
+	Version:         "17.10 (Artful Aardvark)",
+	DID:             "ubuntu",
+	PrettyName:      "Ubuntu 17.10",
+	VersionID:       "17.10",
+	VersionCodeName: "artful",
+}
+
+var bionicDist = &claircore.Distribution{
+	Name:            "Ubuntu",
+	Version:         "18.04.3 LTS (Bionic Beaver)",
+	DID:             "ubuntu",
+	PrettyName:      "Ubuntu 18.04.3 LTS",
+	VersionID:       "18.04",
+	VersionCodeName: "bionic",
+}
+
+var cosmicDist = &claircore.Distribution{
+	Name:            "Ubuntu",
+	Version:         "18.10 (Cosmic Cuttlefish)",
+	DID:             "ubuntu",
+	VersionID:       "18.10",
+	VersionCodeName: "cosmic",
+	PrettyName:      "Ubuntu 18.10",
+}
+
+var discoDist = &claircore.Distribution{
+	Name:            "Ubuntu",
+	Version:         "19.04 (Disco Dingo)",
+	DID:             "ubuntu",
+	VersionID:       "19.04",
+	VersionCodeName: "disco",
+	PrettyName:      "Ubuntu 19.04",
+}
+
+var preciseDist = &claircore.Distribution{
+	Name:       "Ubuntu",
+	Version:    "12.04.5 LTS, Precise Pangolin",
+	DID:        "ubuntu",
+	VersionID:  "12.04",
+	PrettyName: "Ubuntu precise (12.04.5 LTS)",
+}
+
+var trustyDist = &claircore.Distribution{
+	Name:       "Ubuntu",
+	Version:    "14.04.6 LTS, Trusty Tahr",
+	DID:        "ubuntu",
+	PrettyName: "Ubuntu 14.04.6 LTS",
+	VersionID:  "14.04",
+}
+
+var xenialDist = &claircore.Distribution{
+	Name:            "Ubuntu",
+	Version:         "14.04.6 LTS, Trusty Tahr",
+	DID:             "ubuntu",
+	PrettyName:      "Ubuntu 16.04.6 LTS",
+	VersionID:       "16.04",
+	VersionCodeName: "xenial",
+}
+
+func releaseToDist(r Release) *claircore.Distribution {
+	switch r {
+	case Artful:
+		return artfulDist
+	case Bionic:
+		return bionicDist
+	case Cosmic:
+		return bionicDist
+	case Disco:
+		return discoDist
+	case Precise:
+		return preciseDist
+	case Trusty:
+		return trustyDist
+	case Xenial:
+		return xenialDist
+	default:
+		// return empty dist
+		return &claircore.Distribution{}
+	}
 }

--- a/ubuntu/updater.go
+++ b/ubuntu/updater.go
@@ -187,11 +187,7 @@ func (u *Updater) classifyVuln(name string, fixVersion string) *claircore.Vulner
 	vuln := u.curVuln
 	vuln.FixedInVersion = fixVersion
 	vuln.Package = pkg
-	vuln.Dist = &claircore.Distribution{
-		DID:             "ubuntu",
-		Name:            "Ubuntu",
-		VersionCodeName: string(u.release),
-	}
+	vuln.Dist = releaseToDist(u.release)
 	return &vuln
 }
 


### PR DESCRIPTION
This PR implements Ubuntu vulnerability matching. 

PR uses the VersionID field in the os-release file to match parsed vulnerabilities with package distributions. 