### PR TITLE
Louis/fastest url

### DIFF
--- a/pkg/fastesturl/fastesturl.go
+++ b/pkg/fastesturl/fastesturl.go
@@ -1,0 +1,107 @@
+package fastesturl
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+)
+
+// ReqCheckFunc checks if a *http.Response
+// is valid for returning to a client
+type RespCheck func(*http.Response) bool
+
+// FatestURL implements a method for obtaining the first
+// *http.Response object returned from a list of URLs.
+type FastestURL struct {
+	// an http client to use for all requests
+	Client *http.Client
+	// a list of urls we will concurrecntly attempt to request
+	URLs []*url.URL
+	// a template request object we will copy fields from
+	Request *http.Request
+	// a function provided by the caller to determine if a request
+	// should be returned
+	RespCheck RespCheck
+	// protects Response
+	mu *sync.Mutex
+	// the fastest http Response which passed ReqCheckFunc
+	Response *http.Response
+}
+
+// New is a constructor for a FastestURL
+func New(client *http.Client, req *http.Request, check RespCheck, urls []*url.URL) *FastestURL {
+	if client == nil {
+		client = &http.Client{}
+	}
+	if req == nil {
+		req = &http.Request{}
+	}
+	if check == nil {
+		check = func(resp *http.Response) bool {
+			if resp.StatusCode == 200 {
+				return true
+			}
+			return false
+		}
+	}
+	return &FastestURL{
+		Client:    client,
+		URLs:      urls,
+		Request:   req,
+		RespCheck: check,
+		mu:        &sync.Mutex{},
+	}
+}
+
+// Do will return the first *http.Response which passes
+// f.RespCheck.
+//
+// If no successful *http.Response is obtained a nil is returned
+func (f *FastestURL) Do(ctx context.Context) *http.Response {
+	cond := sync.NewCond(f.mu)
+	// immediately lock so workers do not write to f.Response
+	// before Do method blocks on cond.Wait()
+	cond.L.Lock()
+	tctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	for _, url := range f.URLs {
+		u := url
+		go func() {
+			defer cond.Broadcast()
+			req := f.Request.Clone(tctx)
+			req.URL = u
+			req.Host = u.Host
+			resp, err := f.Client.Do(req)
+			if err != nil {
+				return
+			}
+			if f.RespCheck(resp) {
+				f.mu.Lock()
+				if f.Response == nil {
+					f.Response = resp
+				} else {
+					// another routine has set f.Response, close this body and discard
+					resp.Body.Close()
+				}
+				f.mu.Unlock()
+			}
+		}()
+	}
+	// wait on go routines to broadcast. when a broadcast occurs
+	// check if a worker set f.Response and if so return it.
+	// break loop when all workers have broadcasted
+	for lim, i := len(f.URLs), 0; i < lim; i++ {
+		cond.Wait()
+		if f.Response != nil {
+			cond.L.Unlock()
+			return f.Response
+		}
+	}
+	// exhausted all workers without f.Response populated.
+	// cond.L.Lock() will be locked from latest cond.Wait() broadcast
+	// unlock it and return nil
+	cond.L.Unlock()
+	return nil
+}

--- a/pkg/fastesturl/fastesturl.go
+++ b/pkg/fastesturl/fastesturl.go
@@ -6,6 +6,8 @@ import (
 	"net/url"
 	"sync"
 	"time"
+
+	"github.com/rs/zerolog"
 )
 
 // ReqCheckFunc checks if a *http.Response
@@ -24,10 +26,6 @@ type FastestURL struct {
 	// a function provided by the caller to determine if a request
 	// should be returned
 	RespCheck RespCheck
-	// protects Response
-	mu *sync.Mutex
-	// the fastest http Response which passed ReqCheckFunc
-	Response *http.Response
 }
 
 // New is a constructor for a FastestURL
@@ -51,7 +49,6 @@ func New(client *http.Client, req *http.Request, check RespCheck, urls []*url.UR
 		URLs:      urls,
 		Request:   req,
 		RespCheck: check,
-		mu:        &sync.Mutex{},
 	}
 }
 
