### PR TITLE
swap suse to https

### DIFF
--- a/suse/suse.go
+++ b/suse/suse.go
@@ -41,7 +41,7 @@ const (
 var upstreamBase *url.URL
 
 func init() {
-	const base = `http://ftp.suse.com/pub/projects/security/oval/`
+	const base = `https://support.novell.com/security/oval/`
 	var err error
 	upstreamBase, err = url.Parse(base)
 	if err != nil {


### PR DESCRIPTION
This PR flips SUSE's sec db from ftp to https site. FTP seems to no longer work. 