### PR TITLE
cctool: add "manifest" subcommand

### DIFF
--- a/cmd/cctool/manifest.go
+++ b/cmd/cctool/manifest.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+type manifestConfig struct {
+	timeout time.Duration
+	pretty  bool
+}
+
+// Manifest is the subcommand for generating container manifests.
+func Manifest(cmd context.Context, cfg *commonConfig, args []string) error {
+	cmdcfg := manifestConfig{}
+	fs := flag.NewFlagSet("cctool manifest", flag.ExitOnError)
+	fs.DurationVar(&cmdcfg.timeout, "timeout", 5*time.Minute, "timeout for successful http responses")
+	fs.Parse(args)
+
+	images := fs.Args()
+	if len(images) == 0 {
+		s := bufio.NewScanner(os.Stdin)
+		for s.Scan() {
+			images = append(images, strings.TrimSpace(s.Text()))
+		}
+		if err := s.Err(); err != nil {
+			return err
+		}
+	}
+	enc := json.NewEncoder(os.Stdout)
+
+	ctx, done := context.WithTimeout(cmd, cmdcfg.timeout)
+	defer done()
+	var errd bool
+	errs := make([]error, len(images))
+	var eo sync.Once
+	var wg sync.WaitGroup
+	wg.Add(len(images))
+	for i, img := range images {
+		img := img
+		go func() {
+			defer wg.Done()
+			m, err := Inspect(ctx, img)
+			if err != nil {
+				eo.Do(func() { errd = true })
+				errs[i] = err
+				return
+			}
+			if err := enc.Encode(m); err != nil {
+				eo.Do(func() { errd = true })
+				errs[i] = err
+				return
+			}
+		}()
+	}
+	wg.Wait()
+	if errd {
+		buf := &bytes.Buffer{}
+		for _, err := range errs {
+			if err != nil {
+				fmt.Fprintln(buf, err)
+			}
+		}
+		return errors.New(buf.String())
+	}
+	return nil
+}

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -8,3 +8,4 @@
 - [Contributors](./contributor.md)
   - [Logging](./contributor/logging.md)
   - [Local Development](./local-dev.md)
+  - [cctool](./contributor/cctool.md)

--- a/docs/contributor.md
+++ b/docs/contributor.md
@@ -1,1 +1,3 @@
 # Contributors
+This is some documentation helpful for the actual nuts-n-bolts of adding code to
+and testing code in the project.

--- a/docs/contributor/cctool.md
+++ b/docs/contributor/cctool.md
@@ -1,0 +1,25 @@
+# Cctool
+`Cctool` is a small utility to make poking at claircore components easier.
+
+## Build
+Build via the standard incantation:
+```
+go build ./cmd/cctool
+```
+
+## Usage
+`Cctool` is driven by subcommands. Use the "h" flag before a subcommand to see
+common flags and a list of subcommands. Use the "h" flag after a subcommand to
+see flags specific to that subcommand.
+
+### Report
+The `report` subcommand reads in docker-like image references on the command
+line or stdin and outputs a column-oriented summary, suitable for passing to a
+tool like `awk`.
+
+`Report` expects to talk to the development HTTP servers.
+
+### Manifest
+The `manifest` subcommand reads in docker-like image references on the command
+line or stdin and outputs newline-separated json manifests, suitable for passing
+to libindex.


### PR DESCRIPTION
This adds a subcommand to cctool that just emits claircore manifests on stdout.