### PR TITLE
Rename match exps 

### DIFF
--- a/alpine/matcher.go
+++ b/alpine/matcher.go
@@ -32,7 +32,7 @@ func (*Matcher) Filter(record *claircore.IndexRecord) bool {
 
 func (*Matcher) Query() []driver.MatchExp {
 	return []driver.MatchExp{
-		driver.PackageDistributionPrettyName,
+		driver.DistributionPrettyName,
 	}
 }
 

--- a/aws/matcher.go
+++ b/aws/matcher.go
@@ -32,7 +32,7 @@ func (*Matcher) Filter(record *claircore.IndexRecord) bool {
 
 func (*Matcher) Query() []driver.MatchExp {
 	return []driver.MatchExp{
-		driver.PackageDistributionVersionID,
+		driver.DistributionVersionID,
 	}
 }
 

--- a/debian/matcher.go
+++ b/debian/matcher.go
@@ -32,7 +32,7 @@ func (*Matcher) Filter(record *claircore.IndexRecord) bool {
 
 func (*Matcher) Query() []driver.MatchExp {
 	return []driver.MatchExp{
-		driver.PackageDistributionVersion,
+		driver.DistributionVersion,
 	}
 }
 

--- a/internal/vulnstore/postgres/get.go
+++ b/internal/vulnstore/postgres/get.go
@@ -59,21 +59,21 @@ func get(ctx context.Context, pool *pgxpool.Pool, records []*claircore.IndexReco
 
 		for _, m := range dedupedMatchers {
 			switch m {
-			case driver.PackageDistributionDID:
+			case driver.DistributionDID:
 				args = append(args, record.Distribution.DID)
-			case driver.PackageDistributionName:
+			case driver.DistributionName:
 				args = append(args, record.Distribution.Name)
-			case driver.PackageDistributionVersion:
+			case driver.DistributionVersion:
 				args = append(args, record.Distribution.Version)
-			case driver.PackageDistributionVersionCodeName:
+			case driver.DistributionVersionCodeName:
 				args = append(args, record.Distribution.VersionCodeName)
-			case driver.PackageDistributionVersionID:
+			case driver.DistributionVersionID:
 				args = append(args, record.Distribution.VersionID)
-			case driver.PackageDistributionArch:
+			case driver.DistributionArch:
 				args = append(args, record.Distribution.Arch)
-			case driver.PackageDistributionCPE:
+			case driver.DistributionCPE:
 				args = append(args, record.Distribution.CPE)
-			case driver.PackageDistributionPrettyName:
+			case driver.DistributionPrettyName:
 				args = append(args, record.Distribution.PrettyName)
 			}
 		}

--- a/internal/vulnstore/postgres/querybuilder.go
+++ b/internal/vulnstore/postgres/querybuilder.go
@@ -49,21 +49,21 @@ func getBuilder(matchers []driver.MatchExp) (string, []driver.MatchExp, error) {
 		case driver.PackageSourceName: // ???
 			//ex = goqu.Ex{"package_name": ""}
 			continue
-		case driver.PackageDistributionDID:
+		case driver.DistributionDID:
 			ex = goqu.Ex{"dist_did": ""}
-		case driver.PackageDistributionName:
+		case driver.DistributionName:
 			ex = goqu.Ex{"dist_name": ""}
-		case driver.PackageDistributionVersion:
+		case driver.DistributionVersion:
 			ex = goqu.Ex{"dist_version": ""}
-		case driver.PackageDistributionVersionCodeName:
+		case driver.DistributionVersionCodeName:
 			ex = goqu.Ex{"dist_version_code_name": ""}
-		case driver.PackageDistributionVersionID:
+		case driver.DistributionVersionID:
 			ex = goqu.Ex{"dist_version_id": ""}
-		case driver.PackageDistributionArch:
+		case driver.DistributionArch:
 			ex = goqu.Ex{"dist_arch": ""}
-		case driver.PackageDistributionCPE:
+		case driver.DistributionCPE:
 			ex = goqu.Ex{"dist_cpe": ""}
-		case driver.PackageDistributionPrettyName:
+		case driver.DistributionPrettyName:
 			ex = goqu.Ex{"dist_pretty_name": ""}
 		default:
 			return "", nil, fmt.Errorf("was provided unknown matcher: %v", m)

--- a/internal/vulnstore/postgres/querybuilder_test.go
+++ b/internal/vulnstore/postgres/querybuilder_test.go
@@ -16,17 +16,17 @@ func Test_GetBuilder_Deterministic_Arguments(t *testing.T) {
 	}{
 		{
 			name:     "expect dist_did",
-			matchers: []driver.MatchExp{driver.PackageDistributionDID},
+			matchers: []driver.MatchExp{driver.DistributionDID},
 			expected: `SELECT "id", "name", "description", "links", "severity", "package_name", "package_version", "package_kind", "dist_id", "dist_name", "dist_version", "dist_version_code_name", "dist_version_id", "dist_arch", "dist_cpe", "dist_pretty_name", "repo_name", "repo_key", "repo_uri", "fixed_in_version" FROM "vuln" WHERE ((("package_name" = $1) OR ("package_name" = $2)) AND ("dist_did" = $3))`,
 		},
 		{
 			name:     "expect dist_did, dist_name",
-			matchers: []driver.MatchExp{driver.PackageDistributionDID, driver.PackageDistributionName},
+			matchers: []driver.MatchExp{driver.DistributionDID, driver.DistributionName},
 			expected: `SELECT "id", "name", "description", "links", "severity", "package_name", "package_version", "package_kind", "dist_id", "dist_name", "dist_version", "dist_version_code_name", "dist_version_id", "dist_arch", "dist_cpe", "dist_pretty_name", "repo_name", "repo_key", "repo_uri", "fixed_in_version" FROM "vuln" WHERE ((("package_name" = $1) OR ("package_name" = $2)) AND ("dist_did" = $3) AND ("dist_name" = $4))`,
 		},
 		{
 			name:     "expect dist_name, dist_did",
-			matchers: []driver.MatchExp{driver.PackageDistributionName, driver.PackageDistributionDID},
+			matchers: []driver.MatchExp{driver.DistributionName, driver.DistributionDID},
 			expected: `SELECT "id", "name", "description", "links", "severity", "package_name", "package_version", "package_kind", "dist_id", "dist_name", "dist_version", "dist_version_code_name", "dist_version_id", "dist_arch", "dist_cpe", "dist_pretty_name", "repo_name", "repo_key", "repo_uri", "fixed_in_version" FROM "vuln" WHERE ((("package_name" = $1) OR ("package_name" = $2)) AND ("dist_name" = $3) AND ("dist_did" = $4))`,
 		},
 	}

--- a/libvuln/driver/driver.go
+++ b/libvuln/driver/driver.go
@@ -23,21 +23,21 @@ const (
 	// should match claircore.Package.Name => claircore.Vulnerability.Package.Name
 	PackageName
 	// should match claircore.Package.Distribution.DID => claircore.Vulnerability.Package.Distribution.DID
-	PackageDistributionDID
+	DistributionDID
 	// should match claircore.Package.Distribution.Name => claircore.Vulnerability.Package.Distribution.Name
-	PackageDistributionName
+	DistributionName
 	// should match claircore.Package.Distribution.Version => claircore.Vulnerability.Package.Distribution.Version
-	PackageDistributionVersion
+	DistributionVersion
 	// should match claircore.Package.Distribution.VersionCodeName => claircore.Vulnerability.Package.Distribution.VersionCodeName
-	PackageDistributionVersionCodeName
+	DistributionVersionCodeName
 	// should match claircore.Package.Distribution.VersionID => claircore.Vulnerability.Package.Distribution.VersionID
-	PackageDistributionVersionID
+	DistributionVersionID
 	// should match claircore.Package.Distribution.Arch => claircore.Vulnerability.Package.Distribution.Arch
-	PackageDistributionArch
+	DistributionArch
 	// should match claircore.Package.Distribution.CPE => claircore.Vulnerability.Package.Distribution.CPE
-	PackageDistributionCPE
+	DistributionCPE
 	// should match claircore.Package.Distribution.PrettyName => claircore.Vulnerability.Package.Distribution.PrettyName
-	PackageDistributionPrettyName
+	DistributionPrettyName
 )
 
 // Matcher is an interface which a Controller uses to query the vulnstore for vulnerabilities.

--- a/rhel/matcher.go
+++ b/rhel/matcher.go
@@ -29,8 +29,8 @@ func (*Matcher) Query() []driver.MatchExp {
 	// associate multiple CPEs with a given vulnerability.
 	return []driver.MatchExp{
 		//driver.PackageDistributionCPE,
-		driver.PackageDistributionName,
-		driver.PackageDistributionPrettyName,
+		driver.DistributionName,
+		driver.DistributionPrettyName,
 	}
 }
 

--- a/ubuntu/matcher.go
+++ b/ubuntu/matcher.go
@@ -37,7 +37,7 @@ func (*Matcher) Filter(record *claircore.IndexRecord) bool {
 
 func (*Matcher) Query() []driver.MatchExp {
 	return []driver.MatchExp{
-		driver.PackageDistributionVersion,
+		driver.DistributionVersion,
 	}
 }
 


### PR DESCRIPTION
This PR removes the legacy naming for match Exps. Dist info is now decoupled from packages and this is now demonstrated