### PR TITLE
add Name interface method to Matcher

### DIFF
--- a/alpine/matcher.go
+++ b/alpine/matcher.go
@@ -10,6 +10,10 @@ type Matcher struct{}
 
 var _ driver.Matcher = (*Matcher)(nil)
 
+func (*Matcher) Name() string {
+	return "alpine-matcher"
+}
+
 func (*Matcher) Filter(record *claircore.IndexRecord) bool {
 	if record.Distribution == nil {
 		return false

--- a/aws/matcher.go
+++ b/aws/matcher.go
@@ -10,6 +10,10 @@ type Matcher struct{}
 
 var _ driver.Matcher = (*Matcher)(nil)
 
+func (*Matcher) Name() string {
+	return "aws-matcher"
+}
+
 func (*Matcher) Filter(record *claircore.IndexRecord) bool {
 	if record.Distribution == nil {
 		return false

--- a/debian/matcher.go
+++ b/debian/matcher.go
@@ -10,6 +10,10 @@ type Matcher struct{}
 
 var _ driver.Matcher = (*Matcher)(nil)
 
+func (*Matcher) Name() string {
+	return "debian-matcher"
+}
+
 func (*Matcher) Filter(record *claircore.IndexRecord) bool {
 	if record.Distribution == nil {
 		return false

--- a/internal/matcher/matcher_mock.go
+++ b/internal/matcher/matcher_mock.go
@@ -48,6 +48,20 @@ func (mr *MockMatcherMockRecorder) Filter(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Filter", reflect.TypeOf((*MockMatcher)(nil).Filter), arg0)
 }
 
+// Name mocks base method
+func (m *MockMatcher) Name() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Name")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Name indicates an expected call of Name
+func (mr *MockMatcherMockRecorder) Name() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockMatcher)(nil).Name))
+}
+
 // Query mocks base method
 func (m *MockMatcher) Query() []driver.MatchExp {
 	m.ctrl.T.Helper()

--- a/libvuln/driver/driver.go
+++ b/libvuln/driver/driver.go
@@ -42,6 +42,8 @@ const (
 
 // Matcher is an interface which a Controller uses to query the vulnstore for vulnerabilities.
 type Matcher interface {
+	// a unique name for the matcher
+	Name() string
 	// Filter informs the Controller if the implemented Matcher is interested in the provided IndexRecord.
 	Filter(record *claircore.IndexRecord) bool
 	// Query informs the Controller how it should match packages with vulnerabilities.

--- a/ubuntu/matcher.go
+++ b/ubuntu/matcher.go
@@ -16,6 +16,10 @@ var _ driver.Matcher = (*Matcher)(nil)
 
 type Matcher struct{}
 
+func (*Matcher) Name() string {
+	return "ubuntu-matcher"
+}
+
 func (*Matcher) Filter(record *claircore.IndexRecord) bool {
 	if record.Distribution == nil {
 		return false


### PR DESCRIPTION
Adds a interface method to extract a Name from an instantiated Matcher. 
@hdonnay you can merge this and rebase #69 to remove the reflection. 