### PR TITLE
Louis/distribution scanner

### DIFF
--- a/alpine/distributionscanner.go
+++ b/alpine/distributionscanner.go
@@ -1,0 +1,129 @@
+package alpine
+
+import (
+	"bytes"
+	"context"
+	"regexp"
+	"runtime/trace"
+
+	"github.com/quay/claircore"
+	"github.com/quay/claircore/internal/indexer"
+	"github.com/rs/zerolog"
+)
+
+// Alpine linux has patch releases but their security database
+// aggregates security information by major release. We choose
+// to normalize detected distributions into major.minor releases and
+// parse vulnerabilities into major.minor releases
+
+const (
+	scannerName    = "alpine"
+	scannerVersion = "v0.0.1"
+	scannerKind    = "distribution"
+)
+
+type alpineRegex struct {
+	release Release
+	regexp  *regexp.Regexp
+}
+
+// the following regexps will match the PrettyName in the os-release file
+// ex: "Alpine Linux v3.3"
+// and the issue string in the issue file
+// ex: "Welcome to Alpine Linux 3.3"
+var alpineRegexes = []alpineRegex{
+	{
+		release: V3_3,
+		regexp:  regexp.MustCompile(`Alpine Linux (v)?3.3`),
+	},
+	{
+		release: V3_4,
+		regexp:  regexp.MustCompile(`Alpine Linux (v)?3.4`),
+	},
+	{
+		release: V3_5,
+		regexp:  regexp.MustCompile(`Alpine Linux (v)?3.5`),
+	},
+	{
+		release: V3_6,
+		regexp:  regexp.MustCompile(`Alpine Linux (v)?3.6`),
+	},
+	{
+		release: V3_7,
+		regexp:  regexp.MustCompile(`Alpine Linux (v)?3.7`),
+	},
+	{
+		release: V3_8,
+		regexp:  regexp.MustCompile(`Alpine Linux (v)?3.8`),
+	},
+	{
+		release: V3_9,
+		regexp:  regexp.MustCompile(`Alpine Linux (v)?3.9`),
+	},
+	{
+		release: V3_10,
+		regexp:  regexp.MustCompile(`Alpine Linux (v)?3.10`),
+	},
+}
+
+const osReleasePath = `etc/os-release`
+const issuePath = `etc/issue`
+
+var _ indexer.DistributionScanner = (*DistributionScanner)(nil)
+var _ indexer.VersionedScanner = (*DistributionScanner)(nil)
+
+// DistributionScanner attempts to discover if a layer
+// displays characteristics of a alpine distribution
+type DistributionScanner struct{}
+
+// Name implements scanner.VersionedScanner.
+func (*DistributionScanner) Name() string { return scannerName }
+
+// Version implements scanner.VersionedScanner.
+func (*DistributionScanner) Version() string { return scannerVersion }
+
+// Kind implements scanner.VersionedScanner.
+func (*DistributionScanner) Kind() string { return scannerKind }
+
+// Scan will inspect the layer for an os-release or lsb-release file
+// and perform a regex match for keywords indicating the associated alpine release
+//
+// If neither file is found a (nil,nil) is returned.
+// If the files are found but all regexp fail to match an empty distribution is returned.
+func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]*claircore.Distribution, error) {
+	defer trace.StartRegion(ctx, "Scanner.Scan").End()
+	log := zerolog.Ctx(ctx).With().
+		Str("component", "alpine_dist_scanner").
+		Str("name", ds.Name()).
+		Str("version", ds.Version()).
+		Str("kind", ds.Kind()).
+		Str("layer", l.Hash).
+		Logger()
+	log.Debug().Msg("start")
+	defer log.Debug().Msg("done")
+	files, err := l.Files(osReleasePath, issuePath)
+	if err != nil {
+		log.Debug().Msg("didn't find an os-release or lsb release file")
+		return nil, nil
+	}
+	for _, buff := range files {
+		dist := ds.parse(buff)
+		if dist != nil {
+			return []*claircore.Distribution{dist}, nil
+		}
+	}
+	return []*claircore.Distribution{&claircore.Distribution{}}, nil
+}
+
+// parse attempts to match all alpine release regexp and returns the associated
+// distribution if it exists.
+//
+// separated to it's own method to aide testing.
+func (ds *DistributionScanner) parse(buff *bytes.Buffer) *claircore.Distribution {
+	for _, ur := range alpineRegexes {
+		if ur.regexp.Match(buff.Bytes()) {
+			return releaseToDist(ur.release)
+		}
+	}
+	return nil
+}