@@ -60,47 +57,50 @@ func New(client *http.Client, req *http.Request, check RespCheck, urls []*url.UR
 //
 // If no successful *http.Response is obtained a nil is returned
 func (f *FastestURL) Do(ctx context.Context) *http.Response {
-	cond := sync.NewCond(f.mu)
+	log := zerolog.Ctx(ctx).With().Str("routine", "fasesturl_do").Logger()
+	cond := sync.NewCond(&sync.Mutex{})
+	var response *http.Response
+	tctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
 	// immediately lock so workers do not write to f.Response
 	// before Do method blocks on cond.Wait()
 	cond.L.Lock()
-	tctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
 	for _, url := range f.URLs {
 		u := url
 		go func() {
-			defer cond.Broadcast()
+			defer cond.Signal()
 			req := f.Request.Clone(tctx)
 			req.URL = u
 			req.Host = u.Host
 			resp, err := f.Client.Do(req)
 			if err != nil {
+				log.Error().Err(err).Msgf("failed to make request for url: %v", url)
 				return
 			}
 			if f.RespCheck(resp) {
-				f.mu.Lock()
-				if f.Response == nil {
-					f.Response = resp
+				cond.L.Lock()
+				if response == nil {
+					response = resp
 				} else {
 					// another routine has set f.Response, close this body and discard
 					resp.Body.Close()
 				}
-				f.mu.Unlock()
+				cond.L.Unlock()
 			}
 		}()
 	}
-	// wait on go routines to broadcast. when a broadcast occurs
+	// wait on go routines to signal. when a signal occurs
 	// check if a worker set f.Response and if so return it.
-	// break loop when all workers have broadcasted
+	// break loop when all workers have signal
 	for lim, i := len(f.URLs), 0; i < lim; i++ {
 		cond.Wait()
-		if f.Response != nil {
+		if response != nil {
 			cond.L.Unlock()
-			return f.Response
+			return response
 		}
 	}
 	// exhausted all workers without f.Response populated.
-	// cond.L.Lock() will be locked from latest cond.Wait() broadcast
+	// cond.L.Lock() will be locked from latest cond.Wait() signal
 	// unlock it and return nil
 	cond.L.Unlock()
 	return nil

--- a/pkg/fastesturl/fastesturl_test.go
+++ b/pkg/fastesturl/fastesturl_test.go
@@ -15,13 +15,13 @@ import (
 // when all requests fail the default RespCheck
 func TestFastestURLAllFailure(t *testing.T) {
 	ts1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(10 * time.Second)
+		time.Sleep(10 * time.Millisecond)
 		w.Header().Set("X-Test-Server", "1")
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}))
 	ts2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(20 * time.Second)
+		time.Sleep(20 * time.Millisecond)
 		w.Header().Set("X-Test-Server", "2")
 		w.WriteHeader(http.StatusBadRequest)
 		return
@@ -40,13 +40,13 @@ func TestFastestURLAllFailure(t *testing.T) {
 // the slower server
 func TestFastestURLFailure(t *testing.T) {
 	ts1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(10 * time.Second)
+		time.Sleep(10 * time.Millisecond)
 		w.Header().Set("X-Test-Server", "1")
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}))
 	ts2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(20 * time.Second)
+		time.Sleep(20 * time.Millisecond)
 		w.Header().Set("X-Test-Server", "2")
 		return
 	}))
@@ -67,12 +67,12 @@ func TestFastestURLFailure(t *testing.T) {
 // when all servers respond successfully
 func TestFastestURLSuccess(t *testing.T) {
 	ts1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(10 * time.Second)
+		time.Sleep(10 * time.Millisecond)
 		w.Header().Set("X-Test-Server", "1")
 		return
 	}))
 	ts2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(20 * time.Second)
+		time.Sleep(20 * time.Millisecond)
 		w.Header().Set("X-Test-Server", "2")
 		return
 	}))

--- a/pkg/fastesturl/fastesturl_test.go
+++ b/pkg/fastesturl/fastesturl_test.go
@@ -1,0 +1,90 @@
+package fastesturl_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/quay/claircore/pkg/fastesturl"
+)
+
+// TestFastestURLFailure confirms we return nil
+// when all requests fail the default RespCheck
+func TestFastestURLAllFailure(t *testing.T) {
+	ts1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(10 * time.Second)
+		w.Header().Set("X-Test-Server", "1")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}))
+	ts2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(20 * time.Second)
+		w.Header().Set("X-Test-Server", "2")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}))
+	url1, _ := url.Parse(ts1.URL)
+	url2, _ := url.Parse(ts2.URL)
+	furl := fastesturl.New(nil, nil, nil, []*url.URL{url1, url2})
+	resp := furl.Do(context.TODO())
+	if resp != nil {
+		t.Fatalf("resp should be nil")
+	}
+}
+
+// TestFastestURLFailure confirms we only return an http.Response
+// that passes the default RespCheck function despite it being
+// the slower server
+func TestFastestURLFailure(t *testing.T) {
+	ts1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(10 * time.Second)
+		w.Header().Set("X-Test-Server", "1")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}))
+	ts2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(20 * time.Second)
+		w.Header().Set("X-Test-Server", "2")
+		return
+	}))
+	url1, _ := url.Parse(ts1.URL)
+	url2, _ := url.Parse(ts2.URL)
+	furl := fastesturl.New(nil, nil, nil, []*url.URL{url1, url2})
+	resp := furl.Do(context.TODO())
+	if resp == nil {
+		t.Fatalf("resp should not be nil")
+	}
+	respServer := resp.Header.Get("X-Test-Server")
+	if respServer != "2" {
+		t.Fatalf("test server 1 should be first")
+	}
+}
+
+// TestFastestURLSuccess confirms the fastest server wins
+// when all servers respond successfully
+func TestFastestURLSuccess(t *testing.T) {
+	ts1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(10 * time.Second)
+		w.Header().Set("X-Test-Server", "1")
+		return
+	}))
+	ts2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(20 * time.Second)
+		w.Header().Set("X-Test-Server", "2")
+		return
+	}))
+	url1, _ := url.Parse(ts1.URL)
+	url2, _ := url.Parse(ts2.URL)
+	furl := fastesturl.New(nil, nil, nil, []*url.URL{url1, url2})
+	resp := furl.Do(context.TODO())
+	if resp == nil {
+		t.Fatalf("resp should not be nil")
+	}
+	respServer := resp.Header.Get("X-Test-Server")
+	if respServer != "1" {
+		t.Fatalf("test server 1 should be first")
+	}
+}


### PR DESCRIPTION
This PR implements a method of obtaining the fastest http.Response given a list of urls. The intended usage is for lists of mirrors where the same content lives at different hosted servers and you want to a client to receive the first mirror that responds. 