### PR TITLE
all: regroup imports consistently

### DIFF
--- a/alpine/fetcher.go
+++ b/alpine/fetcher.go
@@ -7,10 +7,10 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/rs/zerolog"
+
 	"github.com/quay/claircore/libvuln/driver"
 	"github.com/quay/claircore/pkg/tmp"
-
-	"github.com/rs/zerolog"
 )
 
 func (u *Updater) Fetch() (io.ReadCloser, string, error) {

--- a/alpine/matcher.go
+++ b/alpine/matcher.go
@@ -2,6 +2,7 @@ package alpine
 
 import (
 	version "github.com/knqyf263/go-deb-version"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/libvuln/driver"
 )

--- a/alpine/packagescanner.go
+++ b/alpine/packagescanner.go
@@ -8,11 +8,11 @@ import (
 	"io"
 	"runtime/trace"
 
-	"github.com/quay/claircore"
-	"github.com/quay/claircore/internal/indexer"
-
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+
+	"github.com/quay/claircore"
+	"github.com/quay/claircore/internal/indexer"
 )
 
 const (

--- a/alpine/packagescanner_test.go
+++ b/alpine/packagescanner_test.go
@@ -7,11 +7,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/test/fetch"
 	"github.com/quay/claircore/test/log"
-
-	"github.com/google/go-cmp/cmp"
 )
 
 func TestScan(t *testing.T) {

--- a/alpine/parser.go
+++ b/alpine/parser.go
@@ -6,9 +6,10 @@ import (
 	"io"
 	"time"
 
+	"github.com/rs/zerolog"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/libvuln/driver"
-	"github.com/rs/zerolog"
 )
 
 const (

--- a/alpine/parser_test.go
+++ b/alpine/parser_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/quay/claircore"
 )
 

--- a/alpine/updater.go
+++ b/alpine/updater.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/quay/claircore/libvuln/driver"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+
+	"github.com/quay/claircore/libvuln/driver"
 )
 
 const (

--- a/aws/client.go
+++ b/aws/client.go
@@ -13,9 +13,10 @@ import (
 	"time"
 
 	"github.com/quay/alas"
-	"github.com/quay/claircore/pkg/tmp"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+
+	"github.com/quay/claircore/pkg/tmp"
 )
 
 const (

--- a/aws/client_integration_test.go
+++ b/aws/client_integration_test.go
@@ -5,8 +5,9 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/quay/claircore/test/integration"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/quay/claircore/test/integration"
 )
 
 func Test_Client_Linux1_Integration_GetMirrors(t *testing.T) {

--- a/aws/client_test.go
+++ b/aws/client_test.go
@@ -8,8 +8,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/quay/claircore/test/integration"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/quay/claircore/test/integration"
 )
 
 func Test_Client_Linux1_GetMirrors(t *testing.T) {

--- a/aws/matcher.go
+++ b/aws/matcher.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	version "github.com/knqyf263/go-rpm-version"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/libvuln/driver"
 )

--- a/aws/updater.go
+++ b/aws/updater.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/quay/alas"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/libvuln/driver"
 )

--- a/aws/updater_integration_test.go
+++ b/aws/updater_integration_test.go
@@ -3,8 +3,9 @@ package aws
 import (
 	"testing"
 
-	"github.com/quay/claircore/test/integration"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/quay/claircore/test/integration"
 )
 
 func Test_Updater(t *testing.T) {

--- a/cmd/libindexhttp/main.go
+++ b/cmd/libindexhttp/main.go
@@ -7,10 +7,11 @@ import (
 	"strings"
 
 	"github.com/crgimenes/goconfig"
-	"github.com/quay/claircore/libindex"
-	libhttp "github.com/quay/claircore/libindex/http"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+
+	"github.com/quay/claircore/libindex"
+	libhttp "github.com/quay/claircore/libindex/http"
 )
 
 // Config this struct is using the goconfig library for simple flag and env var

--- a/cmd/libvulnhttp/main.go
+++ b/cmd/libvulnhttp/main.go
@@ -6,12 +6,12 @@ import (
 	"os"
 	"strings"
 
-	"github.com/quay/claircore/libvuln"
-	libhttp "github.com/quay/claircore/libvuln/http"
-
 	"github.com/crgimenes/goconfig"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+
+	"github.com/quay/claircore/libvuln"
+	libhttp "github.com/quay/claircore/libvuln/http"
 )
 
 // Config this struct is using the goconfig library for simple flag and env var

--- a/debian/matcher.go
+++ b/debian/matcher.go
@@ -2,6 +2,7 @@ package debian
 
 import (
 	version "github.com/knqyf263/go-deb-version"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/libvuln/driver"
 )

--- a/debian/matcher_integration_test.go
+++ b/debian/matcher_integration_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/internal/updater"
 	"github.com/quay/claircore/internal/vulnscanner"
@@ -15,8 +17,6 @@ import (
 	"github.com/quay/claircore/libvuln/driver"
 	distlock "github.com/quay/claircore/pkg/distlock/postgres"
 	"github.com/quay/claircore/test/integration"
-
-	"github.com/stretchr/testify/assert"
 )
 
 // Test_Matcher_Integration confirms packages are matched

--- a/debian/updater.go
+++ b/debian/updater.go
@@ -7,13 +7,13 @@ import (
 	"net/http"
 	"regexp"
 
-	"github.com/quay/claircore"
-	"github.com/quay/claircore/libvuln/driver"
-	"github.com/quay/claircore/pkg/ovalutil"
-
 	"github.com/quay/goval-parser/oval"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+
+	"github.com/quay/claircore"
+	"github.com/quay/claircore/libvuln/driver"
+	"github.com/quay/claircore/pkg/ovalutil"
 )
 
 func init() {

--- a/debian/updater_integration_test.go
+++ b/debian/updater_integration_test.go
@@ -5,9 +5,10 @@ package debian
 import (
 	"testing"
 
-	"github.com/quay/claircore/test/integration"
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/quay/claircore/test/integration"
 )
 
 func Test_Updater(t *testing.T) {

--- a/dpkg/scanner.go
+++ b/dpkg/scanner.go
@@ -13,12 +13,12 @@ import (
 	"runtime/trace"
 	"strings"
 
-	"github.com/quay/claircore"
-	"github.com/quay/claircore/internal/indexer"
-
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/tadasv/go-dpkg"
+
+	"github.com/quay/claircore"
+	"github.com/quay/claircore/internal/indexer"
 )
 
 const (

--- a/dpkg/scanner_test.go
+++ b/dpkg/scanner_test.go
@@ -7,11 +7,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/test/fetch"
 	"github.com/quay/claircore/test/log"
-
-	"github.com/google/go-cmp/cmp"
 )
 
 func TestScanner(t *testing.T) {

--- a/internal/indexer/controller/checkmanifest_test.go
+++ b/internal/indexer/controller/checkmanifest_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/internal/indexer"
-	"github.com/stretchr/testify/assert"
 )
 
 // confirm checkManfest statefunc acts appropriately

--- a/internal/indexer/controller/coalesce.go
+++ b/internal/indexer/controller/coalesce.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"sync"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/internal/indexer"
-	"golang.org/x/sync/errgroup"
 )
 
 // coalesce calls each ecosystem's coalescer and merges the returned IndexReports

--- a/internal/indexer/controller/controller.go
+++ b/internal/indexer/controller/controller.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"sync"
 
-	"github.com/quay/claircore"
-	"github.com/quay/claircore/internal/indexer"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+
+	"github.com/quay/claircore"
+	"github.com/quay/claircore/internal/indexer"
 )
 
 // stateFunc implement the logic of our controller and map directly to States.

--- a/internal/indexer/controller/indexfinished_test.go
+++ b/internal/indexer/controller/indexfinished_test.go
@@ -5,8 +5,9 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/quay/claircore/internal/indexer"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/quay/claircore/internal/indexer"
 )
 
 func Test_ScanFinished_Success(t *testing.T) {

--- a/internal/indexer/controller/scanlayers_test.go
+++ b/internal/indexer/controller/scanlayers_test.go
@@ -5,8 +5,9 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/quay/claircore/internal/indexer"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/quay/claircore/internal/indexer"
 )
 
 func Test_ScanLayers(t *testing.T) {

--- a/internal/indexer/fetcher/fecher_integration_test.go
+++ b/internal/indexer/fetcher/fecher_integration_test.go
@@ -6,11 +6,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/quay/claircore/internal/indexer"
 	"github.com/quay/claircore/test"
 	"github.com/quay/claircore/test/integration"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_Fetcher_Integration(t *testing.T) {

--- a/internal/indexer/fetcher/fetcher.go
+++ b/internal/indexer/fetcher/fetcher.go
@@ -12,12 +12,13 @@ import (
 	"os"
 	"sync"
 
-	"github.com/quay/claircore"
-	"github.com/quay/claircore/internal/indexer"
-	"github.com/quay/claircore/moby"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/quay/claircore"
+	"github.com/quay/claircore/internal/indexer"
+	"github.com/quay/claircore/moby"
 )
 
 // fetcher is a private struct which implements our in memory indexer.Fetcher

--- a/internal/indexer/fetcher/fetcher_test.go
+++ b/internal/indexer/fetcher/fetcher_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/internal/indexer"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_Fetcher_LocalPath(t *testing.T) {

--- a/internal/indexer/layerscanner/layerscanner.go
+++ b/internal/indexer/layerscanner/layerscanner.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/quay/claircore"
-	"github.com/quay/claircore/internal/indexer"
+	"github.com/rs/zerolog"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/rs/zerolog"
+	"github.com/quay/claircore"
+	"github.com/quay/claircore/internal/indexer"
 )
 
 // layerScanner implements the indexer.LayerScanner interface.

--- a/internal/indexer/layerscanner/layerscanner_test.go
+++ b/internal/indexer/layerscanner/layerscanner_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/internal/indexer"
 	"github.com/quay/claircore/test"

--- a/internal/indexer/postgres/distributionsbylayer.go
+++ b/internal/indexer/postgres/distributionsbylayer.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/jmoiron/sqlx"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/internal/indexer"
 )

--- a/internal/indexer/postgres/distributionsbylayer_test.go
+++ b/internal/indexer/postgres/distributionsbylayer_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/quay/claircore/test"
 	"github.com/quay/claircore/test/integration"
 	pgtest "github.com/quay/claircore/test/postgres"

--- a/internal/indexer/postgres/indexdistributions.go
+++ b/internal/indexer/postgres/indexdistributions.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/jmoiron/sqlx"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/internal/indexer"
 	"github.com/quay/claircore/pkg/microbatch"

--- a/internal/indexer/postgres/indexdistributions_test.go
+++ b/internal/indexer/postgres/indexdistributions_test.go
@@ -6,11 +6,12 @@ import (
 	"testing"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/test"
 	"github.com/quay/claircore/test/integration"
 	pgtest "github.com/quay/claircore/test/postgres"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_IndexDistributions_Success(t *testing.T) {

--- a/internal/indexer/postgres/indexpackage.go
+++ b/internal/indexer/postgres/indexpackage.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/jmoiron/sqlx"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/internal/indexer"
 	"github.com/quay/claircore/pkg/microbatch"
-
-	"github.com/jackc/pgx/v4/pgxpool"
-	"github.com/jmoiron/sqlx"
 )
 
 const (

--- a/internal/indexer/postgres/indexpackage_test.go
+++ b/internal/indexer/postgres/indexpackage_test.go
@@ -6,11 +6,12 @@ import (
 	"testing"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/test"
 	"github.com/quay/claircore/test/integration"
 	pgtest "github.com/quay/claircore/test/postgres"
-	"github.com/stretchr/testify/assert"
 )
 
 // scanInfo is a helper struct for providing scanner information

--- a/internal/indexer/postgres/indexreport.go
+++ b/internal/indexer/postgres/indexreport.go
@@ -5,9 +5,9 @@ import (
 	"database/sql"
 	"fmt"
 
-	"github.com/quay/claircore"
-
 	"github.com/jmoiron/sqlx"
+
+	"github.com/quay/claircore"
 )
 
 const (

--- a/internal/indexer/postgres/indexreport_test.go
+++ b/internal/indexer/postgres/indexreport_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/test/integration"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_IndexReport_Success(t *testing.T) {

--- a/internal/indexer/postgres/indexrepository.go
+++ b/internal/indexer/postgres/indexrepository.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/jmoiron/sqlx"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/internal/indexer"
 	"github.com/quay/claircore/pkg/microbatch"

--- a/internal/indexer/postgres/indexrepository_test.go
+++ b/internal/indexer/postgres/indexrepository_test.go
@@ -6,11 +6,12 @@ import (
 	"testing"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/test"
 	"github.com/quay/claircore/test/integration"
 	pgtest "github.com/quay/claircore/test/postgres"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_IndexRepositories_Success(t *testing.T) {

--- a/internal/indexer/postgres/layerscanned.go
+++ b/internal/indexer/postgres/layerscanned.go
@@ -5,9 +5,9 @@ import (
 	"database/sql"
 	"fmt"
 
-	"github.com/quay/claircore/internal/indexer"
-
 	"github.com/jmoiron/sqlx"
+
+	"github.com/quay/claircore/internal/indexer"
 )
 
 const (

--- a/internal/indexer/postgres/layerscanned_test.go
+++ b/internal/indexer/postgres/layerscanned_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/quay/claircore/test"
 	"github.com/quay/claircore/test/integration"
 	pgtest "github.com/quay/claircore/test/postgres"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_LayerScanned_Packages_False(t *testing.T) {

--- a/internal/indexer/postgres/manifestscanned.go
+++ b/internal/indexer/postgres/manifestscanned.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/quay/claircore/internal/indexer"
-
 	"github.com/jmoiron/sqlx"
+
+	"github.com/quay/claircore/internal/indexer"
 )
 
 const (

--- a/internal/indexer/postgres/manifestscanned_test.go
+++ b/internal/indexer/postgres/manifestscanned_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/quay/claircore/test"
 	"github.com/quay/claircore/test/integration"
 	pgtest "github.com/quay/claircore/test/postgres"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_ManifestScanned_Failure(t *testing.T) {

--- a/internal/indexer/postgres/packagesbylayer.go
+++ b/internal/indexer/postgres/packagesbylayer.go
@@ -5,10 +5,10 @@ import (
 	"database/sql"
 	"fmt"
 
+	"github.com/jmoiron/sqlx"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/internal/indexer"
-
-	"github.com/jmoiron/sqlx"
 )
 
 const (

--- a/internal/indexer/postgres/packagesbylayer_test.go
+++ b/internal/indexer/postgres/packagesbylayer_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/quay/claircore/test"
 	"github.com/quay/claircore/test/integration"
 	pgtest "github.com/quay/claircore/test/postgres"

--- a/internal/indexer/postgres/registerscanners.go
+++ b/internal/indexer/postgres/registerscanners.go
@@ -5,9 +5,9 @@ import (
 	"database/sql"
 	"fmt"
 
-	"github.com/quay/claircore/internal/indexer"
-
 	"github.com/jmoiron/sqlx"
+
+	"github.com/quay/claircore/internal/indexer"
 )
 
 const (

--- a/internal/indexer/postgres/registerscanners_test.go
+++ b/internal/indexer/postgres/registerscanners_test.go
@@ -5,11 +5,11 @@ import (
 	"database/sql"
 	"testing"
 
-	"github.com/quay/claircore/internal/indexer"
-	"github.com/quay/claircore/test/integration"
-
 	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/quay/claircore/internal/indexer"
+	"github.com/quay/claircore/test/integration"
 )
 
 func Test_RegisterScanners_Success(t *testing.T) {

--- a/internal/indexer/postgres/repositoriesbylayer.go
+++ b/internal/indexer/postgres/repositoriesbylayer.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/jmoiron/sqlx"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/internal/indexer"
 )

--- a/internal/indexer/postgres/repositoriesbylayer_test.go
+++ b/internal/indexer/postgres/repositoriesbylayer_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/quay/claircore/test"
 	"github.com/quay/claircore/test/integration"
 	pgtest "github.com/quay/claircore/test/postgres"

--- a/internal/indexer/postgres/setindexfinished.go
+++ b/internal/indexer/postgres/setindexfinished.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/jmoiron/sqlx"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/internal/indexer"
-
-	"github.com/jmoiron/sqlx"
 )
 
 const (

--- a/internal/indexer/postgres/setindexfinished_test.go
+++ b/internal/indexer/postgres/setindexfinished_test.go
@@ -5,11 +5,11 @@ import (
 	"testing"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/internal/indexer"
 	"github.com/quay/claircore/test/integration"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_SetScanFinished_Success(t *testing.T) {

--- a/internal/indexer/postgres/setindexreport.go
+++ b/internal/indexer/postgres/setindexreport.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/quay/claircore"
-
 	"github.com/jmoiron/sqlx"
+
+	"github.com/quay/claircore"
 )
 
 const (

--- a/internal/indexer/postgres/setindexreport_test.go
+++ b/internal/indexer/postgres/setindexreport_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/test/integration"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_SetIndexReport_StateUpdate(t *testing.T) {

--- a/internal/indexer/postgres/store.go
+++ b/internal/indexer/postgres/store.go
@@ -3,11 +3,11 @@ package postgres
 import (
 	"context"
 
-	"github.com/quay/claircore"
-	"github.com/quay/claircore/internal/indexer"
-
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/jmoiron/sqlx"
+
+	"github.com/quay/claircore"
+	"github.com/quay/claircore/internal/indexer"
 )
 
 var _ indexer.Store = (*store)(nil)

--- a/internal/indexer/postgres/teststore.go
+++ b/internal/indexer/postgres/teststore.go
@@ -7,13 +7,13 @@ import (
 	"os/exec"
 	"testing"
 
-	"github.com/quay/claircore/libindex/migrations"
-	"github.com/quay/claircore/test/integration"
-
 	"github.com/jackc/pgx/v4/pgxpool"
 	_ "github.com/jackc/pgx/v4/stdlib" // Needed for sqlx.Open
 	"github.com/jmoiron/sqlx"
 	"github.com/remind101/migrate"
+
+	"github.com/quay/claircore/libindex/migrations"
+	"github.com/quay/claircore/test/integration"
 )
 
 func TestStore(ctx context.Context, t testing.TB) (*sqlx.DB, *store, func()) {

--- a/internal/indexer/scanner_test.go
+++ b/internal/indexer/scanner_test.go
@@ -8,8 +8,9 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/quay/claircore"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/quay/claircore"
 )
 
 // Test_Scanner_ScanError confirms the state machines does the correct

--- a/internal/updater/controller.go
+++ b/internal/updater/controller.go
@@ -6,11 +6,12 @@ import (
 	"io"
 	"time"
 
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+
 	"github.com/quay/claircore/internal/vulnstore"
 	"github.com/quay/claircore/libvuln/driver"
 	"github.com/quay/claircore/pkg/distlock"
-	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 )
 
 // Controller is a control structure for fetching, parsing, and updating a vulnstore.

--- a/internal/updater/updater_integration_test.go
+++ b/internal/updater/updater_integration_test.go
@@ -5,12 +5,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/quay/claircore/internal/vulnstore/postgres"
 	distlock "github.com/quay/claircore/pkg/distlock/postgres"
 	"github.com/quay/claircore/test/integration"
 	"github.com/quay/claircore/ubuntu"
-
-	"github.com/stretchr/testify/assert"
 )
 
 // Test_Updater_Integration starts with an empty database and runs until a

--- a/internal/vulnscanner/scanner.go
+++ b/internal/vulnscanner/scanner.go
@@ -3,11 +3,12 @@ package vulnscanner
 import (
 	"context"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/internal/matcher"
 	"github.com/quay/claircore/internal/vulnstore"
 	"github.com/quay/claircore/libvuln/driver"
-	"golang.org/x/sync/errgroup"
 )
 
 // VulnScanner utilizes a claircore.IndexReport to create a claircore.VulnerabilityReport

--- a/internal/vulnstore/postgres/get.go
+++ b/internal/vulnstore/postgres/get.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v4/pgxpool"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/internal/vulnstore"
 	"github.com/quay/claircore/libvuln/driver"
-
-	"github.com/jackc/pgx/v4"
-	"github.com/jackc/pgx/v4/pgxpool"
 )
 
 func get(ctx context.Context, pool *pgxpool.Pool, records []*claircore.IndexRecord, opts vulnstore.GetOpts) (map[int][]*claircore.Vulnerability, error) {

--- a/internal/vulnstore/postgres/gethash_integration_test.go
+++ b/internal/vulnstore/postgres/gethash_integration_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/quay/claircore/test/integration"
-
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/quay/claircore/test/integration"
 )
 
 func Test_GetHash_KeyNotExists(t *testing.T) {

--- a/internal/vulnstore/postgres/puthash_integration_test.go
+++ b/internal/vulnstore/postgres/puthash_integration_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/quay/claircore/test/integration"
-
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/quay/claircore/test/integration"
 )
 
 func Test_PutHash_Upsert(t *testing.T) {

--- a/internal/vulnstore/postgres/putvulnerabilities.go
+++ b/internal/vulnstore/postgres/putvulnerabilities.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/quay/claircore"
-	"github.com/quay/claircore/pkg/microbatch"
-
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
+
+	"github.com/quay/claircore"
+	"github.com/quay/claircore/pkg/microbatch"
 )
 
 const (

--- a/internal/vulnstore/postgres/putvulnerabilities_integration_test.go
+++ b/internal/vulnstore/postgres/putvulnerabilities_integration_test.go
@@ -7,11 +7,11 @@ import (
 	"testing"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/test"
 	"github.com/quay/claircore/test/integration"
-
-	"github.com/stretchr/testify/assert"
 )
 
 const (

--- a/internal/vulnstore/postgres/querybuilder.go
+++ b/internal/vulnstore/postgres/querybuilder.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/doug-martin/goqu/v8"
 	_ "github.com/doug-martin/goqu/v8/dialect/postgres"
+
 	"github.com/quay/claircore/libvuln/driver"
 )
 

--- a/internal/vulnstore/postgres/querybuilder_test.go
+++ b/internal/vulnstore/postgres/querybuilder_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/quay/claircore/libvuln/driver"
 )
 

--- a/internal/vulnstore/postgres/testvulnstore.go
+++ b/internal/vulnstore/postgres/testvulnstore.go
@@ -7,15 +7,15 @@ import (
 	"os/exec"
 	"testing"
 
-	"github.com/quay/claircore/libvuln/migrations"
-	"github.com/quay/claircore/test/integration"
-
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/log/testingadapter"
 	"github.com/jackc/pgx/v4/pgxpool"
 	_ "github.com/jackc/pgx/v4/stdlib" // needed for sqlx.Open
 	"github.com/jmoiron/sqlx"
 	"github.com/remind101/migrate"
+
+	"github.com/quay/claircore/libvuln/migrations"
+	"github.com/quay/claircore/test/integration"
 )
 
 func TestStore(ctx context.Context, t testing.TB) (*sqlx.DB, *Store, func()) {

--- a/internal/vulnstore/postgres/vulnstore.go
+++ b/internal/vulnstore/postgres/vulnstore.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/quay/claircore"
-	"github.com/quay/claircore/internal/vulnstore"
-
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/jmoiron/sqlx"
+
+	"github.com/quay/claircore"
+	"github.com/quay/claircore/internal/vulnstore"
 )
 
 // store implements all interfaces in the vulnstore package

--- a/layer_integration_test.go
+++ b/layer_integration_test.go
@@ -9,12 +9,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/quay/claircore/internal/indexer"
 	"github.com/quay/claircore/internal/indexer/fetcher"
 	"github.com/quay/claircore/test"
 	"github.com/quay/claircore/test/integration"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_Layer_Files_Miss(t *testing.T) {

--- a/libindex/http/indexreporthandler.go
+++ b/libindex/http/indexreporthandler.go
@@ -6,9 +6,9 @@ import (
 	h "net/http"
 	"strings"
 
-	"github.com/quay/claircore/libindex"
-
 	"github.com/rs/zerolog/log"
+
+	"github.com/quay/claircore/libindex"
 )
 
 func IndexReport(lib libindex.Libindex) h.HandlerFunc {

--- a/libindex/init.go
+++ b/libindex/init.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/quay/claircore/internal/indexer"
-	"github.com/quay/claircore/internal/indexer/postgres"
-
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/jmoiron/sqlx"
-	"github.com/quay/claircore/libindex/migrations"
 	"github.com/remind101/migrate"
+
+	"github.com/quay/claircore/internal/indexer"
+	"github.com/quay/claircore/internal/indexer/postgres"
+	"github.com/quay/claircore/libindex/migrations"
 )
 
 // initialize a indexer.Store given libindex.Opts

--- a/libindex/libindex.go
+++ b/libindex/libindex.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/jmoiron/sqlx"
+	"github.com/rs/zerolog"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/internal/indexer"
 	"github.com/quay/claircore/internal/indexer/controller"
-
-	"github.com/jmoiron/sqlx"
-	"github.com/rs/zerolog"
 )
 
 // libindex is an interface exporting the public methods of our library.

--- a/libindex/libindex_integration_test.go
+++ b/libindex/libindex_integration_test.go
@@ -10,11 +10,12 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/internal/indexer"
 	"github.com/quay/claircore/internal/indexer/postgres"
 	"github.com/quay/claircore/test"
-	"github.com/stretchr/testify/assert"
 )
 
 const (

--- a/libvuln/http/vulnscanhandler.go
+++ b/libvuln/http/vulnscanhandler.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	h "net/http"
 
+	"github.com/rs/zerolog/log"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/libvuln"
-
 	je "github.com/quay/claircore/pkg/jsonerr"
-	"github.com/rs/zerolog/log"
 )
 
 func VulnScan(lib libvuln.Libvuln) h.HandlerFunc {

--- a/libvuln/init.go
+++ b/libvuln/init.go
@@ -6,16 +6,16 @@ import (
 	"sync"
 	"time"
 
+	"github.com/jackc/pgx/v4/pgxpool"
+	_ "github.com/jackc/pgx/v4/stdlib"
+	"github.com/jmoiron/sqlx"
+	"github.com/remind101/migrate"
+
 	"github.com/quay/claircore/internal/updater"
 	"github.com/quay/claircore/internal/vulnstore"
 	"github.com/quay/claircore/internal/vulnstore/postgres"
 	"github.com/quay/claircore/libvuln/migrations"
 	pglock "github.com/quay/claircore/pkg/distlock/postgres"
-
-	"github.com/jackc/pgx/v4/pgxpool"
-	_ "github.com/jackc/pgx/v4/stdlib"
-	"github.com/jmoiron/sqlx"
-	"github.com/remind101/migrate"
 )
 
 // initUpdaters provides initial burst control to not launch too many updaters at once.

--- a/libvuln/libvuln.go
+++ b/libvuln/libvuln.go
@@ -4,12 +4,13 @@ import (
 	"context"
 
 	"github.com/jmoiron/sqlx"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/internal/vulnscanner"
 	"github.com/quay/claircore/internal/vulnstore"
 	"github.com/quay/claircore/libvuln/driver"
-	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 )
 
 // Libvuln is an interface exporting the public methods of our library.

--- a/libvuln/updaters.go
+++ b/libvuln/updaters.go
@@ -5,6 +5,8 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/rs/zerolog/log"
+
 	"github.com/quay/claircore/alpine"
 	"github.com/quay/claircore/aws"
 	"github.com/quay/claircore/debian"
@@ -13,7 +15,6 @@ import (
 	"github.com/quay/claircore/rhel"
 	"github.com/quay/claircore/suse"
 	"github.com/quay/claircore/ubuntu"
-	"github.com/rs/zerolog/log"
 )
 
 var ubuntuReleases = []ubuntu.Release{

--- a/moby/stacker.go
+++ b/moby/stacker.go
@@ -7,8 +7,9 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/quay/claircore"
 	mobyarchive "github.com/moby/moby/pkg/archive"
+
+	"github.com/quay/claircore"
 )
 
 // Stacker should take a list of *claircore.Layer structs and stacks their contents

--- a/oracle/parser.go
+++ b/oracle/parser.go
@@ -7,12 +7,12 @@ import (
 	"io"
 	"time"
 
+	"github.com/quay/goval-parser/oval"
+	"github.com/rs/zerolog"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/libvuln/driver"
 	"github.com/quay/claircore/pkg/ovalutil"
-
-	"github.com/quay/goval-parser/oval"
-	"github.com/rs/zerolog"
 )
 
 var _ driver.Parser = (*Updater)(nil)

--- a/oracle/parser_test.go
+++ b/oracle/parser_test.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/quay/claircore/test/log"
-
 	"github.com/quay/goval-parser/oval"
+
+	"github.com/quay/claircore/test/log"
 )
 
 func TestParse(t *testing.T) {

--- a/oracle/updater.go
+++ b/oracle/updater.go
@@ -9,11 +9,11 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/quay/claircore/libvuln/driver"
-	"github.com/quay/claircore/pkg/ovalutil"
-
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+
+	"github.com/quay/claircore/libvuln/driver"
+	"github.com/quay/claircore/pkg/ovalutil"
 )
 
 const (

--- a/osrelease/scanner_test.go
+++ b/osrelease/scanner_test.go
@@ -11,10 +11,10 @@ import (
 	"runtime/trace"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/test/integration"
-
-	"github.com/google/go-cmp/cmp"
 )
 
 type parsecase struct {

--- a/pkg/ovalutil/fetcher.go
+++ b/pkg/ovalutil/fetcher.go
@@ -9,10 +9,10 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/rs/zerolog"
+
 	"github.com/quay/claircore/libvuln/driver"
 	"github.com/quay/claircore/pkg/tmp"
-
-	"github.com/rs/zerolog"
 )
 
 // Compressor is used by Fetcher to decompress data it fetches.

--- a/pkg/ovalutil/rpminfo.go
+++ b/pkg/ovalutil/rpminfo.go
@@ -6,10 +6,10 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/quay/claircore"
-
 	"github.com/quay/goval-parser/oval"
 	"github.com/rs/zerolog"
+
+	"github.com/quay/claircore"
 )
 
 // RPMInfo holds information for extracting Vulnerabilities from an OVAL

--- a/rhel/parse_test.go
+++ b/rhel/parse_test.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/quay/claircore/test/log"
-
 	"github.com/quay/goval-parser/oval"
+
+	"github.com/quay/claircore/test/log"
 )
 
 func TestParse(t *testing.T) {

--- a/rhel/rhel.go
+++ b/rhel/rhel.go
@@ -9,11 +9,11 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/quay/goval-parser/oval"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/libvuln/driver"
 	"github.com/quay/claircore/pkg/ovalutil"
-
-	"github.com/quay/goval-parser/oval"
 )
 
 // We currently grab the oval databases db distro-wise.

--- a/rpm/packagescanner.go
+++ b/rpm/packagescanner.go
@@ -15,12 +15,12 @@ import (
 	"runtime/trace"
 	"strings"
 
-	"github.com/quay/claircore"
-	"github.com/quay/claircore/internal/indexer"
-
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/quay/claircore"
+	"github.com/quay/claircore/internal/indexer"
 )
 
 const (

--- a/rpm/packagescanner_test.go
+++ b/rpm/packagescanner_test.go
@@ -8,11 +8,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/test/fetch"
 	"github.com/quay/claircore/test/log"
-
-	"github.com/google/go-cmp/cmp"
 )
 
 func TestScan(t *testing.T) {

--- a/suse/suse.go
+++ b/suse/suse.go
@@ -9,13 +9,13 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/quay/claircore"
-	"github.com/quay/claircore/libvuln/driver"
-	"github.com/quay/claircore/pkg/ovalutil"
-
 	"github.com/quay/goval-parser/oval"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+
+	"github.com/quay/claircore"
+	"github.com/quay/claircore/libvuln/driver"
+	"github.com/quay/claircore/pkg/ovalutil"
 )
 
 // Release indicates the SUSE release OVAL database to pull from.

--- a/test/postgres/distribution.go
+++ b/test/postgres/distribution.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/jmoiron/sqlx"
+
 	"github.com/quay/claircore"
 )
 

--- a/test/postgres/distribution_scanartifact.go
+++ b/test/postgres/distribution_scanartifact.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/jmoiron/sqlx"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/internal/indexer"
 )

--- a/test/postgres/package.go
+++ b/test/postgres/package.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/jmoiron/sqlx"
+
 	"github.com/quay/claircore"
 )
 

--- a/test/postgres/package_scanartifact.go
+++ b/test/postgres/package_scanartifact.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/jmoiron/sqlx"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/internal/indexer"
 )

--- a/test/postgres/repository.go
+++ b/test/postgres/repository.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/jmoiron/sqlx"
+
 	"github.com/quay/claircore"
 )
 

--- a/test/postgres/repository_scanartifact.go
+++ b/test/postgres/repository_scanartifact.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/jmoiron/sqlx"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/internal/indexer"
 )

--- a/test/postgres/scanner.go
+++ b/test/postgres/scanner.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/jmoiron/sqlx"
+
 	"github.com/quay/claircore/internal/indexer"
 )
 

--- a/ubuntu/matcher.go
+++ b/ubuntu/matcher.go
@@ -1,10 +1,10 @@
 package ubuntu
 
 import (
+	version "github.com/knqyf263/go-deb-version"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/libvuln/driver"
-
-	version "github.com/knqyf263/go-deb-version"
 )
 
 const (

--- a/ubuntu/matcher_integration_test.go
+++ b/ubuntu/matcher_integration_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/internal/updater"
 	"github.com/quay/claircore/internal/vulnscanner"
@@ -15,8 +17,6 @@ import (
 	"github.com/quay/claircore/libvuln/driver"
 	distlock "github.com/quay/claircore/pkg/distlock/postgres"
 	"github.com/quay/claircore/test/integration"
-
-	"github.com/stretchr/testify/assert"
 )
 
 // Test_Matcher_Integration confirms packages are matched

--- a/ubuntu/updater.go
+++ b/ubuntu/updater.go
@@ -6,13 +6,13 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/quay/claircore"
-	"github.com/quay/claircore/libvuln/driver"
-	"github.com/quay/claircore/pkg/ovalutil"
-
 	"github.com/quay/goval-parser/oval"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+
+	"github.com/quay/claircore"
+	"github.com/quay/claircore/libvuln/driver"
+	"github.com/quay/claircore/pkg/ovalutil"
 )
 
 const (

--- a/ubuntu/updater_integration_test.go
+++ b/ubuntu/updater_integration_test.go
@@ -3,9 +3,10 @@ package ubuntu
 import (
 	"testing"
 
-	"github.com/quay/claircore/test/integration"
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/quay/claircore/test/integration"
 )
 
 func Test_Updater(t *testing.T) {


### PR DESCRIPTION
Here's the script used, if the need ever arises again:

```
set -e
go list -f '{{$d := .Dir}}{{range .GoFiles}}{{printf "%s/%s\n" $d .}}{{end}}' ./... |
    xargs sed -i'' '/import (/,/)/{ /^$/d }'
go list -f '{{.Dir}}' ./... |
    xargs goimports -local "$(go list -m)" -w
go generate ./...
```