--- a/alpine/distributionscanner.go
+++ b/alpine/distributionscanner.go
@@ -93,17 +93,15 @@ func (*DistributionScanner) Kind() string { return scannerKind }
 func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]*claircore.Distribution, error) {
 	defer trace.StartRegion(ctx, "Scanner.Scan").End()
 	log := zerolog.Ctx(ctx).With().
-		Str("component", "alpine_dist_scanner").
-		Str("name", ds.Name()).
+		Str("component", "alpine/DistributionScanner.Scan").
 		Str("version", ds.Version()).
-		Str("kind", ds.Kind()).
 		Str("layer", l.Hash).
 		Logger()
 	log.Debug().Msg("start")
 	defer log.Debug().Msg("done")
 	files, err := l.Files(osReleasePath, issuePath)
 	if err != nil {
-		log.Debug().Msg("didn't find an os-release or lsb release file")
+		log.Debug().Msg("didn't find an os-release or issue file")
 		return nil, nil
 	}
 	for _, buff := range files {

--- a/alpine/distributionscanner_test.go
+++ b/alpine/distributionscanner_test.go
@@ -1,0 +1,159 @@
+package alpine
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+var v3_3_OSRelease []byte = []byte(`NAME="Alpine Linux"
+ID=alpine
+VERSION_ID=3.3.3
+PRETTY_NAME="Alpine Linux v3.3"
+HOME_URL="http://alpinelinux.org"
+BUG_REPORT_URL="http://bugs.alpinelinux.org"`)
+
+var v3_3_Issue []byte = []byte(`Welcome to Alpine Linux 3.3
+Kernel \r on an \m (\l)`)
+
+var v3_4_OSRelease []byte = []byte(`NAME="Alpine Linux"
+ID=alpine
+VERSION_ID=3.4.6
+PRETTY_NAME="Alpine Linux v3.4"
+HOME_URL="http://alpinelinux.org"
+BUG_REPORT_URL="http://bugs.alpinelinux.org"`)
+
+var v3_4_Issue []byte = []byte(`Welcome to Alpine Linux 3.4
+Kernel \r on an \m (\l)`)
+
+var v3_5_OSRelease []byte = []byte(`NAME="Alpine Linux"
+ID=alpine
+VERSION_ID=3.5.3
+PRETTY_NAME="Alpine Linux v3.5"
+HOME_URL="http://alpinelinux.org"
+BUG_REPORT_URL="http://bugs.alpinelinux.org"`)
+
+var v3_5_Issue []byte = []byte(`Welcome to Alpine Linux 3.5
+Kernel \r on an \m (\l)`)
+
+var v3_6_OSRelease []byte = []byte(`NAME="Alpine Linux"
+ID=alpine
+VERSION_ID=3.6.5
+PRETTY_NAME="Alpine Linux v3.6"
+HOME_URL="http://alpinelinux.org"
+BUG_REPORT_URL="http://bugs.alpinelinux.org"`)
+
+var v3_6_Issue []byte = []byte(`Welcome to Alpine Linux 3.6
+Kernel \r on an \m (\l)`)
+
+var v3_7_OSRelease []byte = []byte(`NAME="Alpine Linux"
+ID=alpine
+VERSION_ID=3.7.3
+PRETTY_NAME="Alpine Linux v3.7"
+HOME_URL="http://alpinelinux.org"
+BUG_REPORT_URL="http://bugs.alpinelinux.org"`)
+
+var v3_7_Issue []byte = []byte(`Welcome to Alpine Linux 3.7
+Kernel \r on an \m (\l)`)
+
+var v3_8_OSRelease []byte = []byte(`NAME="Alpine Linux"
+ID=alpine
+VERSION_ID=3.8.4
+PRETTY_NAME="Alpine Linux v3.8"
+HOME_URL="http://alpinelinux.org"
+BUG_REPORT_URL="http://bugs.alpinelinux.org"`)
+
+var v3_8_Issue []byte = []byte(`Welcome to Alpine Linux 3.8
+Kernel \r on an \m (\l)`)
+
+var v3_9_OSRelease []byte = []byte(`NAME="Alpine Linux"
+ID=alpine
+VERSION_ID=3.9.4
+PRETTY_NAME="Alpine Linux v3.9"
+HOME_URL="https://alpinelinux.org/"
+BUG_REPORT_URL="https://bugs.alpinelinux.org/"`)
+
+var v3_9_Issue []byte = []byte(`Welcome to Alpine Linux 3.9
+Kernel \r on an \m (\l)`)
+
+var v3_10_OSRelease []byte = []byte(`NAME="Alpine Linux"
+ID=alpine
+VERSION_ID=3.10.3
+PRETTY_NAME="Alpine Linux v3.10"
+HOME_URL="https://alpinelinux.org/"
+BUG_REPORT_URL="https://bugs.alpinelinux.org/"`)
+
+var v3_10_Issue []byte = []byte(`Welcome to Alpine Linux 3.10
+Kernel \r on an \m (\l)`)
+
+func TestDistributionScanner(t *testing.T) {
+	table := []struct {
+		name      string
+		release   Release
+		osRelease []byte
+		issue     []byte
+	}{
+		{
+			name:      "v3_3",
+			release:   V3_3,
+			osRelease: v3_3_OSRelease,
+			issue:     v3_3_Issue,
+		},
+		{
+			name:      "v3_4",
+			release:   V3_4,
+			osRelease: v3_4_OSRelease,
+			issue:     v3_4_Issue,
+		},
+		{
+			name:      "v3_5",
+			release:   V3_5,
+			osRelease: v3_5_OSRelease,
+			issue:     v3_5_Issue,
+		},
+		{
+			name:      "v3_6",
+			release:   V3_6,
+			osRelease: v3_6_OSRelease,
+			issue:     v3_6_Issue,
+		},
+		{
+			name:      "v3_7",
+			release:   V3_7,
+			osRelease: v3_7_OSRelease,
+			issue:     v3_7_Issue,
+		},
+		{
+			name:      "v3_8",
+			release:   V3_8,
+			osRelease: v3_8_OSRelease,
+			issue:     v3_8_Issue,
+		},
+		{
+			name:      "v3_9",
+			release:   V3_9,
+			osRelease: v3_9_OSRelease,
+			issue:     v3_9_Issue,
+		},
+		{
+			name:      "v3_10",
+			release:   V3_10,
+			osRelease: v3_10_OSRelease,
+			issue:     v3_10_Issue,
+		},
+	}
+	for _, tt := range table {
+		t.Run(tt.name, func(t *testing.T) {
+			scanner := DistributionScanner{}
+			dist := scanner.parse(bytes.NewBuffer(tt.osRelease))
+			if !cmp.Equal(dist, releaseToDist(tt.release)) {
+				t.Fatalf("%v", cmp.Diff(dist, releaseToDist(tt.release)))
+			}
+			dist = scanner.parse(bytes.NewBuffer(tt.issue))
+			if !cmp.Equal(dist, releaseToDist(tt.release)) {
+				t.Fatalf("%v", cmp.Diff(dist, releaseToDist(tt.release)))
+			}
+		})
+	}
+}

--- a/alpine/release.go
+++ b/alpine/release.go
@@ -1,5 +1,12 @@
 package alpine
 
+import "github.com/quay/claircore"
+
+// Alpine linux has patch releases but their security database
+// aggregates security information by major release. We choose
+// to normalize detected distributions into major.minor releases and
+// parse vulnerabilities into major.minor releases
+
 // Release is a particular release of the Alpine linux distribution
 type Release string
 
@@ -33,3 +40,83 @@ const (
 	Name = "Alpine Linux"
 	ID   = "alpine"
 )
+
+var alpine3_3Dist = &claircore.Distribution{
+	Name:       "Alpine Linux",
+	DID:        "alpine",
+	VersionID:  "3.3",
+	PrettyName: "Alpine Linux v3.3",
+}
+
+var alpine3_4Dist = &claircore.Distribution{
+	Name:       "Alpine Linux",
+	DID:        "alpine",
+	VersionID:  "3.4",
+	PrettyName: "Alpine Linux v3.4",
+}
+
+var alpine3_5Dist = &claircore.Distribution{
+	Name:       "Alpine Linux",
+	DID:        "alpine",
+	VersionID:  "3.5",
+	PrettyName: "Alpine Linux v3.5",
+}
+
+var alpine3_6Dist = &claircore.Distribution{
+	Name:       "Alpine Linux",
+	DID:        "alpine",
+	VersionID:  "3.6",
+	PrettyName: "Alpine Linux v3.6",
+}
+
+var alpine3_7Dist = &claircore.Distribution{
+	Name:       "Alpine Linux",
+	DID:        "alpine",
+	VersionID:  "3.7",
+	PrettyName: "Alpine Linux v3.7",
+}
+
+var alpine3_8Dist = &claircore.Distribution{
+	Name:       "Alpine Linux",
+	DID:        "alpine",
+	VersionID:  "3.8",
+	PrettyName: "Alpine Linux v3.8",
+}
+
+var alpine3_9Dist = &claircore.Distribution{
+	Name:       "Alpine Linux",
+	DID:        "alpine",
+	VersionID:  "3.9",
+	PrettyName: "Alpine Linux v3.9",
+}
+
+var alpine3_10Dist = &claircore.Distribution{
+	Name:       "Alpine Linux",
+	DID:        "alpine",
+	VersionID:  "3.10",
+	PrettyName: "Alpine Linux v3.10",
+}
+
+func releaseToDist(r Release) *claircore.Distribution {
+	switch r {
+	case V3_3:
+		return alpine3_3Dist
+	case V3_4:
+		return alpine3_4Dist
+	case V3_5:
+		return alpine3_5Dist
+	case V3_6:
+		return alpine3_6Dist
+	case V3_7:
+		return alpine3_7Dist
+	case V3_8:
+		return alpine3_8Dist
+	case V3_9:
+		return alpine3_9Dist
+	case V3_10:
+		return alpine3_10Dist
+	default:
+		// return empty dist
+		return &claircore.Distribution{}
+	}
+}

--- a/aws/distributionscanner_test.go
+++ b/aws/distributionscanner_test.go
@@ -48,7 +48,7 @@ func TestDistributionScanner(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			scanner := DistributionScanner{}
 			dist := scanner.parse(bytes.NewBuffer(tt.osRelease))
-			cmpDist, _ := releaseToDist(tt.release)
+			cmpDist := releaseToDist(tt.release)
 			if !cmp.Equal(dist, cmpDist) {
 				t.Fatalf("%v", cmp.Diff(dist, cmpDist))
 			}

--- a/aws/distributionscanner_test.go
+++ b/aws/distributionscanner_test.go
@@ -1,0 +1,57 @@
+package aws
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+var linux1OSRelease []byte = []byte(`NAME="Amazon Linux AMI"
+VERSION="2018.03"
+ID="amzn"
+ID_LIKE="rhel fedora"
+VERSION_ID="2018.03"
+PRETTY_NAME="Amazon Linux AMI 2018.03"
+ANSI_COLOR="0;33"
+CPE_NAME="cpe:/o:amazon:linux:2018.03:ga"
+HOME_URL="http://aws.amazon.com/amazon-linux-ami/"`)
+
+var linux2OSRelease []byte = []byte(`NAME="Amazon Linux"
+VERSION="2"
+ID="amzn"
+ID_LIKE="centos rhel fedora"
+VERSION_ID="2"
+PRETTY_NAME="Amazon Linux 2"
+ANSI_COLOR="0;33"
+CPE_NAME="cpe:2.3:o:amazon:amazon_linux:2"
+HOME_URL="https://amazonlinux.com/"`)
+
+func TestDistributionScanner(t *testing.T) {
+	table := []struct {
+		name      string
+		release   Release
+		osRelease []byte
+	}{
+		{
+			name:      "linux1",
+			release:   Linux1,
+			osRelease: linux1OSRelease,
+		},
+		{
+			name:      "linux2",
+			release:   Linux2,
+			osRelease: linux2OSRelease,
+		},
+	}
+	for _, tt := range table {
+		t.Run(tt.name, func(t *testing.T) {
+			scanner := DistributionScanner{}
+			dist := scanner.parse(bytes.NewBuffer(tt.osRelease))
+			cmpDist, _ := releaseToDist(tt.release)
+			if !cmp.Equal(dist, cmpDist) {
+				t.Fatalf("%v", cmp.Diff(dist, cmpDist))
+			}
+		})
+	}
+}

--- a/aws/distributionscannner.go
+++ b/aws/distributionscannner.go
@@ -92,10 +92,7 @@ func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]
 func (ds *DistributionScanner) parse(buff *bytes.Buffer) *claircore.Distribution {
 	for _, ur := range awsRegexes {
 		if ur.regexp.Match(buff.Bytes()) {
-			dist, err := releaseToDist(ur.release)
-			if err != nil {
-				panic("aws distrubution scanner: awsRegex configured with unknown release")
-			}
+			dist := releaseToDist(ur.release)
 			return dist
 		}
 	}

--- a/aws/distributionscannner.go
+++ b/aws/distributionscannner.go
@@ -1,0 +1,103 @@
+package aws
+
+import (
+	"bytes"
+	"context"
+	"regexp"
+	"runtime/trace"
+
+	"github.com/quay/claircore"
+	"github.com/quay/claircore/internal/indexer"
+	"github.com/rs/zerolog"
+)
+
+// AWS Linux keeps a consistent os-release file between
+// major releases.
+// All tested images on docker hub contained os-release file
+
+const (
+	scannerName    = "aws"
+	scannerVersion = "v0.0.1"
+	scannerKind    = "distribution"
+)
+
+type awsRegex struct {
+	release Release
+	regexp  *regexp.Regexp
+}
+
+var awsRegexes = []awsRegex{
+	{
+		release: Linux1,
+		regexp:  regexp.MustCompile(`Amazon Linux AMI 2018.03`),
+	},
+	{
+		release: Linux2,
+		regexp:  regexp.MustCompile(`Amazon Linux 2`),
+	},
+}
+
+const osReleasePath = `etc/os-release`
+
+var _ indexer.DistributionScanner = (*DistributionScanner)(nil)
+var _ indexer.VersionedScanner = (*DistributionScanner)(nil)
+
+// DistributionScanner attempts to discover if a layer
+// displays characteristics of a AWS distribution
+type DistributionScanner struct{}
+
+// Name implements scanner.VersionedScanner.
+func (*DistributionScanner) Name() string { return scannerName }
+
+// Version implements scanner.VersionedScanner.
+func (*DistributionScanner) Version() string { return scannerVersion }
+
+// Kind implements scanner.VersionedScanner.
+func (*DistributionScanner) Kind() string { return scannerKind }
+
+// Scan will inspect the layer for an os-release or lsb-release file
+// and perform a regex match for keywords indicating the associated AWS release
+//
+// If neither file is found a (nil,nil) is returned.
+// If the files are found but all regexp fail to match an empty distribution is returned.
+func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]*claircore.Distribution, error) {
+	defer trace.StartRegion(ctx, "Scanner.Scan").End()
+	log := zerolog.Ctx(ctx).With().
+		Str("component", "aws_dist_scanner").
+		Str("name", ds.Name()).
+		Str("version", ds.Version()).
+		Str("kind", ds.Kind()).
+		Str("layer", l.Hash).
+		Logger()
+	log.Debug().Msg("start")
+	defer log.Debug().Msg("done")
+	files, err := l.Files(osReleasePath)
+	if err != nil {
+		log.Debug().Msg("didn't find an os-release")
+		return nil, nil
+	}
+	for _, buff := range files {
+		dist := ds.parse(buff)
+		if dist != nil {
+			return []*claircore.Distribution{dist}, nil
+		}
+	}
+	return []*claircore.Distribution{&claircore.Distribution{}}, nil
+}
+
+// parse attempts to match all AWS release regexp and returns the associated
+// distribution if it exists.
+//
+// separated to it's own method to aide testing.
+func (ds *DistributionScanner) parse(buff *bytes.Buffer) *claircore.Distribution {
+	for _, ur := range awsRegexes {
+		if ur.regexp.Match(buff.Bytes()) {
+			dist, err := releaseToDist(ur.release)
+			if err != nil {
+				panic("aws distrubution scanner: awsRegex configured with unknown release")
+			}
+			return dist
+		}
+	}
+	return nil
+}

--- a/aws/releases.go
+++ b/aws/releases.go
@@ -21,6 +21,7 @@ var linux1Dist = &claircore.Distribution{
 	Version:    "2018.03",
 	VersionID:  "2018.03",
 	PrettyName: "Amazon Linux AMI 2018.03",
+	CPE:        "cpe:/o:amazon:linux:2018.03:ga",
 }
 
 var linux2Dist = &claircore.Distribution{
@@ -29,6 +30,7 @@ var linux2Dist = &claircore.Distribution{
 	Version:    "2",
 	VersionID:  "2",
 	PrettyName: "Amazon Linux 2",
+	CPE:        "cpe:2.3:o:amazon:amazon_linux:2",
 }
 
 func releaseToDist(release Release) (*claircore.Distribution, error) {

--- a/aws/releases.go
+++ b/aws/releases.go
@@ -1,8 +1,6 @@
 package aws
 
 import (
-	"fmt"
-
 	"github.com/quay/claircore"
 )
 
@@ -33,13 +31,14 @@ var linux2Dist = &claircore.Distribution{
 	CPE:        "cpe:2.3:o:amazon:amazon_linux:2",
 }
 
-func releaseToDist(release Release) (*claircore.Distribution, error) {
+func releaseToDist(release Release) *claircore.Distribution {
 	switch release {
 	case Linux1:
-		return linux1Dist, nil
+		return linux1Dist
 	case Linux2:
-		return linux2Dist, nil
+		return linux2Dist
 	default:
-		return nil, fmt.Errorf("unknown release")
+		// return empty dist
+		return &claircore.Distribution{}
 	}
 }

--- a/aws/updater.go
+++ b/aws/updater.go
@@ -73,10 +73,7 @@ func (u *Updater) Parse(ctx context.Context, contents io.ReadCloser) ([]*clairco
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal updates xml: %v", err)
 	}
-	dist, err := releaseToDist(u.release)
-	if err != nil {
-		return nil, fmt.Errorf("failed to classify vulns with distribution: %w", err)
-	}
+	dist := releaseToDist(u.release)
 
 	vulns := []*claircore.Vulnerability{}
 	for _, update := range updates.Updates {

--- a/debian/distributionscanner.go
+++ b/debian/distributionscanner.go
@@ -1,0 +1,104 @@
+package debian
+
+import (
+	"bytes"
+	"context"
+	"regexp"
+	"runtime/trace"
+
+	"github.com/quay/claircore"
+	"github.com/quay/claircore/internal/indexer"
+	"github.com/rs/zerolog"
+)
+
+const (
+	scannerName    = "debian"
+	scannerVersion = "v0.0.1"
+	scannerKind    = "distribution"
+)
+
+type debianRegex struct {
+	release Release
+	regexp  *regexp.Regexp
+}
+
+var debianRegexes = []debianRegex{
+	{
+		release: Buster,
+		regexp:  regexp.MustCompile(`(?is)debian gnu/linux 10`),
+	},
+	{
+		release: Jessie,
+		regexp:  regexp.MustCompile(`(?is)debian gnu/linux 8`),
+	},
+	{
+		release: Stretch,
+		regexp:  regexp.MustCompile(`(?is)debian gnu/linux 9`),
+	},
+	{
+		release: Wheezy,
+		regexp:  regexp.MustCompile(`(?is)debian gnu/linux 7`),
+	},
+}
+
+const osReleasePath = `etc/os-release`
+const issuePath = `etc/issue`
+
+var _ indexer.DistributionScanner = (*DistributionScanner)(nil)
+var _ indexer.VersionedScanner = (*DistributionScanner)(nil)
+
+// DistributionScanner attempts to discover if a layer
+// displays characteristics of a Debian distribution
+type DistributionScanner struct{}
+
+// Name implements scanner.VersionedScanner.
+func (*DistributionScanner) Name() string { return scannerName }
+
+// Version implements scanner.VersionedScanner.
+func (*DistributionScanner) Version() string { return scannerVersion }
+
+// Kind implements scanner.VersionedScanner.
+func (*DistributionScanner) Kind() string { return scannerKind }
+
+// Scan will inspect the layer for an os-release or lsb-release file
+// and perform a regex match for keywords indicating the associated Debian release
+//
+// If neither file is found a (nil,nil) is returned.
+// If the files are found but all regexp fail to match an empty distribution is returned.
+func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]*claircore.Distribution, error) {
+	defer trace.StartRegion(ctx, "Scanner.Scan").End()
+	log := zerolog.Ctx(ctx).With().
+		Str("component", "ubuntu_dist_scanner").
+		Str("name", ds.Name()).
+		Str("version", ds.Version()).
+		Str("kind", ds.Kind()).
+		Str("layer", l.Hash).
+		Logger()
+	log.Debug().Msg("start")
+	defer log.Debug().Msg("done")
+	files, err := l.Files(osReleasePath, issuePath)
+	if err != nil {
+		log.Debug().Msg("didn't find an os-release or lsb release file")
+		return nil, nil
+	}
+	for _, buff := range files {
+		dist := ds.parse(buff)
+		if dist != nil {
+			return []*claircore.Distribution{dist}, nil
+		}
+	}
+	return []*claircore.Distribution{&claircore.Distribution{}}, nil
+}
+
+// parse attempts to match all Debian release regexp and returns the associated
+// distribution if it exists.
+//
+// separated to it's own method to aide testing.
+func (ds *DistributionScanner) parse(buff *bytes.Buffer) *claircore.Distribution {
+	for _, ur := range debianRegexes {
+		if ur.regexp.Match(buff.Bytes()) {
+			return releaseToDist(ur.release)
+		}
+	}
+	return nil
+}

--- a/debian/distributionscanner.go
+++ b/debian/distributionscanner.go
@@ -68,10 +68,8 @@ func (*DistributionScanner) Kind() string { return scannerKind }
 func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]*claircore.Distribution, error) {
 	defer trace.StartRegion(ctx, "Scanner.Scan").End()
 	log := zerolog.Ctx(ctx).With().
-		Str("component", "debian_dist_scanner").
-		Str("name", ds.Name()).
+		Str("component", "debian/DistributionScanner.Scan").
 		Str("version", ds.Version()).
-		Str("kind", ds.Kind()).
 		Str("layer", l.Hash).
 		Logger()
 	log.Debug().Msg("start")

--- a/debian/distributionscanner_test.go
+++ b/debian/distributionscanner_test.go
@@ -1,0 +1,196 @@
+package debian
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+var busterOSRelease []byte = []byte(`PRETTY_NAME="Debian GNU/Linux 10 (buster)"
+NAME="Debian GNU/Linux"
+VERSION_ID="10"
+VERSION="10 (buster)"
+VERSION_CODENAME=buster
+ID=debian
+HOME_URL="https://www.debian.org/"
+SUPPORT_URL="https://www.debian.org/support"
+BUG_REPORT_URL="https://bugs.debian.org/"`)
+
+var busterOSReleaseBad []byte = []byte(`PRETTY_NAME="Debian GNU/Linux"
+NAME="Debian GNU/Linux"
+VERSION_ID="10"
+VERSION="10 (buster)"
+VERSION_CODENAME=buster
+ID=debian
+HOME_URL="https://www.debian.org/"
+SUPPORT_URL="https://www.debian.org/support"
+BUG_REPORT_URL="https://bugs.debian.org/"`)
+
+var busterIssue []byte = []byte(`Debian GNU/Linux 10 \n \l`)
+
+var busterIssueBad []byte = []byte(`Debian GNU/Linux \n \l`)
+
+var jessieOSRelease []byte = []byte(`PRETTY_NAME="Debian GNU/Linux 8 (jessie)"
+NAME="Debian GNU/Linux"
+VERSION_ID="8"
+VERSION="8 (jessie)"
+ID=debian
+HOME_URL="http://www.debian.org/"
+SUPPORT_URL="http://www.debian.org/support"
+BUG_REPORT_URL="https://bugs.debian.org/"`)
+
+var jessieOSReleaseBad []byte = []byte(`PRETTY_NAME="Debian GNU/Linux"
+NAME="Debian GNU/Linux"
+VERSION_ID="8"
+VERSION="8 (jessie)"
+ID=debian
+HOME_URL="http://www.debian.org/"
+SUPPORT_URL="http://www.debian.org/support"
+BUG_REPORT_URL="https://bugs.debian.org/"`)
+
+var jessieIssue []byte = []byte(`Debian GNU/Linux 8 \n \l`)
+
+var jessieIssueBad []byte = []byte(`Debian GNU/Linux \n \l`)
+
+var stretchOSRelease []byte = []byte(`PRETTY_NAME="Debian GNU/Linux 9 (stretch)"
+NAME="Debian GNU/Linux"
+VERSION_ID="9"
+VERSION="9 (stretch)"
+VERSION_CODENAME=stretch
+ID=debian
+HOME_URL="https://www.debian.org/"
+SUPPORT_URL="https://www.debian.org/support"
+BUG_REPORT_URL="https://bugs.debian.org/"`)
+
+var stretchOSReleaseBad []byte = []byte(`PRETTY_NAME="Debian GNU/Linux"
+NAME="Debian GNU/Linux"
+VERSION_ID="9"
+VERSION="9 (stretch)"
+VERSION_CODENAME=stretch
+ID=debian
+HOME_URL="https://www.debian.org/"
+SUPPORT_URL="https://www.debian.org/support"
+BUG_REPORT_URL="https://bugs.debian.org/"`)
+
+var stretchIssue []byte = []byte(`Debian GNU/Linux 9 \n \l`)
+
+var stretchIssueBad []byte = []byte(`Debian GNU/Linux`)
+
+var wheezyOSRelease []byte = []byte(`PRETTY_NAME="Debian GNU/Linux 7 (wheezy)"
+NAME="Debian GNU/Linux"
+VERSION_ID="7"
+VERSION="7 (wheezy)"
+ID=debian
+ANSI_COLOR="1;31"
+HOME_URL="http://www.debian.org/"
+SUPPORT_URL="http://www.debian.org/support/"
+BUG_REPORT_URL="http://bugs.debian.org/"`)
+
+var wheezyOSReleaseBad []byte = []byte(`PRETTY_NAME="Debian GNU/Linux"
+NAME="Debian GNU/Linux"
+VERSION_ID="7"
+VERSION="7 (wheezy)"
+ID=debian
+ANSI_COLOR="1;31"
+HOME_URL="http://www.debian.org/"
+SUPPORT_URL="http://www.debian.org/support/"
+BUG_REPORT_URL="http://bugs.debian.org/"`)
+
+var wheezyIssue []byte = []byte(`Debian GNU/Linux 7 \n \l`)
+
+var wheezyIssueBad []byte = []byte(`Debian GNU/Linux`)
+
+func TestDistributionScanner(t *testing.T) {
+	table := []struct {
+		name      string
+		release   Release
+		osRelease []byte
+		issue     []byte
+	}{
+		{
+			name:      "buster",
+			release:   Buster,
+			osRelease: busterOSRelease,
+			issue:     busterIssue,
+		},
+		{
+			name:      "jessie",
+			release:   Jessie,
+			osRelease: jessieOSRelease,
+			issue:     jessieIssue,
+		},
+		{
+			name:      "stretch",
+			release:   Stretch,
+			osRelease: stretchOSRelease,
+			issue:     stretchIssue,
+		},
+		{
+			name:      "wheezy",
+			release:   Wheezy,
+			osRelease: wheezyOSRelease,
+			issue:     wheezyIssue,
+		},
+	}
+	for _, tt := range table {
+		t.Run(tt.name, func(t *testing.T) {
+			scanner := DistributionScanner{}
+			dist := scanner.parse(bytes.NewBuffer(tt.osRelease))
+			if !cmp.Equal(dist, releaseToDist(tt.release)) {
+				t.Fatalf("%v", cmp.Diff(dist, releaseToDist(tt.release)))
+			}
+			dist = scanner.parse(bytes.NewBuffer(tt.issue))
+			if !cmp.Equal(dist, releaseToDist(tt.release)) {
+				t.Fatalf("%v", cmp.Diff(dist, releaseToDist(tt.release)))
+			}
+		})
+	}
+}
+
+func TestDistributionScannerBad(t *testing.T) {
+	table := []struct {
+		name      string
+		release   Release
+		osRelease []byte
+		issue     []byte
+	}{
+		{
+			name:      "buster",
+			release:   Buster,
+			osRelease: busterOSReleaseBad,
+			issue:     busterIssueBad,
+		},
+		{
+			name:      "jessie",
+			release:   Jessie,
+			osRelease: jessieOSReleaseBad,
+			issue:     jessieIssueBad,
+		},
+		{
+			name:      "stretch",
+			release:   Stretch,
+			osRelease: stretchOSReleaseBad,
+			issue:     stretchIssueBad,
+		},
+		{
+			name:      "wheezy",
+			release:   Wheezy,
+			osRelease: wheezyOSReleaseBad,
+			issue:     wheezyIssueBad,
+		},
+	}
+	for _, tt := range table {
+		t.Run(tt.name, func(t *testing.T) {
+			scanner := DistributionScanner{}
+			dist := scanner.parse(bytes.NewBuffer(tt.osRelease))
+			if dist != nil {
+				t.Fatalf("expected dist to be nil but got: %v", dist)
+			}
+			dist = scanner.parse(bytes.NewBuffer(tt.issue))
+			if dist != nil {
+				t.Fatalf("expected dist to be nil but got: %v", dist)
+			}
+		})
+	}
+}

--- a/debian/distributionscanner_test.go
+++ b/debian/distributionscanner_test.go
@@ -17,19 +17,7 @@ HOME_URL="https://www.debian.org/"
 SUPPORT_URL="https://www.debian.org/support"
 BUG_REPORT_URL="https://bugs.debian.org/"`)
 
-var busterOSReleaseBad []byte = []byte(`PRETTY_NAME="Debian GNU/Linux"
-NAME="Debian GNU/Linux"
-VERSION_ID="10"
-VERSION="10 (buster)"
-VERSION_CODENAME=buster
-ID=debian
-HOME_URL="https://www.debian.org/"
-SUPPORT_URL="https://www.debian.org/support"
-BUG_REPORT_URL="https://bugs.debian.org/"`)
-
 var busterIssue []byte = []byte(`Debian GNU/Linux 10 \n \l`)
-
-var busterIssueBad []byte = []byte(`Debian GNU/Linux \n \l`)
 
 var jessieOSRelease []byte = []byte(`PRETTY_NAME="Debian GNU/Linux 8 (jessie)"
 NAME="Debian GNU/Linux"
@@ -40,18 +28,7 @@ HOME_URL="http://www.debian.org/"
 SUPPORT_URL="http://www.debian.org/support"
 BUG_REPORT_URL="https://bugs.debian.org/"`)
 
-var jessieOSReleaseBad []byte = []byte(`PRETTY_NAME="Debian GNU/Linux"
-NAME="Debian GNU/Linux"
-VERSION_ID="8"
-VERSION="8 (jessie)"
-ID=debian
-HOME_URL="http://www.debian.org/"
-SUPPORT_URL="http://www.debian.org/support"
-BUG_REPORT_URL="https://bugs.debian.org/"`)
-
 var jessieIssue []byte = []byte(`Debian GNU/Linux 8 \n \l`)
-
-var jessieIssueBad []byte = []byte(`Debian GNU/Linux \n \l`)
 
 var stretchOSRelease []byte = []byte(`PRETTY_NAME="Debian GNU/Linux 9 (stretch)"
 NAME="Debian GNU/Linux"
@@ -63,19 +40,7 @@ HOME_URL="https://www.debian.org/"
 SUPPORT_URL="https://www.debian.org/support"
 BUG_REPORT_URL="https://bugs.debian.org/"`)
 
-var stretchOSReleaseBad []byte = []byte(`PRETTY_NAME="Debian GNU/Linux"
-NAME="Debian GNU/Linux"
-VERSION_ID="9"
-VERSION="9 (stretch)"
-VERSION_CODENAME=stretch
-ID=debian
-HOME_URL="https://www.debian.org/"
-SUPPORT_URL="https://www.debian.org/support"
-BUG_REPORT_URL="https://bugs.debian.org/"`)
-
 var stretchIssue []byte = []byte(`Debian GNU/Linux 9 \n \l`)
-
-var stretchIssueBad []byte = []byte(`Debian GNU/Linux`)
 
 var wheezyOSRelease []byte = []byte(`PRETTY_NAME="Debian GNU/Linux 7 (wheezy)"
 NAME="Debian GNU/Linux"
@@ -87,19 +52,7 @@ HOME_URL="http://www.debian.org/"
 SUPPORT_URL="http://www.debian.org/support/"
 BUG_REPORT_URL="http://bugs.debian.org/"`)
 
-var wheezyOSReleaseBad []byte = []byte(`PRETTY_NAME="Debian GNU/Linux"
-NAME="Debian GNU/Linux"
-VERSION_ID="7"
-VERSION="7 (wheezy)"
-ID=debian
-ANSI_COLOR="1;31"
-HOME_URL="http://www.debian.org/"
-SUPPORT_URL="http://www.debian.org/support/"
-BUG_REPORT_URL="http://bugs.debian.org/"`)
-
 var wheezyIssue []byte = []byte(`Debian GNU/Linux 7 \n \l`)
-
-var wheezyIssueBad []byte = []byte(`Debian GNU/Linux`)
 
 func TestDistributionScanner(t *testing.T) {
 	table := []struct {
@@ -143,53 +96,6 @@ func TestDistributionScanner(t *testing.T) {
 			dist = scanner.parse(bytes.NewBuffer(tt.issue))
 			if !cmp.Equal(dist, releaseToDist(tt.release)) {
 				t.Fatalf("%v", cmp.Diff(dist, releaseToDist(tt.release)))
-			}
-		})
-	}
-}
-
-func TestDistributionScannerBad(t *testing.T) {
-	table := []struct {
-		name      string
-		release   Release
-		osRelease []byte
-		issue     []byte
-	}{
-		{
-			name:      "buster",
-			release:   Buster,
-			osRelease: busterOSReleaseBad,
-			issue:     busterIssueBad,
-		},
-		{
-			name:      "jessie",
-			release:   Jessie,
-			osRelease: jessieOSReleaseBad,
-			issue:     jessieIssueBad,
-		},
-		{
-			name:      "stretch",
-			release:   Stretch,
-			osRelease: stretchOSReleaseBad,
-			issue:     stretchIssueBad,
-		},
-		{
-			name:      "wheezy",
-			release:   Wheezy,
-			osRelease: wheezyOSReleaseBad,
-			issue:     wheezyIssueBad,
-		},
-	}
-	for _, tt := range table {
-		t.Run(tt.name, func(t *testing.T) {
-			scanner := DistributionScanner{}
-			dist := scanner.parse(bytes.NewBuffer(tt.osRelease))
-			if dist != nil {
-				t.Fatalf("expected dist to be nil but got: %v", dist)
-			}
-			dist = scanner.parse(bytes.NewBuffer(tt.issue))
-			if dist != nil {
-				t.Fatalf("expected dist to be nil but got: %v", dist)
 			}
 		})
 	}

--- a/oracle/distributionscanner.go
+++ b/oracle/distributionscanner.go
@@ -77,10 +77,8 @@ func (*DistributionScanner) Kind() string { return scannerKind }
 func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]*claircore.Distribution, error) {
 	defer trace.StartRegion(ctx, "Scanner.Scan").End()
 	log := zerolog.Ctx(ctx).With().
-		Str("component", "oracle_dist_scanner").
-		Str("name", ds.Name()).
+		Str("component", "oracle/DistributionScanner.Scan").
 		Str("version", ds.Version()).
-		Str("kind", ds.Kind()).
 		Str("layer", l.Hash).
 		Logger()
 	log.Debug().Msg("start")

--- a/oracle/distributionscanner.go
+++ b/oracle/distributionscanner.go
@@ -11,11 +11,11 @@ import (
 	"github.com/rs/zerolog"
 )
 
-// Oracle Linux does provide sub major releases such as 7.7 and 6.10
+// Oracle Linux has minor releases such as 7.7 and 6.10
 // however their elsa OVAL xml sec db always references the major release
 // for example: <platform>Oracle Linux 5</platform>
 // for this reason the oracle distribution scanner will detect and normalize
-// sub releases to major releases to match vulnerabilities correctly
+// minor releases to major releases to match vulnerabilities correctly
 
 const (
 	scannerName    = "oracle"

--- a/oracle/distributionscanner_test.go
+++ b/oracle/distributionscanner_test.go
@@ -26,25 +26,6 @@ ORACLE_BUGZILLA_PRODUCT_VERSION=8.0
 ORACLE_SUPPORT_PRODUCT="Oracle Linux"
 ORACLE_SUPPORT_PRODUCT_VERSION=8.0`)
 
-var eightOSReleaseBad []byte = []byte(`NAME="Oracle Linux Server"
-VERSION="8.0"
-ID="ol"
-ID_LIKE="fedora"
-VARIANT="Server"
-VARIANT_ID="server"
-VERSION_ID="8.0"
-PLATFORM_ID="platform:el8"
-PRETTY_NAME="Oracle Linux Server"
-ANSI_COLOR="0;31"
-CPE_NAME="cpe:/o:oracle:linux:8:0:server"
-HOME_URL="https://linux.oracle.com/"
-BUG_REPORT_URL="https://bugzilla.oracle.com/"
-
-ORACLE_BUGZILLA_PRODUCT="Oracle Linux 8"
-ORACLE_BUGZILLA_PRODUCT_VERSION=8.0
-ORACLE_SUPPORT_PRODUCT="Oracle Linux"
-ORACLE_SUPPORT_PRODUCT_VERSION=8.0`)
-
 var sevenOSRelease []byte = []byte(`NAME="Oracle Linux Server"
 VERSION="7.7"
 ID="ol"
@@ -53,24 +34,6 @@ VARIANT="Server"
 VARIANT_ID="server"
 VERSION_ID="7.7"
 PRETTY_NAME="Oracle Linux Server 7.7"
-ANSI_COLOR="0;31"
-CPE_NAME="cpe:/o:oracle:linux:7:7:server"
-HOME_URL="https://linux.oracle.com/"
-BUG_REPORT_URL="https://bugzilla.oracle.com/"
-
-ORACLE_BUGZILLA_PRODUCT="Oracle Linux 7"
-ORACLE_BUGZILLA_PRODUCT_VERSION=7.7
-ORACLE_SUPPORT_PRODUCT="Oracle Linux"
-ORACLE_SUPPORT_PRODUCT_VERSION=7.7`)
-
-var sevenOSReleaseBad []byte = []byte(`NAME="Oracle Linux Server"
-VERSION="7.7"
-ID="ol"
-ID_LIKE="fedora"
-VARIANT="Server"
-VARIANT_ID="server"
-VERSION_ID="7.7"
-PRETTY_NAME="Oracle Linux Server"
 ANSI_COLOR="0;31"
 CPE_NAME="cpe:/o:oracle:linux:7:7:server"
 HOME_URL="https://linux.oracle.com/"
@@ -96,29 +59,9 @@ ORACLE_BUGZILLA_PRODUCT_VERSION=6.10
 ORACLE_SUPPORT_PRODUCT="Oracle Linux"
 ORACLE_SUPPORT_PRODUCT_VERSION=6.10`)
 
-var sixOSReleaseBad []byte = []byte(`NAME="Oracle Linux Server"
-VERSION="6.10"
-ID="ol"
-VERSION_ID="6.10"
-PRETTY_NAME="Oracle Linux Server"
-ANSI_COLOR="0;31"
-CPE_NAME="cpe:/o:oracle:linux:6:10:server"
-HOME_URL="https://linux.oracle.com/"
-BUG_REPORT_URL="https://bugzilla.oracle.com/"
-
-ORACLE_BUGZILLA_PRODUCT="Oracle Linux 6"
-ORACLE_BUGZILLA_PRODUCT_VERSION=6.10
-ORACLE_SUPPORT_PRODUCT="Oracle Linux"
-ORACLE_SUPPORT_PRODUCT_VERSION=6.10`)
-
 // Oracle Five versions do not have os-release file and only have /etc/issue file
 var fiveIssue []byte = []byte(`
 Oracle Linux Server release 5.11
-Kernel \r on an \m
-`)
-
-var fiveIssueBad []byte = []byte(`
-Oracle Linux Server release
 Kernel \r on an \m
 `)
 
@@ -155,44 +98,6 @@ func TestDistributionScanner(t *testing.T) {
 			dist := scanner.parse(bytes.NewBuffer(tt.file))
 			if !cmp.Equal(dist, releaseToDist(tt.release)) {
 				t.Fatalf("%v", cmp.Diff(dist, releaseToDist(tt.release)))
-			}
-		})
-	}
-}
-
-func TestDistributionScannerBad(t *testing.T) {
-	table := []struct {
-		name    string
-		release Release
-		file    []byte
-	}{
-		{
-			name:    "8.0",
-			release: Eight,
-			file:    eightOSReleaseBad,
-		},
-		{
-			name:    "7.7",
-			release: Seven,
-			file:    sevenOSReleaseBad,
-		},
-		{
-			name:    "6.10",
-			release: Six,
-			file:    sixOSReleaseBad,
-		},
-		{
-			name:    "5.11",
-			release: Five,
-			file:    fiveIssueBad,
-		},
-	}
-	for _, tt := range table {
-		t.Run(tt.name, func(t *testing.T) {
-			scanner := DistributionScanner{}
-			dist := scanner.parse(bytes.NewBuffer(tt.file))
-			if dist != nil {
-				t.Fatalf("expected nil dist got %v", dist)
 			}
 		})
 	}

--- a/oracle/distributionscanner_test.go
+++ b/oracle/distributionscanner_test.go
@@ -1,0 +1,199 @@
+package oracle
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+var eightOSRelease []byte = []byte(`NAME="Oracle Linux Server"
+VERSION="8.0"
+ID="ol"
+ID_LIKE="fedora"
+VARIANT="Server"
+VARIANT_ID="server"
+VERSION_ID="8.0"
+PLATFORM_ID="platform:el8"
+PRETTY_NAME="Oracle Linux Server 8.0"
+ANSI_COLOR="0;31"
+CPE_NAME="cpe:/o:oracle:linux:8:0:server"
+HOME_URL="https://linux.oracle.com/"
+BUG_REPORT_URL="https://bugzilla.oracle.com/"
+
+ORACLE_BUGZILLA_PRODUCT="Oracle Linux 8"
+ORACLE_BUGZILLA_PRODUCT_VERSION=8.0
+ORACLE_SUPPORT_PRODUCT="Oracle Linux"
+ORACLE_SUPPORT_PRODUCT_VERSION=8.0`)
+
+var eightOSReleaseBad []byte = []byte(`NAME="Oracle Linux Server"
+VERSION="8.0"
+ID="ol"
+ID_LIKE="fedora"
+VARIANT="Server"
+VARIANT_ID="server"
+VERSION_ID="8.0"
+PLATFORM_ID="platform:el8"
+PRETTY_NAME="Oracle Linux Server"
+ANSI_COLOR="0;31"
+CPE_NAME="cpe:/o:oracle:linux:8:0:server"
+HOME_URL="https://linux.oracle.com/"
+BUG_REPORT_URL="https://bugzilla.oracle.com/"
+
+ORACLE_BUGZILLA_PRODUCT="Oracle Linux 8"
+ORACLE_BUGZILLA_PRODUCT_VERSION=8.0
+ORACLE_SUPPORT_PRODUCT="Oracle Linux"
+ORACLE_SUPPORT_PRODUCT_VERSION=8.0`)
+
+var sevenOSRelease []byte = []byte(`NAME="Oracle Linux Server"
+VERSION="7.7"
+ID="ol"
+ID_LIKE="fedora"
+VARIANT="Server"
+VARIANT_ID="server"
+VERSION_ID="7.7"
+PRETTY_NAME="Oracle Linux Server 7.7"
+ANSI_COLOR="0;31"
+CPE_NAME="cpe:/o:oracle:linux:7:7:server"
+HOME_URL="https://linux.oracle.com/"
+BUG_REPORT_URL="https://bugzilla.oracle.com/"
+
+ORACLE_BUGZILLA_PRODUCT="Oracle Linux 7"
+ORACLE_BUGZILLA_PRODUCT_VERSION=7.7
+ORACLE_SUPPORT_PRODUCT="Oracle Linux"
+ORACLE_SUPPORT_PRODUCT_VERSION=7.7`)
+
+var sevenOSReleaseBad []byte = []byte(`NAME="Oracle Linux Server"
+VERSION="7.7"
+ID="ol"
+ID_LIKE="fedora"
+VARIANT="Server"
+VARIANT_ID="server"
+VERSION_ID="7.7"
+PRETTY_NAME="Oracle Linux Server"
+ANSI_COLOR="0;31"
+CPE_NAME="cpe:/o:oracle:linux:7:7:server"
+HOME_URL="https://linux.oracle.com/"
+BUG_REPORT_URL="https://bugzilla.oracle.com/"
+
+ORACLE_BUGZILLA_PRODUCT="Oracle Linux 7"
+ORACLE_BUGZILLA_PRODUCT_VERSION=7.7
+ORACLE_SUPPORT_PRODUCT="Oracle Linux"
+ORACLE_SUPPORT_PRODUCT_VERSION=7.7`)
+
+var sixOSRelease []byte = []byte(`NAME="Oracle Linux Server"
+VERSION="6.10"
+ID="ol"
+VERSION_ID="6.10"
+PRETTY_NAME="Oracle Linux Server 6.10"
+ANSI_COLOR="0;31"
+CPE_NAME="cpe:/o:oracle:linux:6:10:server"
+HOME_URL="https://linux.oracle.com/"
+BUG_REPORT_URL="https://bugzilla.oracle.com/"
+
+ORACLE_BUGZILLA_PRODUCT="Oracle Linux 6"
+ORACLE_BUGZILLA_PRODUCT_VERSION=6.10
+ORACLE_SUPPORT_PRODUCT="Oracle Linux"
+ORACLE_SUPPORT_PRODUCT_VERSION=6.10`)
+
+var sixOSReleaseBad []byte = []byte(`NAME="Oracle Linux Server"
+VERSION="6.10"
+ID="ol"
+VERSION_ID="6.10"
+PRETTY_NAME="Oracle Linux Server"
+ANSI_COLOR="0;31"
+CPE_NAME="cpe:/o:oracle:linux:6:10:server"
+HOME_URL="https://linux.oracle.com/"
+BUG_REPORT_URL="https://bugzilla.oracle.com/"
+
+ORACLE_BUGZILLA_PRODUCT="Oracle Linux 6"
+ORACLE_BUGZILLA_PRODUCT_VERSION=6.10
+ORACLE_SUPPORT_PRODUCT="Oracle Linux"
+ORACLE_SUPPORT_PRODUCT_VERSION=6.10`)
+
+// Oracle Five versions do not have os-release file and only have /etc/issue file
+var fiveIssue []byte = []byte(`
+Oracle Linux Server release 5.11
+Kernel \r on an \m
+`)
+
+var fiveIssueBad []byte = []byte(`
+Oracle Linux Server release
+Kernel \r on an \m
+`)
+
+func TestDistributionScanner(t *testing.T) {
+	table := []struct {
+		name    string
+		release Release
+		file    []byte
+	}{
+		{
+			name:    "8.0",
+			release: Eight,
+			file:    eightOSRelease,
+		},
+		{
+			name:    "7.7",
+			release: Seven,
+			file:    sevenOSRelease,
+		},
+		{
+			name:    "6.10",
+			release: Six,
+			file:    sixOSRelease,
+		},
+		{
+			name:    "5.11",
+			release: Five,
+			file:    fiveIssue,
+		},
+	}
+	for _, tt := range table {
+		t.Run(tt.name, func(t *testing.T) {
+			scanner := DistributionScanner{}
+			dist := scanner.parse(bytes.NewBuffer(tt.file))
+			if !cmp.Equal(dist, releaseToDist(tt.release)) {
+				t.Fatalf("%v", cmp.Diff(dist, releaseToDist(tt.release)))
+			}
+		})
+	}
+}
+
+func TestDistributionScannerBad(t *testing.T) {
+	table := []struct {
+		name    string
+		release Release
+		file    []byte
+	}{
+		{
+			name:    "8.0",
+			release: Eight,
+			file:    eightOSReleaseBad,
+		},
+		{
+			name:    "7.7",
+			release: Seven,
+			file:    sevenOSReleaseBad,
+		},
+		{
+			name:    "6.10",
+			release: Six,
+			file:    sixOSReleaseBad,
+		},
+		{
+			name:    "5.11",
+			release: Five,
+			file:    fiveIssueBad,
+		},
+	}
+	for _, tt := range table {
+		t.Run(tt.name, func(t *testing.T) {
+			scanner := DistributionScanner{}
+			dist := scanner.parse(bytes.NewBuffer(tt.file))
+			if dist != nil {
+				t.Fatalf("expected nil dist got %v", dist)
+			}
+		})
+	}
+}

--- a/oracle/releases.go
+++ b/oracle/releases.go
@@ -2,11 +2,11 @@ package oracle
 
 import "github.com/quay/claircore"
 
-// Oracle Linux does provide sub major releases such as 7.7 and 6.10
+// Oracle Linux has minor releases such as 7.7 and 6.10
 // however their elsa OVAL xml sec db always references the major release
 // for example: <platform>Oracle Linux 5</platform>
 // for this reason the oracle distribution scanner will detect and normalize
-// sub releases to major releases to match vulnerabilities correctly
+// minor releases to major releases to match vulnerabilities correctly
 
 type Release string
 
@@ -16,21 +16,6 @@ const (
 	Six   Release = "6"
 	Five  Release = "5"
 )
-
-// NAME="Oracle Linux Server"
-// VERSION="6.9"
-// ID="ol"
-// VERSION_ID="6.9"
-// PRETTY_NAME="Oracle Linux Server 6.9"
-// ANSI_COLOR="0;31"
-// CPE_NAME="cpe:/o:oracle:linux:6:9:server"
-// HOME_URL="https://linux.oracle.com/"
-// BUG_REPORT_URL="https://bugzilla.oracle.com/"
-
-// ORACLE_BUGZILLA_PRODUCT="Oracle Linux 6"
-// ORACLE_BUGZILLA_PRODUCT_VERSION=6.9
-// ORACLE_SUPPORT_PRODUCT="Oracle Linux"
-// ORACLE_SUPPORT_PRODUCT_VERSION=6.9
 
 var eightDist = &claircore.Distribution{
 	Name:            "Oracle Linux Server",

--- a/oracle/releases.go
+++ b/oracle/releases.go
@@ -1,0 +1,85 @@
+package oracle
+
+import "github.com/quay/claircore"
+
+// Oracle Linux does provide sub major releases such as 7.7 and 6.10
+// however their elsa OVAL xml sec db always references the major release
+// for example: <platform>Oracle Linux 5</platform>
+// for this reason the oracle distribution scanner will detect and normalize
+// sub releases to major releases to match vulnerabilities correctly
+
+type Release string
+
+const (
+	Eight Release = "8"
+	Seven Release = "7"
+	Six   Release = "6"
+	Five  Release = "5"
+)
+
+// NAME="Oracle Linux Server"
+// VERSION="6.9"
+// ID="ol"
+// VERSION_ID="6.9"
+// PRETTY_NAME="Oracle Linux Server 6.9"
+// ANSI_COLOR="0;31"
+// CPE_NAME="cpe:/o:oracle:linux:6:9:server"
+// HOME_URL="https://linux.oracle.com/"
+// BUG_REPORT_URL="https://bugzilla.oracle.com/"
+
+// ORACLE_BUGZILLA_PRODUCT="Oracle Linux 6"
+// ORACLE_BUGZILLA_PRODUCT_VERSION=6.9
+// ORACLE_SUPPORT_PRODUCT="Oracle Linux"
+// ORACLE_SUPPORT_PRODUCT_VERSION=6.9
+
+var eightDist = &claircore.Distribution{
+	Name:            "Oracle Linux Server",
+	Version:         "8",
+	DID:             "ol",
+	PrettyName:      "Oracle Linux Server 8",
+	VersionID:       "8",
+	VersionCodeName: "Oracle Linux 8",
+}
+
+var sevenDist = &claircore.Distribution{
+	Name:            "Oracle Linux Server",
+	Version:         "7",
+	DID:             "ol",
+	PrettyName:      "Oracle Linux Server 7",
+	VersionID:       "7",
+	VersionCodeName: "Oracle Linux 7",
+}
+
+var sixDist = &claircore.Distribution{
+	Name:            "Oracle Linux Server",
+	Version:         "6",
+	DID:             "ol",
+	PrettyName:      "Oracle Linux Server 6",
+	VersionID:       "6",
+	VersionCodeName: "Oracle Linux 6",
+}
+
+var fiveDist = &claircore.Distribution{
+	Name:            "Oracle Linux Server",
+	Version:         "5",
+	DID:             "ol",
+	PrettyName:      "Oracle Linux Server 5",
+	VersionID:       "5",
+	VersionCodeName: "Oracle Linux 5",
+}
+
+func releaseToDist(r Release) *claircore.Distribution {
+	switch r {
+	case Eight:
+		return eightDist
+	case Seven:
+		return sevenDist
+	case Six:
+		return sixDist
+	case Five:
+		return fiveDist
+	default:
+		// return empty dist
+		return &claircore.Distribution{}
+	}
+}

--- a/rhel/distributionscanner.go
+++ b/rhel/distributionscanner.go
@@ -81,10 +81,8 @@ func (*DistributionScanner) Kind() string { return scannerKind }
 func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]*claircore.Distribution, error) {
 	defer trace.StartRegion(ctx, "Scanner.Scan").End()
 	log := zerolog.Ctx(ctx).With().
-		Str("component", "rhel_dist_scanner").
-		Str("name", ds.Name()).
+		Str("component", "rhel/DistributionScanner.Scan").
 		Str("version", ds.Version()).
-		Str("kind", ds.Kind()).
 		Str("layer", l.Hash).
 		Logger()
 	log.Debug().Msg("start")

--- a/rhel/distributionscanner.go
+++ b/rhel/distributionscanner.go
@@ -1,0 +1,117 @@
+package rhel
+
+import (
+	"bytes"
+	"context"
+	"regexp"
+	"runtime/trace"
+
+	"github.com/quay/claircore"
+	"github.com/quay/claircore/internal/indexer"
+	"github.com/rs/zerolog"
+)
+
+const osReleasePath = `etc/os-release`
+const rhReleasePath = `etc/redhat-release`
+
+const (
+	scannerName    = "rhel"
+	scannerVersion = "v0.0.1"
+	scannerKind    = "distribution"
+)
+
+type rhelRegex struct {
+	release Release
+	regexp  *regexp.Regexp
+}
+
+// the follow set of regexps will match both the PrettyName in the os-releaes file
+// ex: Red Hat Enterprise Linux Server 7.7 (Maipo)
+// and the release string in the redhat-release
+// ex: Red Hat Enterprise Linux Server release 7.7 (Maipo)
+var rhelRegexes = []rhelRegex{
+	{
+		release: RHEL3,
+		// regex for /etc/issue
+		regexp: regexp.MustCompile(`Red Hat Enterprise Linux (Server)?\s*(release)?\s*3(\.\d)?`),
+	},
+	{
+		release: RHEL4,
+		regexp:  regexp.MustCompile(`Red Hat Enterprise Linux (Server)?\s*(release)?\s*4(\.\d)?`),
+	},
+	{
+		release: RHEL5,
+		regexp:  regexp.MustCompile(`Red Hat Enterprise Linux (Server)?\s*(release)?\s*5(\.\d)?`),
+	},
+	{
+		release: RHEL6,
+		regexp:  regexp.MustCompile(`Red Hat Enterprise Linux (Server)?\s*(release)?\s*6(\.\d)?`),
+	},
+	{
+		release: RHEL7,
+		regexp:  regexp.MustCompile(`Red Hat Enterprise Linux (Server)?\s*(release)?\s*7(\.\d)?`),
+	},
+	{
+		release: RHEL8,
+		regexp:  regexp.MustCompile(`Red Hat Enterprise Linux (Server)?\s*(release)?\s*8(\.\d)?`),
+	},
+}
+
+var _ indexer.DistributionScanner = (*DistributionScanner)(nil)
+var _ indexer.VersionedScanner = (*DistributionScanner)(nil)
+
+// DistributionScanner attempts to discover if a layer
+// displays characteristics of a Oracle distribution
+type DistributionScanner struct{}
+
+// Name implements scanner.VersionedScanner.
+func (*DistributionScanner) Name() string { return scannerName }
+
+// Version implements scanner.VersionedScanner.
+func (*DistributionScanner) Version() string { return scannerVersion }
+
+// Kind implements scanner.VersionedScanner.
+func (*DistributionScanner) Kind() string { return scannerKind }
+
+// Scan will inspect the layer for an os-release or lsb-release file
+// and perform a regex match for keywords indicating the associated Oracle release
+//
+// If neither file is found a (nil,nil) is returned.
+// If the files are found but all regexp fail to match an empty distribution is returned.
+func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]*claircore.Distribution, error) {
+	defer trace.StartRegion(ctx, "Scanner.Scan").End()
+	log := zerolog.Ctx(ctx).With().
+		Str("component", "rhel_dist_scanner").
+		Str("name", ds.Name()).
+		Str("version", ds.Version()).
+		Str("kind", ds.Kind()).
+		Str("layer", l.Hash).
+		Logger()
+	log.Debug().Msg("start")
+	defer log.Debug().Msg("done")
+	files, err := l.Files(osReleasePath, rhReleasePath)
+	if err != nil {
+		log.Debug().Msg("didn't find an os-release or redhat-release file")
+		return nil, nil
+	}
+	for _, buff := range files {
+		dist := ds.parse(buff)
+		if dist != nil {
+			return []*claircore.Distribution{dist}, nil
+		}
+	}
+	return []*claircore.Distribution{&claircore.Distribution{}}, nil
+}
+
+// parse attempts to match all Oracle release regexp and returns the associated
+// distribution if it exists.
+//
+// separated to it's own method to aide testing.
+func (ds *DistributionScanner) parse(buff *bytes.Buffer) *claircore.Distribution {
+	for _, ur := range rhelRegexes {
+		if ur.regexp.Match(buff.Bytes()) {
+			return releaseToDist(ur.release)
+		}
+	}
+	return nil
+}

