### PR TITLE
Test fixes

### DIFF
--- a/alpine/fetcher_test.go
+++ b/alpine/fetcher_test.go
@@ -11,6 +11,10 @@ import (
 )
 
 func TestFetcher(t *testing.T) {
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
+	ctx, _ = log.TestLogger(ctx, t)
+
 	var table = []struct {
 		release   Release
 		repo      Repo
@@ -24,9 +28,6 @@ func TestFetcher(t *testing.T) {
 	}
 
 	for _, test := range table {
-		ctx := context.Background()
-		logger := log.TestLogger(t)
-		ctx = logger.WithContext(ctx)
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			http.ServeFile(w, r, test.serveFile)
 		}))

--- a/alpine/packagescanner_test.go
+++ b/alpine/packagescanner_test.go
@@ -131,9 +131,9 @@ func TestScan(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
-	logger := log.TestLogger(t)
-	ctx = logger.WithContext(ctx)
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
+	ctx, _ = log.TestLogger(ctx, t)
 	l := &claircore.Layer{
 		Hash: hash,
 	}

--- a/alpine/parser_test.go
+++ b/alpine/parser_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/quay/claircore"
+	"github.com/quay/claircore/test/log"
 )
 
 var V3_10_community_truncated_vulns = []*claircore.Vulnerability{
@@ -160,6 +161,9 @@ var V3_10_community_truncated_vulns = []*claircore.Vulnerability{
 }
 
 func TestParser(t *testing.T) {
+	t.Parallel()
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
 	var table = []struct {
 		release  Release
 		repo     Repo
@@ -176,7 +180,9 @@ func TestParser(t *testing.T) {
 
 	for _, test := range table {
 		t.Run(test.testFile, func(t *testing.T) {
-			t.Parallel()
+			ctx, done := context.WithCancel(ctx)
+			defer done()
+			ctx, _ = log.TestLogger(ctx, t)
 
 			path := fmt.Sprintf("testdata/%s", test.testFile)
 			f, err := os.Open(path)
@@ -188,7 +194,7 @@ func TestParser(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to create updater: %v", err)
 			}
-			vulns, err := u.Parse(context.Background(), f)
+			vulns, err := u.Parse(ctx, f)
 			if err != nil {
 				t.Fatalf("failed to parse xml: %v", err)
 			}

--- a/aws/client_integration_test.go
+++ b/aws/client_integration_test.go
@@ -12,6 +12,8 @@ import (
 
 func Test_Client_Linux1_Integration_GetMirrors(t *testing.T) {
 	integration.Skip(t)
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
 	tests := []Release{Linux1, Linux2}
 
 	for _, test := range tests {
@@ -19,7 +21,7 @@ func Test_Client_Linux1_Integration_GetMirrors(t *testing.T) {
 			c: &http.Client{},
 		}
 
-		err := client.getMirrors(context.Background(), test)
+		err := client.getMirrors(ctx, test)
 		assert.NoError(t, err)
 		assert.NotEmpty(t, client.mirrors)
 		t.Log(client.mirrors)

--- a/aws/client_test.go
+++ b/aws/client_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func Test_Client_Linux1_GetMirrors(t *testing.T) {
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
 	tests := []struct {
 		release  Release
 		expected []string
@@ -61,7 +63,7 @@ func Test_Client_Linux1_GetMirrors(t *testing.T) {
 			urls = append(urls, u)
 		}
 
-		tctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		tctx, cancel := context.WithTimeout(ctx, 15*time.Second)
 		defer cancel()
 		err := client.getMirrors(tctx, test.release)
 		assert.NoError(t, err)
@@ -71,6 +73,8 @@ func Test_Client_Linux1_GetMirrors(t *testing.T) {
 }
 
 func Test_Client_Linux2_GetMirrors(t *testing.T) {
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
 	tests := []struct {
 		release  Release
 		expected []string
@@ -108,7 +112,7 @@ func Test_Client_Linux2_GetMirrors(t *testing.T) {
 			urls = append(urls, u)
 		}
 
-		tctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		tctx, cancel := context.WithTimeout(ctx, 15*time.Second)
 		defer cancel()
 		err := client.getMirrors(tctx, test.release)
 		assert.NoError(t, err)
@@ -119,6 +123,8 @@ func Test_Client_Linux2_GetMirrors(t *testing.T) {
 
 func Test_Client_RepoMD(t *testing.T) {
 	integration.Skip(t)
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
 
 	tests := []Release{Linux1, Linux2}
 
@@ -126,7 +132,7 @@ func Test_Client_RepoMD(t *testing.T) {
 		client, err := NewClient(test)
 		assert.NoError(t, err)
 
-		tctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		tctx, cancel := context.WithTimeout(ctx, 15*time.Second)
 		defer cancel()
 		_, err = client.RepoMD(tctx)
 		assert.NoError(t, err)
@@ -136,6 +142,8 @@ func Test_Client_RepoMD(t *testing.T) {
 
 func Test_Client_Updates(t *testing.T) {
 	integration.Skip(t)
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
 
 	tests := []Release{Linux1, Linux2}
 
@@ -143,7 +151,7 @@ func Test_Client_Updates(t *testing.T) {
 		client, err := NewClient(test)
 		assert.NoError(t, err)
 
-		tctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		tctx, cancel := context.WithTimeout(ctx, 15*time.Second)
 		defer cancel()
 		rc, err := client.Updates(tctx)
 		assert.NoError(t, err)

--- a/aws/updater_integration_test.go
+++ b/aws/updater_integration_test.go
@@ -7,10 +7,13 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/quay/claircore/test/integration"
+	"github.com/quay/claircore/test/log"
 )
 
 func Test_Updater(t *testing.T) {
 	integration.Skip(t)
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
 	var tt = []struct {
 		name    string
 		release Release
@@ -27,15 +30,19 @@ func Test_Updater(t *testing.T) {
 
 	for _, table := range tt {
 		t.Run(table.name, func(t *testing.T) {
+			ctx, done := context.WithCancel(ctx)
+			defer done()
+			ctx, _ = log.TestLogger(ctx, t)
+
 			updater, err := NewUpdater(table.release)
 			assert.NoError(t, err)
 
-			contents, updateHash, err := updater.Fetch(context.Background(), "")
+			contents, updateHash, err := updater.Fetch(ctx, "")
 			assert.NoError(t, err)
 			assert.NotEmpty(t, contents)
 			assert.NotEmpty(t, updateHash)
 
-			vulns, err := updater.Parse(context.Background(), contents)
+			vulns, err := updater.Parse(ctx, contents)
 			assert.NoError(t, err)
 			assert.NotEmpty(t, vulns)
 		})

--- a/debian/updater_integration_test.go
+++ b/debian/updater_integration_test.go
@@ -4,14 +4,16 @@ import (
 	"context"
 	"testing"
 
-	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/quay/claircore/test/integration"
+	"github.com/quay/claircore/test/log"
 )
 
 func Test_Updater(t *testing.T) {
 	integration.Skip(t)
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
 	var tt = []struct {
 		name    string
 		release Release
@@ -36,19 +38,19 @@ func Test_Updater(t *testing.T) {
 
 	for _, table := range tt {
 		t.Run(table.name, func(t *testing.T) {
+			ctx, done := context.WithCancel(ctx)
+			defer done()
+			ctx, _ = log.TestLogger(ctx, t)
 			updater := NewUpdater(table.release)
-			log.Printf("%v", updater.url)
+			t.Log(updater.url)
 
-			contents, updateHash, err := updater.Fetch(context.Background(), "")
+			contents, updateHash, err := updater.Fetch(ctx, "")
 			assert.NoError(t, err)
 			assert.NotEmpty(t, updateHash)
 
-			vulns, err := updater.Parse(context.Background(), contents)
-
+			vulns, err := updater.Parse(ctx, contents)
 			assert.NoError(t, err)
 			assert.Greater(t, len(vulns), 1)
-
 		})
 	}
-
 }

--- a/dpkg/scanner_test.go
+++ b/dpkg/scanner_test.go
@@ -703,9 +703,9 @@ func TestScanner(t *testing.T) {
 			RepositoryHint: "daafc6eba6eae603327bf8fc49645999",
 		},
 	}
-	ctx := context.Background()
-	logger := log.TestLogger(t)
-	ctx = logger.WithContext(ctx)
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
+	ctx, _ = log.TestLogger(ctx, t)
 	l := &claircore.Layer{
 		Hash: hash,
 	}

--- a/internal/indexer/controller/checkmanifest_test.go
+++ b/internal/indexer/controller/checkmanifest_test.go
@@ -14,6 +14,8 @@ import (
 // confirm checkManfest statefunc acts appropriately
 // when manifest has been seen
 func Test_CheckManifest_Seen(t *testing.T) {
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
 	var tt = []struct {
 		// the name of this test
 		name string
@@ -38,6 +40,8 @@ func Test_CheckManifest_Seen(t *testing.T) {
 
 	for _, table := range tt {
 		t.Run(table.name, func(t *testing.T) {
+			ctx, done := context.WithCancel(ctx)
+			defer done()
 			// get mock
 			m := table.mock(t)
 
@@ -48,7 +52,7 @@ func Test_CheckManifest_Seen(t *testing.T) {
 			s := New(opts)
 
 			// call state func
-			state, err := checkManifest(context.Background(), s)
+			state, err := checkManifest(ctx, s)
 
 			assert.NoError(t, err)
 			assert.Equal(t, table.expectedState, state)
@@ -59,6 +63,8 @@ func Test_CheckManifest_Seen(t *testing.T) {
 // confirm checkManfest statefunc acts appropriately
 // when manifest has been not been seen
 func Test_CheckManifest_UnSeen(t *testing.T) {
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
 	var tt = []struct {
 		// the name of this test
 		name string
@@ -83,6 +89,8 @@ func Test_CheckManifest_UnSeen(t *testing.T) {
 
 	for _, table := range tt {
 		t.Run(table.name, func(t *testing.T) {
+			ctx, done := context.WithCancel(ctx)
+			defer done()
 			// get mock
 			m := table.mock(t)
 
@@ -93,7 +101,7 @@ func Test_CheckManifest_UnSeen(t *testing.T) {
 			s := New(opts)
 
 			// call state func
-			state, err := checkManifest(context.Background(), s)
+			state, err := checkManifest(ctx, s)
 
 			assert.NoError(t, err)
 			assert.Equal(t, table.expectedState, state)

--- a/internal/indexer/controller/indexfinished_test.go
+++ b/internal/indexer/controller/indexfinished_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func Test_IndexFinished_Success(t *testing.T) {
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
 	var tt = []struct {
 		name          string
 		expectedState State
@@ -33,12 +35,14 @@ func Test_IndexFinished_Success(t *testing.T) {
 
 	for _, table := range tt {
 		t.Run(table.name, func(t *testing.T) {
+			ctx, done := context.WithCancel(ctx)
+			defer done()
 			store := table.mock(t)
 			scnr := New(&indexer.Opts{
 				Store: store,
 			})
 
-			state, err := indexFinished(context.Background(), scnr)
+			state, err := indexFinished(ctx, scnr)
 
 			assert.NoError(t, err)
 			assert.Equal(t, table.expectedState, state)

--- a/internal/indexer/controller/scanlayers_test.go
+++ b/internal/indexer/controller/scanlayers_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func Test_ScanLayers(t *testing.T) {
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
 	var tt = []struct {
 		name          string
 		expectedState State
@@ -34,13 +36,15 @@ func Test_ScanLayers(t *testing.T) {
 
 	for _, table := range tt {
 		t.Run(table.name, func(t *testing.T) {
+			ctx, done := context.WithCancel(ctx)
+			defer done()
 			ls, s := table.mock(t)
 			scnr := New(&indexer.Opts{
 				LayerScanner: ls,
 				Store:        s,
 			})
 
-			state, err := scanLayers(context.Background(), scnr)
+			state, err := scanLayers(ctx, scnr)
 			assert.NoError(t, err)
 			assert.Equal(t, table.expectedState, state)
 		})

--- a/internal/indexer/fetcher/fetcher_test.go
+++ b/internal/indexer/fetcher/fetcher_test.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/internal/indexer"
+	"github.com/quay/claircore/test/log"
 )
 
 func Test_Fetcher_LocalPath(t *testing.T) {
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
 	var tt = []struct {
 		name  string
 		layer []*claircore.Layer
@@ -30,15 +31,20 @@ func Test_Fetcher_LocalPath(t *testing.T) {
 
 	for _, table := range tt {
 		t.Run(table.name, func(t *testing.T) {
+			ctx, done := context.WithCancel(ctx)
+			defer done()
+			ctx, _ = log.TestLogger(ctx, t)
 			fetcher := New(nil, nil, indexer.InMem)
-			err := fetcher.Fetch(context.Background(), table.layer)
-
-			assert.NoError(t, err)
+			if err := fetcher.Fetch(ctx, table.layer); err != nil {
+				t.Fatal(err)
+			}
 		})
 	}
 }
 
 func Test_Fetcher_InvalidPath(t *testing.T) {
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
 	var tt = []struct {
 		name  string
 		layer []*claircore.Layer
@@ -69,10 +75,13 @@ func Test_Fetcher_InvalidPath(t *testing.T) {
 
 	for _, table := range tt {
 		t.Run(table.name, func(t *testing.T) {
+			ctx, done := context.WithCancel(ctx)
+			defer done()
+			ctx, _ = log.TestLogger(ctx, t)
 			fetcher := New(nil, nil, indexer.InMem)
-			err := fetcher.Fetch(context.Background(), table.layer)
-
-			assert.Error(t, err)
+			if err := fetcher.Fetch(ctx, table.layer); err == nil {
+				t.Fatal("expected error, got nil")
+			}
 		})
 	}
 }

--- a/internal/indexer/layerscanner/layerscanner_test.go
+++ b/internal/indexer/layerscanner/layerscanner_test.go
@@ -15,6 +15,8 @@ import (
 // Test_Scan_NoError confirms each scanner is called for each layer presented
 // to the layerscanner and no blocking occurs.
 func Test_Scan_NoErrors(t *testing.T) {
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
 	ctrl := gomock.NewController(t)
 
 	mock_ps := indexer.NewMockPackageScanner(ctrl)
@@ -84,7 +86,7 @@ func Test_Scan_NoErrors(t *testing.T) {
 
 	layerscanner := New(1, sOpts)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 	err = layerscanner.Scan(ctx, "test-manifest", layers)
 

--- a/internal/indexer/postgres/distributionsbylayer_test.go
+++ b/internal/indexer/postgres/distributionsbylayer_test.go
@@ -9,12 +9,14 @@ import (
 
 	"github.com/quay/claircore/test"
 	"github.com/quay/claircore/test/integration"
+	"github.com/quay/claircore/test/log"
 	pgtest "github.com/quay/claircore/test/postgres"
 )
 
 func Test_DistributionsByLayer_Success(t *testing.T) {
 	integration.Skip(t)
-	ctx := context.Background()
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
 	var tt = []struct {
 		// name of the test
 		name string
@@ -65,6 +67,9 @@ func Test_DistributionsByLayer_Success(t *testing.T) {
 
 	for _, table := range tt {
 		t.Run(table.name, func(t *testing.T) {
+			ctx, done := context.WithCancel(ctx)
+			defer done()
+			ctx, _ = log.TestLogger(ctx, t)
 			db, store, _, teardown := TestStore(ctx, t)
 			defer teardown()
 

--- a/internal/indexer/postgres/indexpackage_benchmark_test.go
+++ b/internal/indexer/postgres/indexpackage_benchmark_test.go
@@ -7,12 +7,14 @@ import (
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/test"
 	"github.com/quay/claircore/test/integration"
+	"github.com/quay/claircore/test/log"
 	pgtest "github.com/quay/claircore/test/postgres"
 )
 
 func Benchmark_IndexPackages(b *testing.B) {
 	integration.Skip(b)
-	ctx := context.Background()
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
 	benchmarks := []struct {
 		// the name of this benchmark
 		name string
@@ -177,6 +179,9 @@ func Benchmark_IndexPackages(b *testing.B) {
 
 	for _, bench := range benchmarks {
 		b.Run(bench.name, func(b *testing.B) {
+			ctx, done := context.WithCancel(ctx)
+			defer done()
+			ctx, _ = log.TestLogger(ctx, b)
 			db, store, _, teardown := TestStore(ctx, b)
 			defer teardown()
 

--- a/internal/indexer/postgres/layerscanned_test.go
+++ b/internal/indexer/postgres/layerscanned_test.go
@@ -4,16 +4,16 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/quay/claircore/test"
 	"github.com/quay/claircore/test/integration"
+	"github.com/quay/claircore/test/log"
 	pgtest "github.com/quay/claircore/test/postgres"
 )
 
 func Test_LayerScanned_Packages_False(t *testing.T) {
 	integration.Skip(t)
-	ctx := context.Background()
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
 	var tt = []struct {
 		// the name of the test
 		name string
@@ -46,6 +46,9 @@ func Test_LayerScanned_Packages_False(t *testing.T) {
 
 	for _, table := range tt {
 		t.Run(table.name, func(t *testing.T) {
+			ctx, done := context.WithCancel(ctx)
+			defer done()
+			ctx, _ = log.TestLogger(ctx, t)
 			db, store, _, teardown := TestStore(ctx, t)
 			defer teardown()
 
@@ -60,18 +63,21 @@ func Test_LayerScanned_Packages_False(t *testing.T) {
 
 			for _, scnr := range scnrs {
 				b, err := store.LayerScanned(ctx, table.hash, scnr)
-
-				assert.NoError(t, err)
-				assert.False(t, b)
+				if err != nil {
+					t.Error(err)
+				}
+				if b {
+					t.Fatal("expected false")
+				}
 			}
-
 		})
 	}
 }
 
 func Test_LayerScanned_Distributions_False(t *testing.T) {
 	integration.Skip(t)
-	ctx := context.Background()
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
 	var tt = []struct {
 		// the name of the test
 		name string
@@ -104,6 +110,9 @@ func Test_LayerScanned_Distributions_False(t *testing.T) {
 
 	for _, table := range tt {
 		t.Run(table.name, func(t *testing.T) {
+			ctx, done := context.WithCancel(ctx)
+			defer done()
+			ctx, _ = log.TestLogger(ctx, t)
 			db, store, _, teardown := TestStore(ctx, t)
 			defer teardown()
 
@@ -126,14 +135,14 @@ func Test_LayerScanned_Distributions_False(t *testing.T) {
 					t.Fatalf("expected LayerScanned to return false")
 				}
 			}
-
 		})
 	}
 }
 
 func Test_LayerScanned_Repository_False(t *testing.T) {
 	integration.Skip(t)
-	ctx := context.Background()
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
 	var tt = []struct {
 		// the name of the test
 		name string
@@ -166,6 +175,9 @@ func Test_LayerScanned_Repository_False(t *testing.T) {
 
 	for _, table := range tt {
 		t.Run(table.name, func(t *testing.T) {
+			ctx, done := context.WithCancel(ctx)
+			defer done()
+			ctx, _ = log.TestLogger(ctx, t)
 			db, store, _, teardown := TestStore(ctx, t)
 			defer teardown()
 
@@ -187,14 +199,14 @@ func Test_LayerScanned_Repository_False(t *testing.T) {
 					t.Fatalf("expected LayerScanned to return false")
 				}
 			}
-
 		})
 	}
 }
 
 func Test_LayerScanned_Packages_True(t *testing.T) {
 	integration.Skip(t)
-	ctx := context.Background()
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
 	var tt = []struct {
 		// the name of the test
 		name string
@@ -227,6 +239,9 @@ func Test_LayerScanned_Packages_True(t *testing.T) {
 
 	for _, table := range tt {
 		t.Run(table.name, func(t *testing.T) {
+			ctx, done := context.WithCancel(ctx)
+			defer done()
+			ctx, _ = log.TestLogger(ctx, t)
 			db, store, _, teardown := TestStore(ctx, t)
 			defer teardown()
 
@@ -253,14 +268,14 @@ func Test_LayerScanned_Packages_True(t *testing.T) {
 					t.Fatalf("expected LayerScanned to return true")
 				}
 			}
-
 		})
 	}
 }
 
 func Test_LayerScanned_Distribution_True(t *testing.T) {
 	integration.Skip(t)
-	ctx := context.Background()
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
 	var tt = []struct {
 		// the name of the test
 		name string
@@ -293,6 +308,9 @@ func Test_LayerScanned_Distribution_True(t *testing.T) {
 
 	for _, table := range tt {
 		t.Run(table.name, func(t *testing.T) {
+			ctx, done := context.WithCancel(ctx)
+			defer done()
+			ctx, _ = log.TestLogger(ctx, t)
 			db, store, _, teardown := TestStore(ctx, t)
 			defer teardown()
 
@@ -319,14 +337,14 @@ func Test_LayerScanned_Distribution_True(t *testing.T) {
 					t.Fatalf("expected LayerScanned to return true")
 				}
 			}
-
 		})
 	}
 }
 
 func Test_LayerScanned_Repository_True(t *testing.T) {
 	integration.Skip(t)
-	ctx := context.Background()
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
 	var tt = []struct {
 		// the name of the test
 		name string
@@ -359,6 +377,9 @@ func Test_LayerScanned_Repository_True(t *testing.T) {
 
 	for _, table := range tt {
 		t.Run(table.name, func(t *testing.T) {
+			ctx, done := context.WithCancel(ctx)
+			defer done()
+			ctx, _ = log.TestLogger(ctx, t)
 			db, store, _, teardown := TestStore(ctx, t)
 			defer teardown()
 
@@ -385,7 +406,6 @@ func Test_LayerScanned_Repository_True(t *testing.T) {
 					t.Fatalf("expected LayerScanned to return true")
 				}
 			}
-
 		})
 	}
 }

--- a/internal/indexer/postgres/packagesbylayer_benchmark_test.go
+++ b/internal/indexer/postgres/packagesbylayer_benchmark_test.go
@@ -6,12 +6,14 @@ import (
 
 	"github.com/quay/claircore/test"
 	"github.com/quay/claircore/test/integration"
+	"github.com/quay/claircore/test/log"
 	pgtest "github.com/quay/claircore/test/postgres"
 )
 
 func Benchmark_PackagesByLayer(b *testing.B) {
 	integration.Skip(b)
-	ctx := context.Background()
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
 	benchmarks := []struct {
 		name  string
 		hash  string
@@ -88,6 +90,9 @@ func Benchmark_PackagesByLayer(b *testing.B) {
 
 	for _, bench := range benchmarks {
 		b.Run(bench.name, func(b *testing.B) {
+			ctx, done := context.WithCancel(ctx)
+			defer done()
+			ctx, _ = log.TestLogger(ctx, b)
 			db, store, _, teardown := TestStore(ctx, b)
 			defer teardown()
 

--- a/internal/indexer/postgres/packagesbylayer_test.go
+++ b/internal/indexer/postgres/packagesbylayer_test.go
@@ -9,12 +9,14 @@ import (
 
 	"github.com/quay/claircore/test"
 	"github.com/quay/claircore/test/integration"
+	"github.com/quay/claircore/test/log"
 	pgtest "github.com/quay/claircore/test/postgres"
 )
 
 func Test_PackagesByLayer_Success(t *testing.T) {
 	integration.Skip(t)
-	ctx := context.Background()
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
 	var tt = []struct {
 		// name of the test
 		name string
@@ -65,6 +67,9 @@ func Test_PackagesByLayer_Success(t *testing.T) {
 
 	for _, table := range tt {
 		t.Run(table.name, func(t *testing.T) {
+			ctx, done := context.WithCancel(ctx)
+			defer done()
+			ctx, _ = log.TestLogger(ctx, t)
 			db, store, _, teardown := TestStore(ctx, t)
 			defer teardown()
 

--- a/internal/indexer/postgres/repositoriesbylayer_test.go
+++ b/internal/indexer/postgres/repositoriesbylayer_test.go
@@ -9,12 +9,14 @@ import (
 
 	"github.com/quay/claircore/test"
 	"github.com/quay/claircore/test/integration"
+	"github.com/quay/claircore/test/log"
 	pgtest "github.com/quay/claircore/test/postgres"
 )
 
 func Test_RepositoriesByLayer_Success(t *testing.T) {
 	integration.Skip(t)
-	ctx := context.Background()
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
 	var tt = []struct {
 		// name of the test
 		name string
@@ -65,6 +67,9 @@ func Test_RepositoriesByLayer_Success(t *testing.T) {
 
 	for _, table := range tt {
 		t.Run(table.name, func(t *testing.T) {
+			ctx, done := context.WithCancel(ctx)
+			defer done()
+			ctx, _ = log.TestLogger(ctx, t)
 			db, store, _, teardown := TestStore(ctx, t)
 			defer teardown()
 

--- a/internal/vulnstore/postgres/gethash_integration_test.go
+++ b/internal/vulnstore/postgres/gethash_integration_test.go
@@ -5,14 +5,16 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
 
 	"github.com/quay/claircore/test/integration"
+	"github.com/quay/claircore/test/log"
 )
 
 func Test_GetHash_KeyNotExists(t *testing.T) {
 	integration.Skip(t)
-	ctx := context.Background()
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
+	ctx, _ = log.TestLogger(ctx, t)
 	var tt = []struct {
 		name       string
 		iterations int
@@ -36,15 +38,21 @@ func Test_GetHash_KeyNotExists(t *testing.T) {
 
 			// attempt get k,v
 			v, err := store.GetHash(ctx, key)
-			assert.NoError(t, err)
-			assert.Equal(t, "", v)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got, want := v, ""; got != want {
+				t.Fatalf("got: %q, want: %q", got, want)
+			}
 		}
 	}
 }
 
 func Test_GetHash_KeyExists(t *testing.T) {
 	integration.Skip(t)
-	ctx := context.Background()
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
+	ctx, _ = log.TestLogger(ctx, t)
 	var tt = []struct {
 		// the name of the test
 		name string
@@ -76,8 +84,12 @@ func Test_GetHash_KeyExists(t *testing.T) {
 
 			// attempt get k,v
 			v, err := store.GetHash(ctx, key)
-			assert.NoError(t, err)
-			assert.Equal(t, value, v)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got, want := v, value; got != want {
+				t.Fatalf("got: %q, want: %q", got, want)
+			}
 		}
 	}
 }

--- a/internal/vulnstore/postgres/puthash_integration_test.go
+++ b/internal/vulnstore/postgres/puthash_integration_test.go
@@ -8,11 +8,14 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/quay/claircore/test/integration"
+	"github.com/quay/claircore/test/log"
 )
 
 func Test_PutHash_Upsert(t *testing.T) {
 	integration.Skip(t)
-	ctx := context.Background()
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
+	ctx, _ = log.TestLogger(ctx, t)
 	var tt = []struct {
 		name       string
 		iterations int
@@ -76,7 +79,9 @@ func Test_PutHash_Upsert(t *testing.T) {
 
 func Test_PutHash_Insert(t *testing.T) {
 	integration.Skip(t)
-	ctx := context.Background()
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
+	ctx, _ = log.TestLogger(ctx, t)
 	var tt = []struct {
 		name       string
 		iterations int

--- a/internal/vulnstore/postgres/putvulnerabilities_integration_test.go
+++ b/internal/vulnstore/postgres/putvulnerabilities_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/test"
 	"github.com/quay/claircore/test/integration"
+	"github.com/quay/claircore/test/log"
 )
 
 const (
@@ -46,7 +47,8 @@ const (
 // indirectly we confirm the datbase is de-duping identical entries on write
 func Test_PutVulnerabilities_Tombstone_Bump(t *testing.T) {
 	integration.Skip(t)
-	ctx := context.Background()
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
 	var tt = []struct {
 		// the name of the test
 		name string
@@ -83,6 +85,9 @@ func Test_PutVulnerabilities_Tombstone_Bump(t *testing.T) {
 
 	for _, table := range tt {
 		t.Run(table.name, func(t *testing.T) {
+			ctx, done := context.WithCancel(ctx)
+			defer done()
+			ctx, _ = log.TestLogger(ctx, t)
 			db, store, _, teardown := TestStore(ctx, t)
 			defer teardown()
 
@@ -149,7 +154,8 @@ func Test_PutVulnerabilities_Tombstone_Bump(t *testing.T) {
 // is not seen in a subsequent update it is removed from the store
 func Test_PutVulnerabilities_Tombstone_Stale(t *testing.T) {
 	integration.Skip(t)
-	ctx := context.Background()
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
 	var tt = []struct {
 		// the name of the test
 		name string
@@ -186,6 +192,9 @@ func Test_PutVulnerabilities_Tombstone_Stale(t *testing.T) {
 
 	for _, table := range tt {
 		t.Run(table.name, func(t *testing.T) {
+			ctx, done := context.WithCancel(ctx)
+			defer done()
+			ctx, _ = log.TestLogger(ctx, t)
 			db, store, _, teardown := TestStore(ctx, t)
 			defer teardown()
 

--- a/layer_integration_test.go
+++ b/layer_integration_test.go
@@ -19,6 +19,8 @@ import (
 
 func Test_Layer_Files_Miss(t *testing.T) {
 	integration.Skip(t)
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
 	var tt = []struct {
 		// name of the test
 		name string
@@ -57,11 +59,13 @@ func Test_Layer_Files_Miss(t *testing.T) {
 
 	for _, table := range tt {
 		t.Run(table.name, func(t *testing.T) {
+			ctx, done := context.WithCancel(ctx)
+			defer done()
 			// gen layers
 			layers, err := test.GenUniqueLayersRemote(table.layers, table.uris)
 
 			// fetch the layer
-			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
 			defer cancel()
 			err = table.fetcher.Fetch(ctx, layers)
 			assert.NoError(t, err, "fetcher returned an error")
@@ -89,6 +93,8 @@ func Test_Layer_Files_Miss(t *testing.T) {
 
 func Test_Layer_Files_Hit(t *testing.T) {
 	integration.Skip(t)
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
 	var tt = []struct {
 		// name of the test
 		name string
@@ -127,11 +133,13 @@ func Test_Layer_Files_Hit(t *testing.T) {
 
 	for _, table := range tt {
 		t.Run(table.name, func(t *testing.T) {
+			ctx, done := context.WithCancel(ctx)
+			defer done()
 			// gen layers
 			layers, err := test.GenUniqueLayersRemote(table.layers, table.uris)
 
 			// fetch the layer
-			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
 			defer cancel()
 			err = table.fetcher.Fetch(ctx, layers)
 			assert.NoError(t, err, "fetcher returned an error")

--- a/oracle/parser_test.go
+++ b/oracle/parser_test.go
@@ -13,8 +13,9 @@ import (
 
 func TestParse(t *testing.T) {
 	t.Parallel()
-	l := log.TestLogger(t)
-	ctx := l.WithContext(context.Background())
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
+	ctx, _ = log.TestLogger(ctx, t)
 	u, err := NewUpdater(-1)
 	if err != nil {
 		t.Fatal(err)

--- a/osrelease/scanner_test.go
+++ b/osrelease/scanner_test.go
@@ -25,8 +25,9 @@ type parsecase struct {
 
 func (c parsecase) Test(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
-	log := log.TestLogger(t)
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
+	ctx, log := log.TestLogger(ctx, t)
 	ctx, task := trace.NewTask(ctx, "parse test")
 	defer task.End()
 	trace.Log(ctx, "parse test:file", c.File)
@@ -181,11 +182,14 @@ func (lc layercase) Prep(t *testing.T) {
 
 func (lc layercase) Test(t *testing.T) {
 	t.Parallel()
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
+	ctx, _ = log.TestLogger(ctx, t)
 	s := Scanner{}
 	l := &claircore.Layer{
 		LocalPath: lc.name(),
 	}
-	ds, err := s.Scan(context.Background(), l)
+	ds, err := s.Scan(ctx, l)
 	if err != nil {
 		t.Error(err)
 	}

--- a/rhel/matcher_test.go
+++ b/rhel/matcher_test.go
@@ -24,9 +24,9 @@ import (
 
 func TestMatcherIntegration(t *testing.T) {
 	integration.Skip(t)
-	ctx := context.Background()
-	logger := log.TestLogger(t)
-	ctx = logger.WithContext(ctx)
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
+	ctx, _ = log.TestLogger(ctx, t)
 
 	db, store, _, teardown := vulnstore.TestStore(ctx, t)
 	defer teardown()

--- a/rhel/parse_test.go
+++ b/rhel/parse_test.go
@@ -13,8 +13,9 @@ import (
 
 func TestParse(t *testing.T) {
 	t.Parallel()
-	l := log.TestLogger(t)
-	ctx := l.WithContext(context.Background())
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
+	ctx, _ = log.TestLogger(ctx, t)
 	u, err := NewUpdater(3)
 	if err != nil {
 		t.Fatal(err)

--- a/rpm/packagescanner_test.go
+++ b/rpm/packagescanner_test.go
@@ -1246,9 +1246,9 @@ func TestScan(t *testing.T) {
 			t.Skipf("skipping test: missing needed utility %q (%v)", exe, err)
 		}
 	}
-	ctx := context.Background()
-	logger := log.TestLogger(t)
-	ctx = logger.WithContext(ctx)
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
+	ctx, _ = log.TestLogger(ctx, t)
 	l := &claircore.Layer{
 		Hash: hash,
 	}

--- a/suse/integration_test.go
+++ b/suse/integration_test.go
@@ -12,8 +12,9 @@ import (
 
 func TestLiveDatabase(t *testing.T) {
 	integration.Skip(t)
-	l := log.TestLogger(t)
-	ctx := l.WithContext(context.Background())
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
+	ctx, _ = log.TestLogger(ctx, t)
 
 	u, err := NewUpdater(EnterpriseServer15)
 	if err != nil {

--- a/test/updater.go
+++ b/test/updater.go
@@ -43,7 +43,7 @@ func (u *updater) Parse(ctx context.Context, r io.ReadCloser) ([]*claircore.Vuln
 	if err := xml.NewDecoder(r).Decode(&root); err != nil {
 		return nil, fmt.Errorf("test: unable to decode OVAL document: %w", err)
 	}
-	return ovalutil.NewRPMInfo(&root).Extract(context.Background())
+	return ovalutil.NewRPMInfo(&root).Extract(ctx)
 }
 
 func Updater(file string) (driver.Updater, error) {

--- a/ubuntu/matcher_integration_test.go
+++ b/ubuntu/matcher_integration_test.go
@@ -8,8 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/internal/updater"
 	"github.com/quay/claircore/internal/vulnscanner"
@@ -17,6 +15,7 @@ import (
 	"github.com/quay/claircore/libvuln/driver"
 	distlock "github.com/quay/claircore/pkg/distlock/postgres"
 	"github.com/quay/claircore/test/integration"
+	"github.com/quay/claircore/test/log"
 )
 
 // Test_Matcher_Integration confirms packages are matched
@@ -25,7 +24,9 @@ import (
 // CVE data
 func Test_Matcher_Integration(t *testing.T) {
 	integration.Skip(t)
-	ctx := context.Background()
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
+	ctx, _ = log.TestLogger(ctx, t)
 	db, store, _, teardown := vulnstore.TestStore(ctx, t)
 	defer teardown()
 
@@ -43,7 +44,7 @@ func Test_Matcher_Integration(t *testing.T) {
 		Lock:     distlock.NewLock(db, 2*time.Second),
 	})
 	// force update
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 	up.Update(ctx)
 
@@ -60,8 +61,10 @@ func Test_Matcher_Integration(t *testing.T) {
 	}
 
 	vs := vulnscanner.New(store, []driver.Matcher{m})
-	vr, err := vs.Scan(context.Background(), &sr)
-	assert.NoError(t, err)
+	vr, err := vs.Scan(ctx, &sr)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	_, err = json.Marshal(&vr)
 	if err != nil {

--- a/ubuntu/updater_integration_test.go
+++ b/ubuntu/updater_integration_test.go
@@ -4,14 +4,16 @@ import (
 	"context"
 	"testing"
 
-	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/quay/claircore/test/integration"
+	"github.com/quay/claircore/test/log"
 )
 
 func Test_Updater(t *testing.T) {
 	integration.Skip(t)
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
 	var tt = []struct {
 		name    string
 		release Release
@@ -48,17 +50,19 @@ func Test_Updater(t *testing.T) {
 
 	for _, table := range tt {
 		t.Run(table.name, func(t *testing.T) {
+			ctx, done := context.WithCancel(ctx)
+			defer done()
+			ctx, _ = log.TestLogger(ctx, t)
 			updater := NewUpdater(table.release)
-			log.Printf("%v", updater.url)
+			t.Log(updater.url)
 
-			contents, updateHash, err := updater.Fetch(context.Background(), "")
+			contents, updateHash, err := updater.Fetch(ctx, "")
 			assert.NoError(t, err)
 			assert.NotEmpty(t, updateHash)
 
-			vulns, err := updater.Parse(context.Background(), contents)
+			vulns, err := updater.Parse(ctx, contents)
 			assert.NoError(t, err)
 			assert.Greater(t, len(vulns), 1)
-
 		})
 	}
 


### PR DESCRIPTION
These commits should shake out a race in the test logger, and then ensure that tests are using correctly scoped contexts.