### PR TITLE
all: use bigserials in the database

### DIFF
--- a/internal/indexer/postgres/distributionsbylayer.go
+++ b/internal/indexer/postgres/distributionsbylayer.go
@@ -33,9 +33,9 @@ WHERE
 func distributionsByLayer(ctx context.Context, db *sqlx.DB, hash string, scnrs indexer.VersionedScanners) ([]*claircore.Distribution, error) {
 	// TODO Use passed-in Context.
 	// get scanner ids
-	scannerIDs := []int{}
+	scannerIDs := []int64{}
 	for _, scnr := range scnrs {
-		var scannerID int
+		var scannerID int64
 		err := db.Get(&scannerID, scannerIDByNameVersionKind, scnr.Name(), scnr.Version(), scnr.Kind())
 		if err != nil {
 			return nil, fmt.Errorf("store:distributionseByLayer failed to retrieve scanner ids for scnr %v: %v", scnr, err)

--- a/internal/indexer/postgres/layerscanned.go
+++ b/internal/indexer/postgres/layerscanned.go
@@ -22,7 +22,7 @@ const (
 
 func layerScanned(ctx context.Context, db *sqlx.DB, hash string, scnr indexer.VersionedScanner) (bool, error) {
 	// TODO Use passed-in Context.
-	var scannerID int
+	var scannerID int64
 	err := db.Get(&scannerID, selectScannerID, scnr.Name(), scnr.Version())
 	if err != nil {
 		if err == sql.ErrNoRows {

--- a/internal/indexer/postgres/manifestscanned.go
+++ b/internal/indexer/postgres/manifestscanned.go
@@ -19,9 +19,9 @@ const (
 func manifestScanned(ctx context.Context, db *sqlx.DB, hash string, scnrs indexer.VersionedScanners) (bool, error) {
 	// TODO Use passed-in Context.
 	// get the ids of the scanners we are testing for.
-	var expectedIDs []int
+	var expectedIDs []int64
 	for _, scnr := range scnrs {
-		var id int
+		var id int64
 		row := db.QueryRowx(selectScannerIDs, scnr.Name(), scnr.Version(), scnr.Kind())
 		err := row.Scan(&id)
 		if err != nil {
@@ -31,8 +31,8 @@ func manifestScanned(ctx context.Context, db *sqlx.DB, hash string, scnrs indexe
 	}
 
 	// get a map of the found ids which have scanned this package
-	var temp = []int{}
-	var foundIDs = map[int]struct{}{}
+	var temp = []int64{}
+	var foundIDs = map[int64]struct{}{}
 	err := db.Select(&temp, selectScannerIDsByScannerList, hash)
 	if err != nil {
 		return false, fmt.Errorf("store:manifestScanned failed to select scanner IDs for manifest: %v", err)

--- a/internal/indexer/postgres/packagesbylayer.go
+++ b/internal/indexer/postgres/packagesbylayer.go
@@ -38,9 +38,9 @@ WHERE
 func packagesByLayer(ctx context.Context, db *sqlx.DB, hash string, scnrs indexer.VersionedScanners) ([]*claircore.Package, error) {
 	// TODO Use passed-in Context.
 	// get scanner ids
-	scannerIDs := []int{}
+	scannerIDs := []int64{}
 	for _, scnr := range scnrs {
-		var scannerID int
+		var scannerID int64
 		err := db.Get(&scannerID, scannerIDByNameVersionKind, scnr.Name(), scnr.Version(), scnr.Kind())
 		if err != nil {
 			return nil, fmt.Errorf("store:packageByLayer failed to retrieve scanner ids for scnr %v: %v", scnr, err)

--- a/internal/indexer/postgres/registerscanners_test.go
+++ b/internal/indexer/postgres/registerscanners_test.go
@@ -176,8 +176,7 @@ func checkScanners(t *testing.T, db *sqlx.DB, scnrs []scnrInfo) {
 			t.Fatalf("failed to select rows for scnr %v: %v", scnr, err)
 		}
 
-		var i int
-		for rows.Next() {
+		for i := 0; rows.Next(); i++ {
 			if i > 0 {
 				t.Fatalf("query for scnr %v returned more then one row", scnr)
 			}

--- a/internal/indexer/postgres/repositoriesbylayer.go
+++ b/internal/indexer/postgres/repositoriesbylayer.go
@@ -28,9 +28,9 @@ WHERE
 func repositoriesByLayer(ctx context.Context, db *sqlx.DB, hash string, scnrs indexer.VersionedScanners) ([]*claircore.Repository, error) {
 	// TODO Use passed-in Context.
 	// get scanner ids
-	scannerIDs := []int{}
+	scannerIDs := []int64{}
 	for _, scnr := range scnrs {
-		var scannerID int
+		var scannerID int64
 		err := db.Get(&scannerID, scannerIDByNameVersionKind, scnr.Name(), scnr.Version(), scnr.Kind())
 		if err != nil {
 			return nil, fmt.Errorf("store:repositoriesByLayer failed to retrieve scanner ids for scnr %v: %v", scnr, err)

--- a/internal/indexer/postgres/setindexfinished.go
+++ b/internal/indexer/postgres/setindexfinished.go
@@ -19,10 +19,10 @@ const (
 func setScanFinished(ctx context.Context, db *sqlx.DB, sr *claircore.IndexReport, scnrs indexer.VersionedScanners) error {
 	// TODO Use passed-in Context.
 	// extract scanner ids from manifest outside of transaction
-	scannerIDs := []int{}
+	scannerIDs := []int64{}
 
 	for _, scnr := range scnrs {
-		var scannerID int
+		var scannerID int64
 		err := db.Get(&scannerID, scannerIDByNameVersionKind, scnr.Name(), scnr.Version(), scnr.Kind())
 		if err != nil {
 			return fmt.Errorf("store:storeManifest failed to select package scanner id: %v", err)

--- a/internal/indexer/postgres/setindexfinished_test.go
+++ b/internal/indexer/postgres/setindexfinished_test.go
@@ -118,15 +118,15 @@ func Test_SetScanFinished_Success(t *testing.T) {
 }
 
 func checkUpdatedScannerList(t *testing.T, db *sqlx.DB, hash string, updatedScnrs []scnrInfo) {
-	var foundIDs []int
+	var foundIDs []int64
 	err := db.Select(&foundIDs, `SELECT scanner_id FROM scannerlist WHERE manifest_hash = $1`, hash)
 	if err != nil {
 		t.Fatalf("failed to select test scanner ids for manifest %v: %v", hash, err)
 	}
 
-	var expectedIDs []int
+	var expectedIDs []int64
 	for _, scnr := range updatedScnrs {
-		expectedIDs = append(expectedIDs, int(scnr.id))
+		expectedIDs = append(expectedIDs, scnr.id)
 	}
 
 	assert.ElementsMatch(t, expectedIDs, foundIDs)

--- a/libindex/migrations/migration1.go
+++ b/libindex/migrations/migration1.go
@@ -7,7 +7,7 @@ const (
 	--- a unique versioned scanner which is responsible
 	--- for finding packages and distributions in a layer
 	CREATE TABLE IF NOT EXISTS scanner (
-		id SERIAL PRIMARY KEY,
+		id BIGSERIAL PRIMARY KEY,
 		name text NOT NULL,
 		version text NOT NULL,
 		kind text NOT NULL
@@ -18,9 +18,9 @@ const (
 	--- a relation informing us if a manifest hash has 
 	--- been scanned by a particular scanner
 	CREATE TABLE IF NOT EXISTS scannerlist (
-		id SERIAL PRIMARY KEY,
+		id BIGSERIAL PRIMARY KEY,
 		manifest_hash text,
-		scanner_id int REFERENCES scanner(id)
+		scanner_id bigint REFERENCES scanner(id)
 	);
 	CREATE INDEX IF NOT EXISTS scannerlist_manifest_hash_idx ON scannerlist (manifest_hash);
 
@@ -37,7 +37,7 @@ const (
 	-- Distribution
 	--- a unique distribution discovered by a scanner
 	CREATE TABLE IF NOT EXISTS dist (
-		id SERIAL PRIMARY KEY,
+		id BIGSERIAL PRIMARY KEY,
 		name text,
 		did text, -- os-release id field
 		version text,
@@ -52,9 +52,9 @@ const (
 	--- DistributionScanArtifact
 	--- A relation linking discovered distributions to a layer
 	CREATE TABLE IF NOT EXISTS dist_scanartifact (
-		id SERIAL PRIMARY KEY,
-		dist_id int REFERENCES dist(id),
-		scanner_id int REFERENCES scanner(id),
+		id BIGSERIAL PRIMARY KEY,
+		dist_id bigint REFERENCES dist(id),
+		scanner_id bigint REFERENCES scanner(id),
 		layer_hash text
 	);
 	CREATE UNIQUE INDEX IF NOT EXISTS dist_scanartifact_unique_idx ON dist_scanartifact (layer_hash, dist_id, scanner_id);
@@ -62,7 +62,7 @@ const (
 	--- Package
 	--- a unique package discovered by a scanner
 	CREATE TABLE IF NOT EXISTS package (
-		id SERIAL PRIMARY KEY,
+		id BIGSERIAL PRIMARY KEY,
 		name text NOT NULL,
 		kind text NOT NULL,
 		version text NOT NULL
@@ -73,11 +73,11 @@ const (
 	--- A relation linking discovered packages with the 
 	--- layer hash it was found
 	CREATE TABLE IF NOT EXISTS package_scanartifact (
-		id SERIAL PRIMARY KEY,
+		id BIGSERIAL PRIMARY KEY,
 		layer_hash text,
-		package_id int REFERENCES package(id),
-		source_id int REFERENCES package(id),
-		scanner_id int REFERENCES scanner(id),
+		package_id bigint REFERENCES package(id),
+		source_id bigint REFERENCES package(id),
+		scanner_id bigint REFERENCES scanner(id),
 		package_db text,
 		repository_hint text
 	);
@@ -86,7 +86,7 @@ const (
 	--- Repository
 	--- a unique package repository discovered by a scanner
 	CREATE TABLE IF NOT EXISTS repo (
-		id SERIAL PRIMARY KEY,
+		id BIGSERIAL PRIMARY KEY,
 		name text NOT NULL,
 		key text,
 		uri text
@@ -96,9 +96,9 @@ const (
 	--- RepositoryScanArtifact
 	--- A relation linking discovered distributions to a layer
 	CREATE TABLE IF NOT EXISTS repo_scanartifact (
-		id SERIAL PRIMARY KEY,
-		repo_id int REFERENCES repo(id),
-		scanner_id int REFERENCES scanner(id),
+		id BIGSERIAL PRIMARY KEY,
+		repo_id bigint REFERENCES repo(id),
+		scanner_id bigint REFERENCES scanner(id),
 		layer_hash text
 	);
 	CREATE UNIQUE INDEX IF NOT EXISTS repo_scanartifact_unique_idx ON repo_scanartifact (layer_hash, repo_id, scanner_id);

--- a/libvuln/migrations/migration1.go
+++ b/libvuln/migrations/migration1.go
@@ -6,7 +6,7 @@ const (
 CREATE TABLE vuln (
     updater text,
     --- claircore.Vulnerability fields
-    id SERIAL PRIMARY KEY,
+    id BIGSERIAL PRIMARY KEY,
     name text,
     description text,
     links text,


### PR DESCRIPTION
This commit changes the DDL to use bigserials and bigints for IDs, and any
code where ids are being read out of the database is updated to use go's
int64 type.