--- a/rhel/distributionscanner_test.go
+++ b/rhel/distributionscanner_test.go
@@ -1,0 +1,106 @@
+package rhel
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+var rhel3RHRelease []byte = []byte(`Red Hat Enterprise Linux Server release 3.1 (Taroon)`)
+var rhel4RHRelease []byte = []byte(`Red Hat Enterprise Linux Server release 4.8 (Nahant)`)
+var rhel5RHRelease []byte = []byte(`Red Hat Enterprise Linux Server release 5.6 (Tikanga)`)
+var rhel6RHRelease []byte = []byte(`Red Hat Enterprise Linux Server release 6.10 (Santiago)`)
+var rhel7RHRelease []byte = []byte(`Red Hat Enterprise Linux Server release 7.4 (Maipo)`)
+var rhel7OSRelease []byte = []byte(`NAME="Red Hat Enterprise Linux Server"
+VERSION="7.7 (Maipo)"
+ID="rhel"
+ID_LIKE="fedora"
+VARIANT="Server"
+VARIANT_ID="server"
+VERSION_ID="7.7"
+PRETTY_NAME="Red Hat Enterprise Linux Server 7.7 (Maipo)"
+ANSI_COLOR="0;31"
+CPE_NAME="cpe:/o:redhat:enterprise_linux:7.7:GA:server"
+HOME_URL="https://www.redhat.com/"
+BUG_REPORT_URL="https://bugzilla.redhat.com/"
+
+REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 7"
+REDHAT_BUGZILLA_PRODUCT_VERSION=7.7
+REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
+REDHAT_SUPPORT_PRODUCT_VERSION="7.7"`)
+var rhel8RHRelease []byte = []byte(`Red Hat Enterprise Linux Server release 8.1 (Ootpa)`)
+var rhel8OSRelease []byte = []byte(`NAME="Red Hat Enterprise Linux"
+VERSION="8.1 (Ootpa)"
+ID="rhel"
+ID_LIKE="fedora"
+VERSION_ID="8.1"
+PLATFORM_ID="platform:el8"
+PRETTY_NAME="Red Hat Enterprise Linux 8.1 (Ootpa)"
+ANSI_COLOR="0;31"
+CPE_NAME="cpe:/o:redhat:enterprise_linux:8.1:GA"
+HOME_URL="https://www.redhat.com/"
+BUG_REPORT_URL="https://bugzilla.redhat.com/"
+
+REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 8"
+REDHAT_BUGZILLA_PRODUCT_VERSION=8.1
+REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
+REDHAT_SUPPORT_PRODUCT_VERSION="8.1"`)
+
+func TestDistributionScanner(t *testing.T) {
+	table := []struct {
+		name    string
+		release Release
+		file    []byte
+	}{
+		{
+			name:    "RHEL3",
+			release: RHEL3,
+			file:    rhel3RHRelease,
+		},
+		{
+			name:    "RHEL4",
+			release: RHEL4,
+			file:    rhel4RHRelease,
+		},
+		{
+			name:    "RHEL5",
+			release: RHEL5,
+			file:    rhel5RHRelease,
+		},
+		{
+			name:    "RHEL6",
+			release: RHEL6,
+			file:    rhel6RHRelease,
+		},
+		{
+			name:    "RHEL7",
+			release: RHEL7,
+			file:    rhel7RHRelease,
+		},
+		{
+			name:    "RHEL7 OSRelease",
+			release: RHEL7,
+			file:    rhel7OSRelease,
+		},
+		{
+			name:    "RHEL8",
+			release: RHEL8,
+			file:    rhel8RHRelease,
+		},
+		{
+			name:    "RHEL8 OSRelease",
+			release: RHEL8,
+			file:    rhel8OSRelease,
+		},
+	}
+	for _, tt := range table {
+		t.Run(tt.name, func(t *testing.T) {
+			scanner := DistributionScanner{}
+			dist := scanner.parse(bytes.NewBuffer(tt.file))
+			if !cmp.Equal(dist, releaseToDist(tt.release)) {
+				t.Fatalf("%v", cmp.Diff(dist, releaseToDist(tt.release)))
+			}
+		})
+	}
+}

