### PR TITLE
lookup ids to strings

### DIFF
--- a/environment.go
+++ b/environment.go
@@ -12,7 +12,7 @@ type Environment struct {
 	// the layer in which the associated package was introduced
 	IntroducedIn string `json:"introduced_in"`
 	// the ID of the distribution the package was discovered on
-	DistributionID int `json:"distribution_id"`
+	DistributionID int `json:"distribution_id,string"`
 	// the ID of the repository where this package was downloaded from (currently not used)
-	RepositoryID int `json:"repository_id"`
+	RepositoryID int `json:"repository_id,string"`
 }

--- a/internal/matcher/match.go
+++ b/internal/matcher/match.go
@@ -2,6 +2,7 @@ package matcher
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/internal/vulnstore"
@@ -19,7 +20,7 @@ func Match(ctx context.Context, ir *claircore.IndexReport, matchers []driver.Mat
 		Distributions:          ir.Distributions,
 		Repositories:           ir.Repositories,
 		Vulnerabilities:        map[int]*claircore.Vulnerability{},
-		PackageVulnerabilities: map[int][]int{},
+		PackageVulnerabilities: map[int][]string{},
 	}
 
 	// extract IndexRecords from the IndexReport
@@ -55,7 +56,7 @@ func Match(ctx context.Context, ir *claircore.IndexReport, matchers []driver.Mat
 		for pkgID, vulns := range vulnsByPackage {
 			for _, vuln := range vulns {
 				vr.Vulnerabilities[vuln.ID] = vuln
-				vr.PackageVulnerabilities[pkgID] = append(vr.PackageVulnerabilities[pkgID], vuln.ID)
+				vr.PackageVulnerabilities[pkgID] = append(vr.PackageVulnerabilities[pkgID], strconv.Itoa(vuln.ID))
 			}
 		}
 	}

--- a/vulnerabilityreport.go
+++ b/vulnerabilityreport.go
@@ -16,5 +16,5 @@ type VulnerabilityReport struct {
 	// all discovered vulnerabilities affecting this manifest
 	Vulnerabilities map[int]*Vulnerability `json:"vulnerabilities"`
 	// a lookup table associating package ids with 1 or more vulnerability ids. keyed by package id
-	PackageVulnerabilities map[int][]int `json:"package_vulnerabilities"`
+	PackageVulnerabilities map[int][]string `json:"package_vulnerabilities"`
 }


### PR DESCRIPTION
This PR changes any ids used for "lookup" to strings. The resulting map keys for Packages, Distributions, Vulnerability fields in an IndexReport or Vulnerability reports will be transformed to strings. This makes lookups work correctly. 