### PR TITLE
postgres: retrieve updater informaition

### DIFF
--- a/internal/vulnstore/postgres/get.go
+++ b/internal/vulnstore/postgres/get.go
@@ -84,6 +84,7 @@ func get(ctx context.Context, pool *pgxpool.Pool, records []*claircore.IndexReco
 				&v.Repo.URI,
 				&v.Dist.PrettyName,
 				&v.FixedInVersion,
+				&v.Updater,
 			)
 			v.ID = strconv.FormatInt(id, 10)
 			if err != nil {

--- a/internal/vulnstore/postgres/querybuilder.go
+++ b/internal/vulnstore/postgres/querybuilder.go
@@ -81,6 +81,7 @@ func buildGetQuery(record *claircore.IndexRecord, matchers []driver.MatchConstra
 		"repo_key",
 		"repo_uri",
 		"fixed_in_version",
+		"updater",
 	).From("vuln").Where(exps...)
 
 	sql, _, err := query.ToSQL()

--- a/internal/vulnstore/postgres/querybuilder_test.go
+++ b/internal/vulnstore/postgres/querybuilder_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/libvuln/driver"
 	"github.com/quay/claircore/test"
@@ -22,7 +23,7 @@ func Test_GetQueryBuilder_Deterministic_Args(t *testing.T) {
 	}{
 		{
 			name:          "No source package constrained by dist_id",
-			expectedQuery: `SELECT "id", "name", "description", "links", "severity", "package_name", "package_version", "package_kind", "dist_id", "dist_name", "dist_version", "dist_version_code_name", "dist_version_id", "dist_arch", "dist_cpe", "dist_pretty_name", "repo_name", "repo_key", "repo_uri", "fixed_in_version" FROM "vuln" WHERE (("package_name" = 'package-0') AND ("dist_id" = 'did-0'))`,
+			expectedQuery: `SELECT "id", "name", "description", "links", "severity", "package_name", "package_version", "package_kind", "dist_id", "dist_name", "dist_version", "dist_version_code_name", "dist_version_id", "dist_arch", "dist_cpe", "dist_pretty_name", "repo_name", "repo_key", "repo_uri", "fixed_in_version", "updater" FROM "vuln" WHERE (("package_name" = 'package-0') AND ("dist_id" = 'did-0'))`,
 			matchExps:     []driver.MatchConstraint{driver.DistributionDID},
 			indexRecord: func() *claircore.IndexRecord {
 				pkgs := test.GenUniquePackages(1)
@@ -36,7 +37,7 @@ func Test_GetQueryBuilder_Deterministic_Args(t *testing.T) {
 		},
 		{
 			name:          "Source package constrained by dist_id",
-			expectedQuery: `SELECT "id", "name", "description", "links", "severity", "package_name", "package_version", "package_kind", "dist_id", "dist_name", "dist_version", "dist_version_code_name", "dist_version_id", "dist_arch", "dist_cpe", "dist_pretty_name", "repo_name", "repo_key", "repo_uri", "fixed_in_version" FROM "vuln" WHERE ((("package_name" = 'package-0') OR ("package_name" = 'source-package-0')) AND ("dist_id" = 'did-0'))`,
+			expectedQuery: `SELECT "id", "name", "description", "links", "severity", "package_name", "package_version", "package_kind", "dist_id", "dist_name", "dist_version", "dist_version_code_name", "dist_version_id", "dist_arch", "dist_cpe", "dist_pretty_name", "repo_name", "repo_key", "repo_uri", "fixed_in_version", "updater" FROM "vuln" WHERE ((("package_name" = 'package-0') OR ("package_name" = 'source-package-0')) AND ("dist_id" = 'did-0'))`,
 			matchExps:     []driver.MatchConstraint{driver.DistributionDID},
 			indexRecord: func() *claircore.IndexRecord {
 				pkgs := test.GenUniquePackages(1)
@@ -49,7 +50,7 @@ func Test_GetQueryBuilder_Deterministic_Args(t *testing.T) {
 		},
 		{
 			name:          "Source package constrained by dist_id",
-			expectedQuery: `SELECT "id", "name", "description", "links", "severity", "package_name", "package_version", "package_kind", "dist_id", "dist_name", "dist_version", "dist_version_code_name", "dist_version_id", "dist_arch", "dist_cpe", "dist_pretty_name", "repo_name", "repo_key", "repo_uri", "fixed_in_version" FROM "vuln" WHERE ((("package_name" = 'package-0') OR ("package_name" = 'source-package-0')) AND ("dist_id" = 'did-0') AND ("dist_version" = 'version-0'))`,
+			expectedQuery: `SELECT "id", "name", "description", "links", "severity", "package_name", "package_version", "package_kind", "dist_id", "dist_name", "dist_version", "dist_version_code_name", "dist_version_id", "dist_arch", "dist_cpe", "dist_pretty_name", "repo_name", "repo_key", "repo_uri", "fixed_in_version", "updater" FROM "vuln" WHERE ((("package_name" = 'package-0') OR ("package_name" = 'source-package-0')) AND ("dist_id" = 'did-0') AND ("dist_version" = 'version-0'))`,
 			matchExps:     []driver.MatchConstraint{driver.DistributionDID, driver.DistributionVersion},
 			indexRecord: func() *claircore.IndexRecord {
 				pkgs := test.GenUniquePackages(1)
@@ -62,7 +63,7 @@ func Test_GetQueryBuilder_Deterministic_Args(t *testing.T) {
 		},
 		{
 			name:          "Source package constrained by dist_id",
-			expectedQuery: `SELECT "id", "name", "description", "links", "severity", "package_name", "package_version", "package_kind", "dist_id", "dist_name", "dist_version", "dist_version_code_name", "dist_version_id", "dist_arch", "dist_cpe", "dist_pretty_name", "repo_name", "repo_key", "repo_uri", "fixed_in_version" FROM "vuln" WHERE ((("package_name" = 'package-0') OR ("package_name" = 'source-package-0')) AND ("dist_id" = 'did-0') AND ("dist_version" = 'version-0') AND ("dist_version_id" = 'version-id-0'))`,
+			expectedQuery: `SELECT "id", "name", "description", "links", "severity", "package_name", "package_version", "package_kind", "dist_id", "dist_name", "dist_version", "dist_version_code_name", "dist_version_id", "dist_arch", "dist_cpe", "dist_pretty_name", "repo_name", "repo_key", "repo_uri", "fixed_in_version", "updater" FROM "vuln" WHERE ((("package_name" = 'package-0') OR ("package_name" = 'source-package-0')) AND ("dist_id" = 'did-0') AND ("dist_version" = 'version-0') AND ("dist_version_id" = 'version-id-0'))`,
 			matchExps:     []driver.MatchConstraint{driver.DistributionDID, driver.DistributionVersion, driver.DistributionVersionID},
 			indexRecord: func() *claircore.IndexRecord {
 				pkgs := test.GenUniquePackages(1)
@@ -75,7 +76,7 @@ func Test_GetQueryBuilder_Deterministic_Args(t *testing.T) {
 		},
 		{
 			name:          "Source package constrained by dist_id",
-			expectedQuery: `SELECT "id", "name", "description", "links", "severity", "package_name", "package_version", "package_kind", "dist_id", "dist_name", "dist_version", "dist_version_code_name", "dist_version_id", "dist_arch", "dist_cpe", "dist_pretty_name", "repo_name", "repo_key", "repo_uri", "fixed_in_version" FROM "vuln" WHERE ((("package_name" = 'package-0') OR ("package_name" = 'source-package-0')) AND ("dist_id" = 'did-0') AND ("dist_version" = 'version-0') AND ("dist_version_id" = 'version-id-0') AND ("dist_version_code_name" = 'version-code-name-0'))`,
+			expectedQuery: `SELECT "id", "name", "description", "links", "severity", "package_name", "package_version", "package_kind", "dist_id", "dist_name", "dist_version", "dist_version_code_name", "dist_version_id", "dist_arch", "dist_cpe", "dist_pretty_name", "repo_name", "repo_key", "repo_uri", "fixed_in_version", "updater" FROM "vuln" WHERE ((("package_name" = 'package-0') OR ("package_name" = 'source-package-0')) AND ("dist_id" = 'did-0') AND ("dist_version" = 'version-0') AND ("dist_version_id" = 'version-id-0') AND ("dist_version_code_name" = 'version-code-name-0'))`,
 			matchExps:     []driver.MatchConstraint{driver.DistributionDID, driver.DistributionVersion, driver.DistributionVersionID, driver.DistributionVersionCodeName},
 			indexRecord: func() *claircore.IndexRecord {
 				pkgs := test.GenUniquePackages(1)
@@ -95,7 +96,7 @@ func Test_GetQueryBuilder_Deterministic_Args(t *testing.T) {
 				t.Fatalf("failed to create query: %v", err)
 			}
 			if !cmp.Equal(query, tt.expectedQuery) {
-				t.Fatalf("%v", cmp.Diff(query, tt.expectedQuery))
+				t.Fatalf("%v", cmp.Diff(tt.expectedQuery, query))
 			}
 		})
 	}


### PR DESCRIPTION
results in reports with vulnerabilities like:

        "410835": {
            "description": "A Bleichenbacher type side-channel based padding oracle attack was found in the way nettle handles endian conversion of RSA decrypted PKCS#1 v1.5 data. An attacker who is able to run a process on the same physical core as the victim process, could use this flaw extract plaintext or in some cases downgrade any TLS connections to a vulnerable server.",
            "fixed_in_version": "",
            "id": "410835",
            "links": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-16869 http://people.canonical.com/~ubuntu-security/cve/2018/CVE-2018-16869.html http://cat.eyalro.net/ https://lists.lysator.liu.se/pipermail/nettle-bugs/2018/007363.html https://lists.debian.org/debian-lts/2019/03/msg00021.html",
            "name": "CVE-2018-16869",
            "severity": "Low",
            "updater": "ubuntu-bionic-updater"
        },