--- a/rhel/releases.go
+++ b/rhel/releases.go
@@ -2,7 +2,7 @@ package rhel
 
 import "github.com/quay/claircore"
 
-// RHEL has sub major releases however their security database files are bundled together
+// RHEL has minor releases however their security database files are bundled together
 // by major version. for example `com.redhat.rhsa-RHEL7.xml`
 // we choose to normalize detected distributions into major releases and parse vulnerabilities by major release versions.
 

--- a/rhel/releases.go
+++ b/rhel/releases.go
@@ -1,0 +1,87 @@
+package rhel
+
+import "github.com/quay/claircore"
+
+// RHEL has sub major releases however their security database files are bundled together
+// by major version. for example `com.redhat.rhsa-RHEL7.xml`
+// we choose to normalize detected distributions into major releases and parse vulnerabilities by major release versions.
+
+type Release int
+
+const (
+	RHEL3 Release = 3
+	RHEL4 Release = 4
+	RHEL5 Release = 5
+	RHEL6 Release = 6
+	RHEL7 Release = 7
+	RHEL8 Release = 8
+)
+
+var rhel3Dist = &claircore.Distribution{
+	Name:       "Red Hat Enterprise Linux Server",
+	Version:    "3",
+	VersionID:  "3",
+	DID:        "rhel",
+	PrettyName: "Red Hat Enterprise Linux Server 3",
+	CPE:        "cpe:/o:redhat:enterprise_linux:3",
+}
+var rhel4Dist = &claircore.Distribution{
+	Name:       "Red Hat Enterprise Linux Server",
+	Version:    "4",
+	VersionID:  "4",
+	DID:        "rhel",
+	PrettyName: "Red Hat Enterprise Linux Server 4",
+	CPE:        "cpe:/o:redhat:enterprise_linux:4",
+}
+var rhel5Dist = &claircore.Distribution{
+	Name:       "Red Hat Enterprise Linux Server",
+	Version:    "5",
+	VersionID:  "5",
+	DID:        "rhel",
+	PrettyName: "Red Hat Enterprise Linux Server 5",
+	CPE:        "cpe:/o:redhat:enterprise_linux:5",
+}
+var rhel6Dist = &claircore.Distribution{
+	Name:       "Red Hat Enterprise Linux Server",
+	Version:    "6",
+	VersionID:  "6",
+	DID:        "rhel",
+	PrettyName: "Red Hat Enterprise Linux Server 6",
+	CPE:        "cpe:/o:redhat:enterprise_linux:6",
+}
+var rhel7Dist = &claircore.Distribution{
+	Name:       "Red Hat Enterprise Linux Server",
+	Version:    "7",
+	VersionID:  "7",
+	DID:        "rhel",
+	PrettyName: "Red Hat Enterprise Linux Server 7",
+	CPE:        "cpe:/o:redhat:enterprise_linux:7",
+}
+var rhel8Dist = &claircore.Distribution{
+	Name:       "Red Hat Enterprise Linux Server",
+	Version:    "8",
+	VersionID:  "8",
+	DID:        "rhel",
+	PrettyName: "Red Hat Enterprise Linux Server 8",
+	CPE:        "cpe:/o:redhat:enterprise_linux:8",
+}
+
+func releaseToDist(r Release) *claircore.Distribution {
+	switch r {
+	case RHEL3:
+		return rhel3Dist
+	case RHEL4:
+		return rhel4Dist
+	case RHEL5:
+		return rhel5Dist
+	case RHEL6:
+		return rhel6Dist
+	case RHEL7:
+		return rhel7Dist
+	case RHEL8:
+		return rhel8Dist
+	default:
+		// return empty dist
+		return &claircore.Distribution{}
+	}
+}

--- a/rhel/rhel.go
+++ b/rhel/rhel.go
@@ -26,17 +26,6 @@ type Updater struct {
 	name             string
 }
 
-type Release int
-
-const (
-	RHEL3 Release = 3
-	RHEL4 Release = 4
-	RHEL5 Release = 5
-	RHEL6 Release = 6
-	RHEL7 Release = 7
-	RHEL8 Release = 8
-)
-
 // NewUpdater returns an Updater.
 func NewUpdater(v Release, opt ...Option) (*Updater, error) {
 	u := &Updater{

--- a/suse/distributionscanner.go
+++ b/suse/distributionscanner.go
@@ -83,10 +83,8 @@ func (*DistributionScanner) Kind() string { return scannerKind }
 func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]*claircore.Distribution, error) {
 	defer trace.StartRegion(ctx, "Scanner.Scan").End()
 	log := zerolog.Ctx(ctx).With().
-		Str("component", "suse_dist_scanner").
-		Str("name", ds.Name()).
+		Str("component", "suse/DistributionScanner.Scan").
 		Str("version", ds.Version()).
-		Str("kind", ds.Kind()).
 		Str("layer", l.Hash).
 		Logger()
 	log.Debug().Msg("start")

--- a/suse/distributionscanner.go
+++ b/suse/distributionscanner.go
@@ -1,0 +1,119 @@
+package suse
+
+import (
+	"bytes"
+	"context"
+	"regexp"
+	"runtime/trace"
+
+	"github.com/quay/claircore"
+	"github.com/quay/claircore/internal/indexer"
+	"github.com/rs/zerolog"
+)
+
+// Suse Enterprise Server has service pack releases however their security database files are bundled together
+// by major version. for example `SUSE Linux Enterprise Server 15 (all Service Packs) - suse.linux.enterprise.server.15.xml`
+// we choose to normalize detected distributions into major releases and parse vulnerabilities by major release versions.
+//
+// Suse Leap has well defined sub releases and their sec db's match up fine.
+
+const (
+	scannerName    = "suse"
+	scannerVersion = "v0.0.1"
+	scannerKind    = "distribution"
+)
+
+const osReleasePath = `etc/os-release`
+const suseReleasePath = `etc/SuSE-release`
+
+type suseRegex struct {
+	release Release
+	regexp  *regexp.Regexp
+}
+
+var suseRegexes = []suseRegex{
+	{
+		release: EnterpriseServer15,
+		// regex for /etc/issue
+		regexp: regexp.MustCompile(`(?i)SUSE Linux Enterprise Server 15`),
+	},
+	{
+		release: EnterpriseServer12,
+		regexp:  regexp.MustCompile(`(?i)SUSE Linux Enterprise Server 12`),
+	},
+	{
+		release: EnterpriseServer11,
+		regexp:  regexp.MustCompile(`(?i)SUSE Linux Enterprise Server 11`),
+	},
+	{
+		release: Leap151,
+		regexp:  regexp.MustCompile(`(?i)openSUSE Leap 15.1`),
+	},
+	{
+		release: Leap150,
+		regexp:  regexp.MustCompile(`(?i)openSUSE Leap 15.0`),
+	},
+	{
+		release: Leap423,
+		regexp:  regexp.MustCompile(`(?i)openSUSE Leap 42.3`),
+	},
+}
+
+var _ indexer.DistributionScanner = (*DistributionScanner)(nil)
+var _ indexer.VersionedScanner = (*DistributionScanner)(nil)
+
+// DistributionScanner attempts to discover if a layer
+// displays characteristics of a Suse distribution
+type DistributionScanner struct{}
+
+// Name implements scanner.VersionedScanner.
+func (*DistributionScanner) Name() string { return scannerName }
+
+// Version implements scanner.VersionedScanner.
+func (*DistributionScanner) Version() string { return scannerVersion }
+
+// Kind implements scanner.VersionedScanner.
+func (*DistributionScanner) Kind() string { return scannerKind }
+
+// Scan will inspect the layer for an os-release or lsb-release file
+// and perform a regex match for keywords indicating the associated Suse release
+//
+// If neither file is found a (nil,nil) is returned.
+// If the files are found but all regexp fail to match an empty distribution is returned.
+func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]*claircore.Distribution, error) {
+	defer trace.StartRegion(ctx, "Scanner.Scan").End()
+	log := zerolog.Ctx(ctx).With().
+		Str("component", "suse_dist_scanner").
+		Str("name", ds.Name()).
+		Str("version", ds.Version()).
+		Str("kind", ds.Kind()).
+		Str("layer", l.Hash).
+		Logger()
+	log.Debug().Msg("start")
+	defer log.Debug().Msg("done")
+	files, err := l.Files(osReleasePath, suseReleasePath)
+	if err != nil {
+		log.Debug().Msg("didn't find an os-release or SuSE-release")
+		return nil, nil
+	}
+	for _, buff := range files {
+		dist := ds.parse(buff)
+		if dist != nil {
+			return []*claircore.Distribution{dist}, nil
+		}
+	}
+	return []*claircore.Distribution{&claircore.Distribution{}}, nil
+}
+
+// parse attempts to match all Suse release regexp and returns the associated
+// distribution if it exists.
+//
+// separated to it's own method to aide testing.
+func (ds *DistributionScanner) parse(buff *bytes.Buffer) *claircore.Distribution {
+	for _, ur := range suseRegexes {
+		if ur.regexp.Match(buff.Bytes()) {
+			return releaseToDist(ur.release)
+		}
+	}
+	return nil
+}

--- a/suse/distributionscanner_test.go
+++ b/suse/distributionscanner_test.go
@@ -1,0 +1,114 @@
+package suse
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+var enterpriseServer15OSRelease []byte = []byte(`NAME="SLES"
+VERSION="15-SP1"
+VERSION_ID="15.1"
+PRETTY_NAME="SUSE Linux Enterprise Server 15 SP1"
+ID="sles"
+ID_LIKE="suse"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:suse:sles:15:sp1"`)
+
+var enterpriseServer12OSRelase []byte = []byte(`NAME="SLES"
+VERSION="12-SP5"
+VERSION_ID="12.5"
+PRETTY_NAME="SUSE Linux Enterprise Server 12 SP5"
+ID="sles"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:suse:sles:12:sp5"`)
+
+var enterpriseServer11OSRelease []byte = []byte(`NAME="SLES"
+VERSION="11-SP5"
+VERSION_ID="11.2"
+PRETTY_NAME="SUSE Linux Enterprise Server 11 SP5"
+ID="sles"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:suse:sles:12:sp5"`)
+
+var leap151OSRelease []byte = []byte(`NAME="openSUSE Leap"
+VERSION="15.1"
+ID="opensuse-leap"
+ID_LIKE="suse opensuse"
+VERSION_ID="15.1"
+PRETTY_NAME="openSUSE Leap 15.1"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:opensuse:leap:15.1"
+BUG_REPORT_URL="https://bugs.opensuse.org"
+HOME_URL="https://www.opensuse.org/"`)
+
+var leap15OSRelease []byte = []byte(`NAME="openSUSE Leap"
+VERSION="15.0"
+ID="opensuse-leap"
+ID_LIKE="suse opensuse"
+VERSION_ID="15.0"
+PRETTY_NAME="openSUSE Leap 15.0"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:opensuse:leap:15.0"
+BUG_REPORT_URL="https://bugs.opensuse.org"
+HOME_URL="https://www.opensuse.org/"`)
+
+var leap423OSRelease []byte = []byte(`NAME="openSUSE Leap"
+VERSION="42.3"
+ID=opensuse
+ID_LIKE="suse"
+VERSION_ID="42.3"
+PRETTY_NAME="openSUSE Leap 42.3"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:opensuse:leap:42.3"
+BUG_REPORT_URL="https://bugs.opensuse.org"
+HOME_URL="https://www.opensuse.org/"`)
+
+func TestDistributionScanner(t *testing.T) {
+	table := []struct {
+		name      string
+		release   Release
+		osRelease []byte
+	}{
+		{
+			name:      "enterprise server 15",
+			release:   EnterpriseServer15,
+			osRelease: enterpriseServer15OSRelease,
+		},
+		{
+			name:      "enterprise server 12",
+			release:   EnterpriseServer12,
+			osRelease: enterpriseServer12OSRelase,
+		},
+		{
+			name:      "enterprise server 11",
+			release:   EnterpriseServer11,
+			osRelease: enterpriseServer11OSRelease,
+		},
+		{
+			name:      "leap 15.0",
+			release:   Leap150,
+			osRelease: leap15OSRelease,
+		},
+		{
+			name:      "leap 15.1",
+			release:   Leap151,
+			osRelease: leap151OSRelease,
+		},
+		{
+			name:      "leap 42.3",
+			release:   Leap423,
+			osRelease: leap423OSRelease,
+		},
+	}
+	for _, tt := range table {
+		t.Run(tt.name, func(t *testing.T) {
+			scanner := DistributionScanner{}
+			dist := scanner.parse(bytes.NewBuffer(tt.osRelease))
+			if !cmp.Equal(dist, releaseToDist(tt.release)) {
+				t.Fatalf("%v", cmp.Diff(dist, releaseToDist(tt.release)))
+			}
+		})
+	}
+}

--- a/suse/releases.go
+++ b/suse/releases.go
@@ -1,0 +1,96 @@
+package suse
+
+import "github.com/quay/claircore"
+
+// Suse has service pack releases however their security database files are bundled together
+// by major version. for example `SUSE Linux Enterprise Server 15 (all Service Packs) - suse.linux.enterprise.server.15.xml`
+// we choose to normalize detected distributions into major releases and parse vulnerabilities by major release versions.
+
+// Release indicates the SUSE release OVAL database to pull from.
+type Release string
+
+// These are some known Releases.
+const (
+	EnterpriseServer15  Release = `suse.linux.enterprise.server.15`
+	EnterpriseDesktop15 Release = `suse.linux.enterprise.desktop.15`
+	Enterprise15        Release = `suse.linux.enterprise.15`
+	EnterpriseServer12  Release = `suse.linux.enterprise.server.12`
+	EnterpriseDesktop12 Release = `suse.linux.enterprise.desktop.12`
+	Enterprise12        Release = `suse.linux.enterprise.12`
+	EnterpriseServer11  Release = `suse.linux.enterprise.server.11`
+	EnterpriseDesktop11 Release = `suse.linux.enterprise.desktop.11`
+	OpenStackCloud9     Release = `suse.openstack.cloud.9`
+	OpenStackCloud8     Release = `suse.openstack.cloud.8`
+	OpenStackCloud7     Release = `suse.openstack.cloud.7`
+	Leap151             Release = `opensuse.leap.15.1`
+	Leap150             Release = `opensuse.leap.15.0`
+	Leap423             Release = `opensuse.leap.42.3`
+)
+
+var enterpriseServer15Dist = &claircore.Distribution{
+	Name:       "SLES",
+	Version:    "15",
+	VersionID:  "15",
+	PrettyName: "SUSE Linux Enterprise Server 15",
+	DID:        "sles",
+}
+
+var enterpriseServer12Dist = &claircore.Distribution{
+	Name:       "SLES",
+	Version:    "12",
+	VersionID:  "12",
+	PrettyName: "SUSE Linux Enterprise Server 12",
+	DID:        "sles",
+}
+
+var enterpriseServer11Dist = &claircore.Distribution{
+	Name:       "SLES",
+	Version:    "11",
+	VersionID:  "11",
+	PrettyName: "SUSE Linux Enterprise Server 11",
+	DID:        "sles",
+}
+
+var leap151Dist = &claircore.Distribution{
+	Name:       "openSUSE Leap",
+	Version:    "15.1",
+	DID:        "opensuse-leap",
+	VersionID:  "15.1",
+	PrettyName: "openSUSE Leap 15.1",
+}
+
+var leap15Dist = &claircore.Distribution{
+	Name:       "openSUSE Leap",
+	Version:    "15.0",
+	DID:        "opensuse-leap",
+	VersionID:  "15.0",
+	PrettyName: "openSUSE Leap 15.0",
+}
+
+var leap423Dist = &claircore.Distribution{
+	Name:       "openSUSE Leap",
+	Version:    "42.3",
+	DID:        "opensuse",
+	VersionID:  "42.3",
+	PrettyName: "openSUSE Leap 42.3",
+}
+
+func releaseToDist(r Release) *claircore.Distribution {
+	switch r {
+	case EnterpriseServer15:
+		return enterpriseServer15Dist
+	case EnterpriseServer12:
+		return enterpriseServer12Dist
+	case EnterpriseServer11:
+		return enterpriseServer11Dist
+	case Leap150:
+		return leap15Dist
+	case Leap151:
+		return leap151Dist
+	case Leap423:
+		return leap423Dist
+	default:
+		// return empty dist
+		return &claircore.Distribution{}
+	}
+}

--- a/suse/suse.go
+++ b/suse/suse.go
@@ -16,27 +16,6 @@ import (
 	"github.com/quay/claircore/pkg/ovalutil"
 )
 
-// Release indicates the SUSE release OVAL database to pull from.
-type Release string
-
-// These are some known Releases.
-const (
-	EnterpriseServer15  Release = `suse.linux.enterprise.server.15`
-	EnterpriseDesktop15 Release = `suse.linux.enterprise.desktop.15`
-	Enterprise15        Release = `suse.linux.enterprise.15`
-	EnterpriseServer12  Release = `suse.linux.enterprise.server.12`
-	EnterpriseDesktop12 Release = `suse.linux.enterprise.desktop.12`
-	Enterprise12        Release = `suse.linux.enterprise.12`
-	EnterpriseServer11  Release = `suse.linux.enterprise.server.11`
-	EnterpriseDesktop11 Release = `suse.linux.enterprise.desktop.11`
-	OpenStackCloud9     Release = `suse.openstack.cloud.9`
-	OpenStackCloud8     Release = `suse.openstack.cloud.8`
-	OpenStackCloud7     Release = `suse.openstack.cloud.7`
-	Leap151             Release = `opensuse.leap.15.1`
-	Leap150             Release = `opensuse.leap.15.0`
-	Leap423             Release = `opensuse.leap.42.3`
-)
-
 var upstreamBase *url.URL
 
 func init() {

--- a/ubuntu/distributionscanner.go
+++ b/ubuntu/distributionscanner.go
@@ -1,0 +1,116 @@
+package ubuntu
+
+import (
+	"bytes"
+	"context"
+	"regexp"
+	"runtime/trace"
+
+	"github.com/quay/claircore"
+	"github.com/quay/claircore/internal/indexer"
+	"github.com/rs/zerolog"
+)
+
+const (
+	scannerName    = "ubuntu"
+	scannerVersion = "v0.0.1"
+	scannerKind    = "distribution"
+)
+
+type ubuntuRegex struct {
+	release Release
+	regexp  *regexp.Regexp
+}
+
+var ubuntuRegexes = []ubuntuRegex{
+	{
+		release: Artful,
+		regexp:  regexp.MustCompile(`(?is)\bubuntu\b.*\bartful\b`),
+	},
+	{
+		release: Bionic,
+		regexp:  regexp.MustCompile(`(?is)\bubuntu\b.*\bbionic\b`),
+	},
+	{
+		release: Cosmic,
+		regexp:  regexp.MustCompile(`(?is)\bubuntu\b.*\bcosmic\b`),
+	},
+	{
+		release: Disco,
+		regexp:  regexp.MustCompile(`(?is)\bubuntu\b.*\bdisco\b`),
+	},
+	{
+		release: Precise,
+		regexp:  regexp.MustCompile(`(?is)\bubuntu\b.*\bprecise\b`),
+	},
+	{
+		release: Trusty,
+		regexp:  regexp.MustCompile(`(?is)\bubuntu\b.*\btrusty\b`),
+	},
+	{
+		release: Xenial,
+		regexp:  regexp.MustCompile(`(?is)\bubuntu\b.*\bxenial\b`),
+	},
+}
+
+const osReleasePath = `etc/os-release`
+const lsbReleasePath = `etc/lsb-release`
+
+var _ indexer.DistributionScanner = (*DistributionScanner)(nil)
+var _ indexer.VersionedScanner = (*DistributionScanner)(nil)
+
+// DistributionScanner attempts to discover if a layer
+// displays characteristics of a Ubuntu distribution
+type DistributionScanner struct{}
+
+// Name implements scanner.VersionedScanner.
+func (*DistributionScanner) Name() string { return scannerName }
+
+// Version implements scanner.VersionedScanner.
+func (*DistributionScanner) Version() string { return scannerVersion }
+
+// Kind implements scanner.VersionedScanner.
+func (*DistributionScanner) Kind() string { return scannerKind }
+
+// Scan will inspect the layer for an os-release or lsb-release file
+// and perform a regex match for keywords indicating the associated Ubuntu release
+//
+// If neither file is found a (nil,nil) is returned.
+// If the files are found but all regexp fail to match an empty distribution is returned.
+func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]*claircore.Distribution, error) {
+	defer trace.StartRegion(ctx, "Scanner.Scan").End()
+	log := zerolog.Ctx(ctx).With().
+		Str("component", "ubuntu_dist_scanner").
+		Str("name", ds.Name()).
+		Str("version", ds.Version()).
+		Str("kind", ds.Kind()).
+		Str("layer", l.Hash).
+		Logger()
+	log.Debug().Msg("start")
+	defer log.Debug().Msg("done")
+	files, err := l.Files(osReleasePath, lsbReleasePath)
+	if err != nil {
+		log.Debug().Msg("didn't find an os-release or lsb release file")
+		return nil, nil
+	}
+	for _, buff := range files {
+		dist := ds.parse(buff)
+		if dist != nil {
+			return []*claircore.Distribution{dist}, nil
+		}
+	}
+	return []*claircore.Distribution{&claircore.Distribution{}}, nil
+}
+
+// parse attempts to match all Ubuntu release regexp and returns the associated
+// distribution if it exists.
+//
+// separated to it's own method to aide testing.
+func (ds *DistributionScanner) parse(buff *bytes.Buffer) *claircore.Distribution {
+	for _, ur := range ubuntuRegexes {
+		if ur.regexp.Match(buff.Bytes()) {
+			return releaseToDist(ur.release)
+		}
+	}
+	return nil
+}

--- a/ubuntu/distributionscanner.go
+++ b/ubuntu/distributionscanner.go
@@ -80,10 +80,8 @@ func (*DistributionScanner) Kind() string { return scannerKind }
 func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]*claircore.Distribution, error) {
 	defer trace.StartRegion(ctx, "Scanner.Scan").End()
 	log := zerolog.Ctx(ctx).With().
-		Str("component", "ubuntu_dist_scanner").
-		Str("name", ds.Name()).
+		Str("component", "ubuntu/DistributionScanner.Scan").
 		Str("version", ds.Version()).
-		Str("kind", ds.Kind()).
 		Str("layer", l.Hash).
 		Logger()
 	log.Debug().Msg("start")

--- a/ubuntu/distributionscanner_test.go
+++ b/ubuntu/distributionscanner_test.go
@@ -246,7 +246,7 @@ DISTRIB_RELEASE=16.04
 DISTRIB_CODENAME=
 DISTRIB_DESCRIPTION="Ubuntu 16.04.6 LTS"`)
 
-func TestUbuntuDistributionScanner(t *testing.T) {
+func TestDistributionScanner(t *testing.T) {
 	table := []struct {
 		name       string
 		release    Release
@@ -311,7 +311,7 @@ func TestUbuntuDistributionScanner(t *testing.T) {
 	}
 }
 
-func TestUbuntuDistributionScannerBad(t *testing.T) {
+func TestDistributionScannerBad(t *testing.T) {
 	table := []struct {
 		name       string
 		release    Release

--- a/ubuntu/distributionscanner_test.go
+++ b/ubuntu/distributionscanner_test.go
@@ -21,27 +21,9 @@ PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-poli
 VERSION_CODENAME=artful
 UBUNTU_CODENAME=artful`)
 
-var artfulOSReleaseBad []byte = []byte(`NAME="Ubuntu"
-VERSION="17.10 ( Aardvark)"
-ID=ubuntu
-ID_LIKE=debian
-PRETTY_NAME="Ubuntu 17.10"
-VERSION_ID="17.10"
-HOME_URL="https://www.ubuntu.com/"
-SUPPORT_URL="https://help.ubuntu.com/"
-BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
-PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
-VERSION_CODENAME=
-UBUNTU_CODENAME=`)
-
 var artfulLSBRelease []byte = []byte(`DISTRIB_ID=Ubuntu
 DISTRIB_RELEASE=17.10
 DISTRIB_CODENAME=artful
-DISTRIB_DESCRIPTION="Ubuntu 17.10"`)
-
-var artfulLSBReleaseBad []byte = []byte(`DISTRIB_ID=Ubuntu
-DISTRIB_RELEASE=17.10
-DISTRIB_CODENAME=
 DISTRIB_DESCRIPTION="Ubuntu 17.10"`)
 
 // bionic test data
@@ -58,27 +40,9 @@ PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-poli
 VERSION_CODENAME=bionic
 UBUNTU_CODENAME=bionic`)
 
-var bionicOSReleaseBad []byte = []byte(`NAME="Ubuntu"
-VERSION="18.04.3 LTS ( Beaver)"
-ID=ubuntu
-ID_LIKE=debian
-PRETTY_NAME="Ubuntu 18.04.3 LTS"
-VERSION_ID="18.04"
-HOME_URL="https://www.ubuntu.com/"
-SUPPORT_URL="https://help.ubuntu.com/"
-BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
-PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
-VERSION_CODENAME=
-UBUNTU_CODENAME=`)
-
 var bionicLSBRelease []byte = []byte(`DISTRIB_ID=Ubuntu
 DISTRIB_RELEASE=18.04
 DISTRIB_CODENAME=bionic
-DISTRIB_DESCRIPTION="Ubuntu 18.04.3 LTS"`)
-
-var bionicLSBReleaseBad []byte = []byte(`DISTRIB_ID=Ubuntu
-DISTRIB_RELEASE=18.04
-DISTRIB_CODENAME=
 DISTRIB_DESCRIPTION="Ubuntu 18.04.3 LTS"`)
 
 // cosmic test data
@@ -95,27 +59,9 @@ PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-poli
 VERSION_CODENAME=cosmic
 UBUNTU_CODENAME=cosmic`)
 
-var cosmicOSReleaseBad []byte = []byte(`NAME="Ubuntu"
-VERSION="18.10 ( Cuttlefish)"
-ID=ubuntu
-ID_LIKE=debian
-PRETTY_NAME="Ubuntu 18.10"
-VERSION_ID="18.10"
-HOME_URL="https://www.ubuntu.com/"
-SUPPORT_URL="https://help.ubuntu.com/"
-BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
-PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
-VERSION_CODENAME=
-UBUNTU_CODENAME=`)
-
 var cosmicLSBRelease []byte = []byte(`DISTRIB_ID=Ubuntu
 DISTRIB_RELEASE=18.10
 DISTRIB_CODENAME=cosmic
-DISTRIB_DESCRIPTION="Ubuntu 18.10"`)
-
-var cosmicLSBReleaseBad []byte = []byte(`DISTRIB_ID=Ubuntu
-DISTRIB_RELEASE=18.10
-DISTRIB_CODENAME=
 DISTRIB_DESCRIPTION="Ubuntu 18.10"`)
 
 // disco test data
@@ -132,27 +78,9 @@ PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-poli
 VERSION_CODENAME=disco
 UBUNTU_CODENAME=disco`)
 
-var discoOSReleaseBad []byte = []byte(`NAME="Ubuntu"
-VERSION="19.04 ( Dingo)"
-ID=ubuntu
-ID_LIKE=debian
-PRETTY_NAME="Ubuntu 19.04"
-VERSION_ID="19.04"
-HOME_URL="https://www.ubuntu.com/"
-SUPPORT_URL="https://help.ubuntu.com/"
-BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
-PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
-VERSION_CODENAME=
-UBUNTU_CODENAME=`)
-
 var discoLSBRelease []byte = []byte(`DISTRIB_ID=Ubuntu
 DISTRIB_RELEASE=19.04
 DISTRIB_CODENAME=disco
-DISTRIB_DESCRIPTION="Ubuntu 19.04"`)
-
-var discoLSBReleaseBad []byte = []byte(`DISTRIB_ID=Ubuntu
-DISTRIB_RELEASE=19.04
-DISTRIB_CODENAME=
 DISTRIB_DESCRIPTION="Ubuntu 19.04"`)
 
 // precise test data
@@ -163,21 +91,9 @@ ID_LIKE=debian
 PRETTY_NAME="Ubuntu precise (12.04.5 LTS)"
 VERSION_ID="12.04"`)
 
-var preciseOSReleaseBad []byte = []byte(`NAME="Ubuntu"
-VERSION="12.04.5 LTS, Pangolin"
-ID=ubuntu
-ID_LIKE=debian
-PRETTY_NAME="Ubuntu (12.04.5 LTS)"
-VERSION_ID="12.04"`)
-
 var preciseLSBRelease []byte = []byte(`DISTRIB_ID=Ubuntu
 DISTRIB_RELEASE=12.04
 DISTRIB_CODENAME=precise
-DISTRIB_DESCRIPTION="Ubuntu 12.04.5 LTS"`)
-
-var preciseLSBReleaseBad []byte = []byte(`DISTRIB_ID=Ubuntu
-DISTRIB_RELEASE=12.04
-DISTRIB_CODENAME=
 DISTRIB_DESCRIPTION="Ubuntu 12.04.5 LTS"`)
 
 // trusty test data
@@ -191,24 +107,9 @@ HOME_URL="http://www.ubuntu.com/"
 SUPPORT_URL="http://help.ubuntu.com/"
 BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"`)
 
-var trustyOSReleaseBad []byte = []byte(`NAME="Ubuntu"
-VERSION="14.04.6 LTS, Tahr"
-ID=ubuntu
-ID_LIKE=debian
-PRETTY_NAME="Ubuntu 14.04.6 LTS"
-VERSION_ID="14.04"
-HOME_URL="http://www.ubuntu.com/"
-SUPPORT_URL="http://help.ubuntu.com/"
-BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"`)
-
 var trustyLSBRelease []byte = []byte(`DISTRIB_ID=Ubuntu
 DISTRIB_RELEASE=14.04
 DISTRIB_CODENAME=trusty
-DISTRIB_DESCRIPTION="Ubuntu 14.04.6 LTS"`)
-
-var trustyLSBReleaseBad []byte = []byte(`DISTRIB_ID=Ubuntu
-DISTRIB_RELEASE=14.04
-DISTRIB_CODENAME=
 DISTRIB_DESCRIPTION="Ubuntu 14.04.6 LTS"`)
 
 // xenial test data
@@ -224,26 +125,9 @@ BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"
 VERSION_CODENAME=xenial
 UBUNTU_CODENAME=xenial`)
 
-var xenialOSReleaseBad []byte = []byte(`NAME="Ubuntu"
-VERSION="16.04.6 LTS (Xerus)"
-ID=ubuntu
-ID_LIKE=debian
-PRETTY_NAME="Ubuntu 16.04.6 LTS"
-VERSION_ID="16.04"
-HOME_URL="http://www.ubuntu.com/"
-SUPPORT_URL="http://help.ubuntu.com/"
-BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"
-VERSION_CODENAME=
-UBUNTU_CODENAME=`)
-
 var xenialLSBRelease []byte = []byte(`DISTRIB_ID=Ubuntu
 DISTRIB_RELEASE=16.04
 DISTRIB_CODENAME=xenial
-DISTRIB_DESCRIPTION="Ubuntu 16.04.6 LTS"`)
-
-var xenialLSBReleaseBad []byte = []byte(`DISTRIB_ID=Ubuntu
-DISTRIB_RELEASE=16.04
-DISTRIB_CODENAME=
 DISTRIB_DESCRIPTION="Ubuntu 16.04.6 LTS"`)
 
 func TestDistributionScanner(t *testing.T) {
@@ -306,71 +190,6 @@ func TestDistributionScanner(t *testing.T) {
 			dist = scanner.parse(bytes.NewBuffer(tt.lsbRelease))
 			if !cmp.Equal(dist, releaseToDist(tt.release)) {
 				t.Fatalf("%v", cmp.Diff(dist, releaseToDist(tt.release)))
-			}
-		})
-	}
-}
-
-func TestDistributionScannerBad(t *testing.T) {
-	table := []struct {
-		name       string
-		release    Release
-		osRelease  []byte
-		lsbRelease []byte
-	}{
-		{
-			name:       "artful",
-			release:    Artful,
-			osRelease:  artfulOSReleaseBad,
-			lsbRelease: artfulLSBReleaseBad,
-		},
-		{
-			name:       "bionic",
-			release:    Bionic,
-			osRelease:  bionicOSReleaseBad,
-			lsbRelease: bionicLSBReleaseBad,
-		},
-		{
-			name:       "cosmic",
-			release:    Cosmic,
-			osRelease:  cosmicOSReleaseBad,
-			lsbRelease: cosmicLSBReleaseBad,
-		},
-		{
-			name:       "disco",
-			release:    Disco,
-			osRelease:  discoOSReleaseBad,
-			lsbRelease: discoLSBReleaseBad,
-		},
-		{
-			name:       "precise",
-			release:    Precise,
-			osRelease:  preciseOSReleaseBad,
-			lsbRelease: preciseLSBReleaseBad,
-		},
-		{
-			name:       "trusty",
-			release:    Trusty,
-			osRelease:  trustyOSReleaseBad,
-			lsbRelease: trustyLSBReleaseBad,
-		},
-		{
-			name:       "xenial",
-			release:    Xenial,
-			osRelease:  xenialOSReleaseBad,
-			lsbRelease: xenialLSBReleaseBad,
-		},
-	}
-	for _, tt := range table {
-		t.Run(tt.name, func(t *testing.T) {
-			scanner := DistributionScanner{}
-			dist := scanner.parse(bytes.NewBuffer(tt.osRelease))
-			if dist != nil {
-				t.Fatalf("expected nil dist got %v", dist)
-			}
-			dist = scanner.parse(bytes.NewBuffer(tt.lsbRelease))
-			if dist != nil {
-				t.Fatalf("expected nil dist got %v", dist)
 			}
 		})
 	}

--- a/ubuntu/distributionscanner_test.go
+++ b/ubuntu/distributionscanner_test.go
@@ -1,0 +1,377 @@
+package ubuntu
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// artful test data
+var artfulOSRelease []byte = []byte(`NAME="Ubuntu"
+VERSION="17.10 (Artful Aardvark)"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 17.10"
+VERSION_ID="17.10"
+HOME_URL="https://www.ubuntu.com/"
+SUPPORT_URL="https://help.ubuntu.com/"
+BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
+PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+VERSION_CODENAME=artful
+UBUNTU_CODENAME=artful`)
+
+var artfulOSReleaseBad []byte = []byte(`NAME="Ubuntu"
+VERSION="17.10 ( Aardvark)"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 17.10"
+VERSION_ID="17.10"
+HOME_URL="https://www.ubuntu.com/"
+SUPPORT_URL="https://help.ubuntu.com/"
+BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
+PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+VERSION_CODENAME=
+UBUNTU_CODENAME=`)
+
+var artfulLSBRelease []byte = []byte(`DISTRIB_ID=Ubuntu
+DISTRIB_RELEASE=17.10
+DISTRIB_CODENAME=artful
+DISTRIB_DESCRIPTION="Ubuntu 17.10"`)
+
+var artfulLSBReleaseBad []byte = []byte(`DISTRIB_ID=Ubuntu
+DISTRIB_RELEASE=17.10
+DISTRIB_CODENAME=
+DISTRIB_DESCRIPTION="Ubuntu 17.10"`)
+
+// bionic test data
+var bionicOSRelease []byte = []byte(`NAME="Ubuntu"
+VERSION="18.04.3 LTS (Bionic Beaver)"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 18.04.3 LTS"
+VERSION_ID="18.04"
+HOME_URL="https://www.ubuntu.com/"
+SUPPORT_URL="https://help.ubuntu.com/"
+BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
+PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+VERSION_CODENAME=bionic
+UBUNTU_CODENAME=bionic`)
+
+var bionicOSReleaseBad []byte = []byte(`NAME="Ubuntu"
+VERSION="18.04.3 LTS ( Beaver)"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 18.04.3 LTS"
+VERSION_ID="18.04"
+HOME_URL="https://www.ubuntu.com/"
+SUPPORT_URL="https://help.ubuntu.com/"
+BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
+PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+VERSION_CODENAME=
+UBUNTU_CODENAME=`)
+
+var bionicLSBRelease []byte = []byte(`DISTRIB_ID=Ubuntu
+DISTRIB_RELEASE=18.04
+DISTRIB_CODENAME=bionic
+DISTRIB_DESCRIPTION="Ubuntu 18.04.3 LTS"`)
+
+var bionicLSBReleaseBad []byte = []byte(`DISTRIB_ID=Ubuntu
+DISTRIB_RELEASE=18.04
+DISTRIB_CODENAME=
+DISTRIB_DESCRIPTION="Ubuntu 18.04.3 LTS"`)
+
+// cosmic test data
+var cosmicOSRelease []byte = []byte(`NAME="Ubuntu"
+VERSION="18.10 (Cosmic Cuttlefish)"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 18.10"
+VERSION_ID="18.10"
+HOME_URL="https://www.ubuntu.com/"
+SUPPORT_URL="https://help.ubuntu.com/"
+BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
+PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+VERSION_CODENAME=cosmic
+UBUNTU_CODENAME=cosmic`)
+
+var cosmicOSReleaseBad []byte = []byte(`NAME="Ubuntu"
+VERSION="18.10 ( Cuttlefish)"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 18.10"
+VERSION_ID="18.10"
+HOME_URL="https://www.ubuntu.com/"
+SUPPORT_URL="https://help.ubuntu.com/"
+BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
+PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+VERSION_CODENAME=
+UBUNTU_CODENAME=`)
+
+var cosmicLSBRelease []byte = []byte(`DISTRIB_ID=Ubuntu
+DISTRIB_RELEASE=18.10
+DISTRIB_CODENAME=cosmic
+DISTRIB_DESCRIPTION="Ubuntu 18.10"`)
+
+var cosmicLSBReleaseBad []byte = []byte(`DISTRIB_ID=Ubuntu
+DISTRIB_RELEASE=18.10
+DISTRIB_CODENAME=
+DISTRIB_DESCRIPTION="Ubuntu 18.10"`)
+
+// disco test data
+var discoOSRelease []byte = []byte(`NAME="Ubuntu"
+VERSION="19.04 (Disco Dingo)"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 19.04"
+VERSION_ID="19.04"
+HOME_URL="https://www.ubuntu.com/"
+SUPPORT_URL="https://help.ubuntu.com/"
+BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
+PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+VERSION_CODENAME=disco
+UBUNTU_CODENAME=disco`)
+
+var discoOSReleaseBad []byte = []byte(`NAME="Ubuntu"
+VERSION="19.04 ( Dingo)"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 19.04"
+VERSION_ID="19.04"
+HOME_URL="https://www.ubuntu.com/"
+SUPPORT_URL="https://help.ubuntu.com/"
+BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
+PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+VERSION_CODENAME=
+UBUNTU_CODENAME=`)
+
+var discoLSBRelease []byte = []byte(`DISTRIB_ID=Ubuntu
+DISTRIB_RELEASE=19.04
+DISTRIB_CODENAME=disco
+DISTRIB_DESCRIPTION="Ubuntu 19.04"`)
+
+var discoLSBReleaseBad []byte = []byte(`DISTRIB_ID=Ubuntu
+DISTRIB_RELEASE=19.04
+DISTRIB_CODENAME=
+DISTRIB_DESCRIPTION="Ubuntu 19.04"`)
+
+// precise test data
+var preciseOSRelease []byte = []byte(`NAME="Ubuntu"
+VERSION="12.04.5 LTS, Precise Pangolin"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu precise (12.04.5 LTS)"
+VERSION_ID="12.04"`)
+
+var preciseOSReleaseBad []byte = []byte(`NAME="Ubuntu"
+VERSION="12.04.5 LTS, Pangolin"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu (12.04.5 LTS)"
+VERSION_ID="12.04"`)
+
+var preciseLSBRelease []byte = []byte(`DISTRIB_ID=Ubuntu
+DISTRIB_RELEASE=12.04
+DISTRIB_CODENAME=precise
+DISTRIB_DESCRIPTION="Ubuntu 12.04.5 LTS"`)
+
+var preciseLSBReleaseBad []byte = []byte(`DISTRIB_ID=Ubuntu
+DISTRIB_RELEASE=12.04
+DISTRIB_CODENAME=
+DISTRIB_DESCRIPTION="Ubuntu 12.04.5 LTS"`)
+
+// trusty test data
+var trustyOSRelease []byte = []byte(`NAME="Ubuntu"
+VERSION="14.04.6 LTS, Trusty Tahr"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 14.04.6 LTS"
+VERSION_ID="14.04"
+HOME_URL="http://www.ubuntu.com/"
+SUPPORT_URL="http://help.ubuntu.com/"
+BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"`)
+
+var trustyOSReleaseBad []byte = []byte(`NAME="Ubuntu"
+VERSION="14.04.6 LTS, Tahr"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 14.04.6 LTS"
+VERSION_ID="14.04"
+HOME_URL="http://www.ubuntu.com/"
+SUPPORT_URL="http://help.ubuntu.com/"
+BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"`)
+
+var trustyLSBRelease []byte = []byte(`DISTRIB_ID=Ubuntu
+DISTRIB_RELEASE=14.04
+DISTRIB_CODENAME=trusty
+DISTRIB_DESCRIPTION="Ubuntu 14.04.6 LTS"`)
+
+var trustyLSBReleaseBad []byte = []byte(`DISTRIB_ID=Ubuntu
+DISTRIB_RELEASE=14.04
+DISTRIB_CODENAME=
+DISTRIB_DESCRIPTION="Ubuntu 14.04.6 LTS"`)
+
+// xenial test data
+var xenialOSRelease []byte = []byte(`NAME="Ubuntu"
+VERSION="16.04.6 LTS (Xenial Xerus)"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 16.04.6 LTS"
+VERSION_ID="16.04"
+HOME_URL="http://www.ubuntu.com/"
+SUPPORT_URL="http://help.ubuntu.com/"
+BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"
+VERSION_CODENAME=xenial
+UBUNTU_CODENAME=xenial`)
+
+var xenialOSReleaseBad []byte = []byte(`NAME="Ubuntu"
+VERSION="16.04.6 LTS (Xerus)"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 16.04.6 LTS"
+VERSION_ID="16.04"
+HOME_URL="http://www.ubuntu.com/"
+SUPPORT_URL="http://help.ubuntu.com/"
+BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"
+VERSION_CODENAME=
+UBUNTU_CODENAME=`)
+
+var xenialLSBRelease []byte = []byte(`DISTRIB_ID=Ubuntu
+DISTRIB_RELEASE=16.04
+DISTRIB_CODENAME=xenial
+DISTRIB_DESCRIPTION="Ubuntu 16.04.6 LTS"`)
+
+var xenialLSBReleaseBad []byte = []byte(`DISTRIB_ID=Ubuntu
+DISTRIB_RELEASE=16.04
+DISTRIB_CODENAME=
+DISTRIB_DESCRIPTION="Ubuntu 16.04.6 LTS"`)
+
+func TestUbuntuDistributionScanner(t *testing.T) {
+	table := []struct {
+		name       string
+		release    Release
+		osRelease  []byte
+		lsbRelease []byte
+	}{
+		{
+			name:       "artful",
+			release:    Artful,
+			osRelease:  artfulOSRelease,
+			lsbRelease: artfulLSBRelease,
+		},
+		{
+			name:       "bionic",
+			release:    Bionic,
+			osRelease:  bionicOSRelease,
+			lsbRelease: bionicLSBRelease,
+		},
+		{
+			name:       "cosmic",
+			release:    Cosmic,
+			osRelease:  cosmicOSRelease,
+			lsbRelease: cosmicLSBRelease,
+		},
+		{
+			name:       "disco",
+			release:    Disco,
+			osRelease:  discoOSRelease,
+			lsbRelease: discoLSBRelease,
+		},
+		{
+			name:       "precise",
+			release:    Precise,
+			osRelease:  preciseOSRelease,
+			lsbRelease: preciseLSBRelease,
+		},
+		{
+			name:       "trusty",
+			release:    Trusty,
+			osRelease:  trustyOSRelease,
+			lsbRelease: trustyLSBRelease,
+		},
+		{
+			name:       "xenial",
+			release:    Xenial,
+			osRelease:  xenialOSRelease,
+			lsbRelease: xenialLSBRelease,
+		},
+	}
+	for _, tt := range table {
+		t.Run(tt.name, func(t *testing.T) {
+			scanner := DistributionScanner{}
+			dist := scanner.parse(bytes.NewBuffer(tt.osRelease))
+			if !cmp.Equal(dist, releaseToDist(tt.release)) {
+				t.Fatalf("%v", cmp.Diff(dist, releaseToDist(tt.release)))
+			}
+			dist = scanner.parse(bytes.NewBuffer(tt.lsbRelease))
+			if !cmp.Equal(dist, releaseToDist(tt.release)) {
+				t.Fatalf("%v", cmp.Diff(dist, releaseToDist(tt.release)))
+			}
+		})
+	}
+}
+
+func TestUbuntuDistributionScannerBad(t *testing.T) {
+	table := []struct {
+		name       string
+		release    Release
+		osRelease  []byte
+		lsbRelease []byte
+	}{
+		{
+			name:       "artful",
+			release:    Artful,
+			osRelease:  artfulOSReleaseBad,
+			lsbRelease: artfulLSBReleaseBad,
+		},
+		{
+			name:       "bionic",
+			release:    Bionic,
+			osRelease:  bionicOSReleaseBad,
+			lsbRelease: bionicLSBReleaseBad,
+		},
+		{
+			name:       "cosmic",
+			release:    Cosmic,
+			osRelease:  cosmicOSReleaseBad,
+			lsbRelease: cosmicLSBReleaseBad,
+		},
+		{
+			name:       "disco",
+			release:    Disco,
+			osRelease:  discoOSReleaseBad,
+			lsbRelease: discoLSBReleaseBad,
+		},
+		{
+			name:       "precise",
+			release:    Precise,
+			osRelease:  preciseOSReleaseBad,
+			lsbRelease: preciseLSBReleaseBad,
+		},
+		{
+			name:       "trusty",
+			release:    Trusty,
+			osRelease:  trustyOSReleaseBad,
+			lsbRelease: trustyLSBReleaseBad,
+		},
+		{
+			name:       "xenial",
+			release:    Xenial,
+			osRelease:  xenialOSReleaseBad,
+			lsbRelease: xenialLSBReleaseBad,
+		},
+	}
+	for _, tt := range table {
+		t.Run(tt.name, func(t *testing.T) {
+			scanner := DistributionScanner{}
+			dist := scanner.parse(bytes.NewBuffer(tt.osRelease))
+			if dist != nil {
+				t.Fatalf("expected nil dist got %v", dist)
+			}
+			dist = scanner.parse(bytes.NewBuffer(tt.lsbRelease))
+			if dist != nil {
+				t.Fatalf("expected nil dist got %v", dist)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR implements distribution scanners for each supported distribution. 
Alternative methods are used since many containers do not have os-release files.
All detected distributions or normalized to reflect how their secdb's are organized. 

Draft while I do a little cleanup. 