### PR TITLE
Unify digest representation

### DIFF
--- a/alpine/distributionscanner.go
+++ b/alpine/distributionscanner.go
@@ -6,9 +6,10 @@ import (
 	"regexp"
 	"runtime/trace"
 
+	"github.com/rs/zerolog"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/internal/indexer"
-	"github.com/rs/zerolog"
 )
 
 // Alpine linux has patch releases but their security database
@@ -95,7 +96,7 @@ func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]
 	log := zerolog.Ctx(ctx).With().
 		Str("component", "alpine/DistributionScanner.Scan").
 		Str("version", ds.Version()).
-		Str("layer", l.Hash).
+		Str("layer", l.Hash.String()).
 		Logger()
 	log.Debug().Msg("start")
 	defer log.Debug().Msg("done")

--- a/alpine/packagescanner.go
+++ b/alpine/packagescanner.go
@@ -50,11 +50,11 @@ func (*Scanner) Scan(ctx context.Context, layer *claircore.Layer) ([]*claircore.
 		return nil, err
 	}
 	defer trace.StartRegion(ctx, "Scanner.Scan").End()
-	trace.Log(ctx, "layer:sha256", layer.Hash)
+	trace.Log(ctx, "layer", layer.Hash.String())
 	log := zerolog.Ctx(ctx).With().
 		Str("component", "alpine/Scanner.Scan").
 		Str("version", pkgVersion).
-		Str("layer", layer.Hash).
+		Str("layer", layer.Hash.String()).
 		Logger()
 	ctx = log.WithContext(ctx)
 	log.Debug().Msg("start")

--- a/alpine/packagescanner_test.go
+++ b/alpine/packagescanner_test.go
@@ -14,7 +14,10 @@ import (
 )
 
 func TestScan(t *testing.T) {
-	const hash = `89d9c30c1d48bac627e5c6cb0d1ed1eec28e7dbdfbcc04712e4c79c0f83faf17`
+	hash, err := claircore.ParseDigest("sha256:89d9c30c1d48bac627e5c6cb0d1ed1eec28e7dbdfbcc04712e4c79c0f83faf17")
+	if err != nil {
+		t.Fatal(err)
+	}
 	want := []*claircore.Package{
 		&claircore.Package{
 			Name:           "musl",

--- a/aws/distributionscanner.go
+++ b/aws/distributionscanner.go
@@ -6,9 +6,10 @@ import (
 	"regexp"
 	"runtime/trace"
 
+	"github.com/rs/zerolog"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/internal/indexer"
-	"github.com/rs/zerolog"
 )
 
 // AWS Linux keeps a consistent os-release file between
@@ -67,7 +68,7 @@ func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]
 		Str("name", ds.Name()).
 		Str("version", ds.Version()).
 		Str("kind", ds.Kind()).
-		Str("layer", l.Hash).
+		Str("layer", l.Hash.String()).
 		Logger()
 	log.Debug().Msg("start")
 	defer log.Debug().Msg("done")

--- a/cmd/cctool/inspector.go
+++ b/cmd/cctool/inspector.go
@@ -47,8 +47,12 @@ func Inspect(ctx context.Context, r string) (*claircore.Manifest, error) {
 	if err != nil {
 		return nil, err
 	}
+	ccd, err := claircore.ParseDigest(h.String())
+	if err != nil {
+		return nil, err
+	}
 	out := claircore.Manifest{
-		Hash: h.Hex,
+		Hash: ccd,
 	}
 
 	ls, err := img.Layers()
@@ -69,6 +73,10 @@ func Inspect(ctx context.Context, r string) (*claircore.Manifest, error) {
 		if err != nil {
 			return nil, err
 		}
+		ccd, err := claircore.ParseDigest(d.String())
+		if err != nil {
+			return nil, err
+		}
 		u, err := rURL.Parse(path.Join("/", "v2", strings.TrimPrefix(repo.RepositoryStr(), repo.RegistryStr()), "blobs", d.String()))
 		if err != nil {
 			return nil, err
@@ -85,7 +93,7 @@ func Inspect(ctx context.Context, r string) (*claircore.Manifest, error) {
 
 		res.Request.Header.Del("User-Agent")
 		out.Layers = append(out.Layers, &claircore.Layer{
-			Hash:    d.Hex,
+			Hash:    ccd,
 			URI:     res.Request.URL.String(),
 			Headers: res.Request.Header,
 		})

--- a/debian/distributionscanner.go
+++ b/debian/distributionscanner.go
@@ -6,9 +6,10 @@ import (
 	"regexp"
 	"runtime/trace"
 
+	"github.com/rs/zerolog"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/internal/indexer"
-	"github.com/rs/zerolog"
 )
 
 const (
@@ -70,7 +71,7 @@ func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]
 	log := zerolog.Ctx(ctx).With().
 		Str("component", "debian/DistributionScanner.Scan").
 		Str("version", ds.Version()).
-		Str("layer", l.Hash).
+		Str("layer", l.Hash.String()).
 		Logger()
 	log.Debug().Msg("start")
 	defer log.Debug().Msg("done")

--- a/debian/testdata/indexreport-buster-jackson-databind.json
+++ b/debian/testdata/indexreport-buster-jackson-databind.json
@@ -1,5 +1,5 @@
 {
-  "manifest_hash": "0194e59b0b159c8182f2d382953a61d169aa285fe847121f8fc59e7c5a47791a",
+  "manifest_hash": "sha256:0194e59b0b159c8182f2d382953a61d169aa285fe847121f8fc59e7c5a47791a",
   "state": "IndexFinished",
   "packages": {
     "180": {
@@ -1087,7 +1087,7 @@
     "180": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1095,7 +1095,7 @@
     "182": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1103,7 +1103,7 @@
     "184": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1111,7 +1111,7 @@
     "186": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1119,7 +1119,7 @@
     "188": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1127,7 +1127,7 @@
     "190": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1135,7 +1135,7 @@
     "192": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1143,7 +1143,7 @@
     "194": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1151,7 +1151,7 @@
     "196": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1159,7 +1159,7 @@
     "198": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1167,7 +1167,7 @@
     "200": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1175,7 +1175,7 @@
     "202": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1183,7 +1183,7 @@
     "204": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1191,7 +1191,7 @@
     "206": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1199,7 +1199,7 @@
     "208": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1207,7 +1207,7 @@
     "210": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1215,7 +1215,7 @@
     "212": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1223,7 +1223,7 @@
     "214": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1231,7 +1231,7 @@
     "216": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1239,7 +1239,7 @@
     "218": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1247,7 +1247,7 @@
     "220": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1255,7 +1255,7 @@
     "222": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1263,7 +1263,7 @@
     "224": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1271,7 +1271,7 @@
     "226": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1279,7 +1279,7 @@
     "228": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1287,7 +1287,7 @@
     "230": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1295,7 +1295,7 @@
     "232": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1303,7 +1303,7 @@
     "234": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1311,7 +1311,7 @@
     "236": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1319,7 +1319,7 @@
     "238": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1327,7 +1327,7 @@
     "240": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1335,7 +1335,7 @@
     "242": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1343,7 +1343,7 @@
     "244": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1351,7 +1351,7 @@
     "246": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1359,7 +1359,7 @@
     "248": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1367,7 +1367,7 @@
     "250": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1375,7 +1375,7 @@
     "252": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1383,7 +1383,7 @@
     "254": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1391,7 +1391,7 @@
     "256": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1399,7 +1399,7 @@
     "258": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1407,7 +1407,7 @@
     "260": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1415,7 +1415,7 @@
     "262": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1423,7 +1423,7 @@
     "264": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1431,7 +1431,7 @@
     "266": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1439,7 +1439,7 @@
     "268": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1447,7 +1447,7 @@
     "270": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1455,7 +1455,7 @@
     "272": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1463,7 +1463,7 @@
     "274": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1471,7 +1471,7 @@
     "276": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1479,7 +1479,7 @@
     "278": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1487,7 +1487,7 @@
     "280": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1495,7 +1495,7 @@
     "282": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1503,7 +1503,7 @@
     "284": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1511,7 +1511,7 @@
     "286": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1519,7 +1519,7 @@
     "288": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1527,7 +1527,7 @@
     "290": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1535,7 +1535,7 @@
     "292": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1543,7 +1543,7 @@
     "294": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1551,7 +1551,7 @@
     "296": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1559,7 +1559,7 @@
     "298": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1567,7 +1567,7 @@
     "300": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1575,7 +1575,7 @@
     "302": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1583,7 +1583,7 @@
     "304": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1591,7 +1591,7 @@
     "306": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1599,7 +1599,7 @@
     "308": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1607,7 +1607,7 @@
     "310": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1615,7 +1615,7 @@
     "312": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1623,7 +1623,7 @@
     "314": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1631,7 +1631,7 @@
     "316": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1639,7 +1639,7 @@
     "318": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1647,7 +1647,7 @@
     "320": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1655,7 +1655,7 @@
     "322": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1663,7 +1663,7 @@
     "324": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1671,7 +1671,7 @@
     "326": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1679,7 +1679,7 @@
     "328": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1687,7 +1687,7 @@
     "330": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1695,7 +1695,7 @@
     "332": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1703,7 +1703,7 @@
     "334": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1711,7 +1711,7 @@
     "336": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1719,7 +1719,7 @@
     "338": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1727,7 +1727,7 @@
     "340": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1735,7 +1735,7 @@
     "342": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1743,7 +1743,7 @@
     "344": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1751,7 +1751,7 @@
     "346": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1759,7 +1759,7 @@
     "348": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1767,7 +1767,7 @@
     "350": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1775,7 +1775,7 @@
     "352": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1783,7 +1783,7 @@
     "354": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1791,7 +1791,7 @@
     "356": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1799,7 +1799,7 @@
     "358": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }
@@ -1807,7 +1807,7 @@
     "360": [
       {
         "package_db": "var/lib/dpkg/status",
-        "introduced_in": "4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
+        "introduced_in": "sha256:4ae16bd4778367b46064f39554128dd2fda2803a5747fddeff74059f353391c9",
         "distribution_id": "2",
         "repository_id": ""
       }

--- a/digest.go
+++ b/digest.go
@@ -2,33 +2,51 @@ package claircore
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"crypto/sha512"
 	"database/sql/driver"
 	"encoding/hex"
 	"fmt"
+	"hash"
 )
 
+// Digest is a type representing the hash of some data.
+//
+// It's used throughout claircore packages as an attempt to remain independent
+// of a specific hashing algorithm.
 type Digest struct {
 	algo     string
 	checksum []byte
+	repr     string
 }
 
+// Checksum returns the checksum byte slice.
 func (d Digest) Checksum() []byte { return d.checksum }
 
+// Algorithm returns a string representation of the algorithm used for this
+// digest.
 func (d Digest) Algorithm() string { return d.algo }
 
+// Hash returns an instance of the hashing algorithm used for this Digest.
+func (d Digest) Hash() hash.Hash {
+	switch d.algo {
+	case "sha256":
+		return sha256.New()
+	case "sha512":
+		return sha512.New()
+	default:
+		panic("Hash() called on an invalid Digest")
+	}
+}
+
 func (d Digest) String() string {
-	b, _ := d.MarshalText()
-	return string(b)
+	return d.repr
 }
 
 // MarshalText implements encoding.TextMarshaler.
 func (d Digest) MarshalText() ([]byte, error) {
-	el := hex.EncodedLen(len(d.checksum))
-	hl := len(d.algo) + 1
-	b := make([]byte, hl+el)
-	copy(b, d.algo)
-	b[len(d.algo)] = ':'
-	hex.Encode(b[hl:], d.checksum)
+	b := make([]byte, len(d.repr))
+	copy(b, d.repr)
 	return b, nil
 }
 
@@ -36,14 +54,61 @@ func (d Digest) MarshalText() ([]byte, error) {
 func (d *Digest) UnmarshalText(t []byte) error {
 	i := bytes.IndexByte(t, ':')
 	if i == -1 {
-		return fmt.Errorf("invalid digest format")
+		return &DigestError{msg: "invalid digest format"}
 	}
 	d.algo = string(t[:i])
 	t = t[i+1:]
-	d.checksum = make([]byte, hex.DecodedLen(len(t)))
-	if _, err := hex.Decode(d.checksum, t); err != nil {
-		return fmt.Errorf("invalid digest format")
+	b := make([]byte, hex.DecodedLen(len(t)))
+	if _, err := hex.Decode(b, t); err != nil {
+		return &DigestError{
+			msg:   "unable to decode digest as hex",
+			inner: err,
+		}
 	}
+	return d.setChecksum(b)
+}
+
+// DigestError is the concrete type backing errors returned from Digest's
+// methods.
+type DigestError struct {
+	msg   string
+	inner error
+}
+
+// Error implements error.
+func (e *DigestError) Error() string {
+	return e.msg
+}
+
+// Unwrap enables errors.Unwrap.
+func (e *DigestError) Unwrap() error {
+	return e.inner
+}
+
+func (d *Digest) setChecksum(b []byte) error {
+	var sz int
+	switch d.algo {
+	case "sha256":
+		sz = sha256.Size
+	case "sha512":
+		sz = sha512.Size
+	default:
+		return &DigestError{msg: fmt.Sprintf("unknown algorthm %q", d.algo)}
+	}
+	if l := len(b); l != sz {
+		return &DigestError{msg: fmt.Sprintf("bad checksum length: %d", l)}
+	}
+
+	el := hex.EncodedLen(sz)
+	hl := len(d.algo) + 1
+	sb := make([]byte, hl+el)
+	copy(sb, d.algo)
+	sb[len(d.algo)] = ':'
+	hex.Encode(sb[hl:], b)
+
+	d.checksum = b
+	d.repr = string(sb)
+
 	return nil
 }
 
@@ -51,27 +116,25 @@ func (d *Digest) UnmarshalText(t []byte) error {
 func (d *Digest) Scan(i interface{}) error {
 	s, ok := i.(string)
 	if !ok {
-		return fmt.Errorf("invalid digest type")
+		return &DigestError{msg: "invalid digest type"}
 	}
 	return d.UnmarshalText([]byte(s))
 }
 
 // Value implements driver.Valuer.
 func (d Digest) Value() (driver.Value, error) {
-	b, err := d.MarshalText()
-	if err != nil {
-		return nil, err
-	}
-	return string(b), nil
+	return d.repr, nil
 }
 
-func NewDigest(algo string, sum []byte) Digest {
-	return Digest{
-		algo:     algo,
-		checksum: sum,
+// NewDigest constructs a Digest.
+func NewDigest(algo string, sum []byte) (Digest, error) {
+	d := Digest{
+		algo: algo,
 	}
+	return d, d.setChecksum(sum)
 }
 
+// ParseDigest constructs a Digest from a string, ensuring it's well-formed.
 func ParseDigest(digest string) (Digest, error) {
 	d := Digest{}
 	return d, d.UnmarshalText([]byte(digest))

--- a/dpkg/scanner.go
+++ b/dpkg/scanner.go
@@ -57,11 +57,11 @@ func (ps *Scanner) Kind() string { return kind }
 func (ps *Scanner) Scan(ctx context.Context, layer *claircore.Layer) ([]*claircore.Package, error) {
 	// Preamble
 	defer trace.StartRegion(ctx, "Scanner.Scan").End()
-	trace.Log(ctx, "layer:sha256", layer.Hash)
+	trace.Log(ctx, "layer", layer.Hash.String())
 	log := zerolog.Ctx(ctx).With().
 		Str("component", "dpkg/Scanner.Scan").
 		Str("version", ps.Version()).
-		Str("layer", layer.Hash).
+		Str("layer", layer.Hash.String()).
 		Logger()
 	ctx = log.WithContext(ctx)
 	log.Debug().Msg("start")

--- a/dpkg/scanner_test.go
+++ b/dpkg/scanner_test.go
@@ -14,7 +14,10 @@ import (
 )
 
 func TestScanner(t *testing.T) {
-	const hash = "35c102085707f703de2d9eaad8752d6fe1b8f02b5d2149f1d8357c9cc7fb7d0a"
+	hash, err := claircore.ParseDigest("sha256:35c102085707f703de2d9eaad8752d6fe1b8f02b5d2149f1d8357c9cc7fb7d0a")
+	if err != nil {
+		t.Fatal(err)
+	}
 	want := []*claircore.Package{
 		&claircore.Package{
 			Name:           "fdisk",

--- a/environment.go
+++ b/environment.go
@@ -10,7 +10,7 @@ type Environment struct {
 	// the package database the associated package was discovered in
 	PackageDB string `json:"package_db"`
 	// the layer in which the associated package was introduced
-	IntroducedIn string `json:"introduced_in"`
+	IntroducedIn Digest `json:"introduced_in"`
 	// the ID of the distribution the package was discovered on
 	DistributionID string `json:"distribution_id"`
 	// the ID of the repository where this package was downloaded from (currently not used)

--- a/indexreport.go
+++ b/indexreport.go
@@ -18,7 +18,7 @@ type IndexRecord struct {
 // without repetition.
 type IndexReport struct {
 	// the manifest hash this IndexReport is describing
-	Hash string `json:"manifest_hash"`
+	Hash Digest `json:"manifest_hash"`
 	// the current state of the index operation
 	State string `json:"state"`
 	// all discovered packages in this manifest key'd by package id

--- a/internal/indexer/controller/controller.go
+++ b/internal/indexer/controller/controller.go
@@ -105,7 +105,7 @@ func New(opts *indexer.Opts) *Controller {
 func (s *Controller) Index(ctx context.Context, manifest *claircore.Manifest) *claircore.IndexReport {
 	log := zerolog.Ctx(ctx).With().
 		Str("component", "internal/indexer/controller/Controller.Index").
-		Str("manifest", s.manifest.Hash).
+		Str("manifest", s.manifest.Hash.String()).
 		Str("state", s.getState().String()).
 		Logger()
 	ctx = log.WithContext(ctx)

--- a/internal/indexer/controller/reduce.go
+++ b/internal/indexer/controller/reduce.go
@@ -18,9 +18,10 @@ func reduce(ctx context.Context, store indexer.Store, scnrs indexer.VersionedSca
 				return nil, err
 			}
 			if !ok {
-				if _, ok := seen[l.Hash]; !ok {
+				h := l.Hash.String()
+				if _, ok := seen[h]; !ok {
 					do = append(do, l)
-					seen[l.Hash] = struct{}{}
+					seen[h] = struct{}{}
 				}
 			}
 		}

--- a/internal/indexer/layerscanner.go
+++ b/internal/indexer/layerscanner.go
@@ -10,5 +10,5 @@ import (
 // discovered items into the persistence layer. scanning mechanics (concurrency, ordering, etc...)
 // will be defined by implementations.
 type LayerScanner interface {
-	Scan(ctx context.Context, manifest string, layers []*claircore.Layer) error
+	Scan(ctx context.Context, manifest claircore.Digest, layers []*claircore.Layer) error
 }

--- a/internal/indexer/layerscanner/layerscanner.go
+++ b/internal/indexer/layerscanner/layerscanner.go
@@ -57,7 +57,7 @@ func (ls *layerScanner) discardToken() {
 //
 // If the provided ctx is canceled all routines are canceled and an error will be returned.
 // If one or more layer scans fail Scan will report the first received error and all pending and inflight scans will be canceled.
-func (ls *layerScanner) Scan(ctx context.Context, manifest string, layers []*claircore.Layer) error {
+func (ls *layerScanner) Scan(ctx context.Context, manifest claircore.Digest, layers []*claircore.Layer) error {
 	// compute concurrency level
 	x := float64(len(layers))
 	y := float64(ls.cLevel)

--- a/internal/indexer/layerscanner/layerscanner_test.go
+++ b/internal/indexer/layerscanner/layerscanner_test.go
@@ -2,6 +2,7 @@ package layerscanner
 
 import (
 	"context"
+	"crypto/sha256"
 	"testing"
 	"time"
 
@@ -85,7 +86,11 @@ func Test_Scan_NoErrors(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
-	if err := layerscanner.Scan(ctx, "test-manifest", layers); err != nil {
+	d, err := claircore.NewDigest("sha256", make([]byte, sha256.Size))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := layerscanner.Scan(ctx, d, layers); err != nil {
 		t.Fatalf("failed to scan test layers: %v", err)
 	}
 }

--- a/internal/indexer/layerscanner_mock.go
+++ b/internal/indexer/layerscanner_mock.go
@@ -35,7 +35,7 @@ func (m *MockLayerScanner) EXPECT() *MockLayerScannerMockRecorder {
 }
 
 // Scan mocks base method
-func (m *MockLayerScanner) Scan(arg0 context.Context, arg1 string, arg2 []*claircore.Layer) error {
+func (m *MockLayerScanner) Scan(arg0 context.Context, arg1 claircore.Digest, arg2 []*claircore.Layer) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Scan", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)

--- a/internal/indexer/linux/coalescer.go
+++ b/internal/indexer/linux/coalescer.go
@@ -10,7 +10,7 @@ import (
 
 // layerArifact aggregates the any artifacts found within a layer
 type layerArtifacts struct {
-	hash  string
+	hash  claircore.Digest
 	pkgs  []*claircore.Package
 	dist  []*claircore.Distribution // each layer can only have a single distribution
 	repos []*claircore.Repository

--- a/internal/indexer/linux/coalescer_test.go
+++ b/internal/indexer/linux/coalescer_test.go
@@ -1,7 +1,9 @@
 package linux
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
 	"strconv"
 	"testing"
 
@@ -38,43 +40,44 @@ func Test_Coalescer(t *testing.T) {
 	dists := test.GenUniqueDistributions(3) // we will discard dist 0 due to zero value ambiguity
 	layerArtifacts := []layerArtifacts{
 		{
-			hash:  "A",
 			pkgs:  pkgs[0:1],
 			dist:  nil,
 			repos: nil,
 		},
 		{
-			hash:  "B",
 			pkgs:  pkgs[1:2],
 			dist:  nil,
 			repos: nil,
 		},
 		{
-			hash:  "C",
 			pkgs:  pkgs[2:3],
 			dist:  dists[1:2],
 			repos: nil,
 		},
 		{
-			hash:  "D",
 			pkgs:  pkgs[3:4],
 			dist:  nil,
 			repos: nil,
 		},
 		{
-			hash:  "E",
 			pkgs:  pkgs[4:5],
 			dist:  dists[2:],
 			repos: nil,
 		},
 		{
-			hash:  "F",
 			pkgs:  pkgs[5:],
 			dist:  nil,
 			repos: nil,
 		},
 	}
-	err := coalescer.coalesce(ctx, layerArtifacts)
+	var err error
+	for i := range layerArtifacts {
+		layerArtifacts[i].hash, err = claircore.NewDigest("sha256", bytes.Repeat([]byte{uint8(i)}, sha256.Size))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	err = coalescer.coalesce(ctx, layerArtifacts)
 	if err != nil {
 		t.Fatalf("received error from coalesce method: %v", err)
 	}

--- a/internal/indexer/postgres/distributionsbylayer.go
+++ b/internal/indexer/postgres/distributionsbylayer.go
@@ -30,7 +30,7 @@ WHERE
 	dist_scanartifact.layer_hash = '%s' AND dist_scanartifact.scanner_id IN (?);`
 )
 
-func distributionsByLayer(ctx context.Context, db *sqlx.DB, hash string, scnrs indexer.VersionedScanners) ([]*claircore.Distribution, error) {
+func distributionsByLayer(ctx context.Context, db *sqlx.DB, hash claircore.Digest, scnrs indexer.VersionedScanners) ([]*claircore.Distribution, error) {
 	// TODO Use passed-in Context.
 	// get scanner ids
 	scannerIDs := []int64{}

--- a/internal/indexer/postgres/distributionsbylayer_test.go
+++ b/internal/indexer/postgres/distributionsbylayer_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	"github.com/quay/claircore"
 	"github.com/quay/claircore/test"
 	"github.com/quay/claircore/test/integration"
 	"github.com/quay/claircore/test/log"
@@ -21,7 +22,7 @@ func Test_DistributionsByLayer_Success(t *testing.T) {
 		// name of the test
 		name string
 		// the layer hash we want to test
-		hash string
+		hash claircore.Digest
 		// number dists to create
 		dists int
 		// number scnrs to create
@@ -29,37 +30,37 @@ func Test_DistributionsByLayer_Success(t *testing.T) {
 	}{
 		{
 			name:  "10 dists, 5 scanners",
-			hash:  "test-layer-hash",
+			hash:  randomHash(t),
 			dists: 10,
 			scnrs: 5,
 		},
 		{
 			name:  "50 distss, 25 scanners",
-			hash:  "test-layer-hash",
+			hash:  randomHash(t),
 			dists: 50,
 			scnrs: 25,
 		},
 		{
 			name:  "100 distss, 50 scanners",
-			hash:  "test-layer-hash",
+			hash:  randomHash(t),
 			dists: 100,
 			scnrs: 50,
 		},
 		{
 			name:  "500 distss, 250 scanners",
-			hash:  "test-layer-hash",
+			hash:  randomHash(t),
 			dists: 500,
 			scnrs: 250,
 		},
 		{
 			name:  "1000 distss, 500 scanners",
-			hash:  "test-layer-hash",
+			hash:  randomHash(t),
 			dists: 1000,
 			scnrs: 500,
 		},
 		{
 			name:  "2000 distss, 1000 scanners",
-			hash:  "test-layer-hash",
+			hash:  randomHash(t),
 			dists: 2000,
 			scnrs: 1000,
 		},

--- a/internal/indexer/postgres/indexdistributions_test.go
+++ b/internal/indexer/postgres/indexdistributions_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/jmoiron/sqlx"
 
 	"github.com/quay/claircore"
@@ -30,56 +31,56 @@ func Test_IndexDistributions_Success(t *testing.T) {
 			name:  "10 packages",
 			dists: 10,
 			layer: &claircore.Layer{
-				Hash: "test-layer-hash",
+				Hash: randomHash(t),
 			},
 		},
 		{
 			name:  "50 packages",
 			dists: 50,
 			layer: &claircore.Layer{
-				Hash: "test-layer-hash",
+				Hash: randomHash(t),
 			},
 		},
 		{
 			name:  "100 packages",
 			dists: 100,
 			layer: &claircore.Layer{
-				Hash: "test-layer-hash",
+				Hash: randomHash(t),
 			},
 		},
 		{
 			name:  "250 packages",
 			dists: 250,
 			layer: &claircore.Layer{
-				Hash: "test-layer-hash",
+				Hash: randomHash(t),
 			},
 		},
 		{
 			name:  "500 packages",
 			dists: 500,
 			layer: &claircore.Layer{
-				Hash: "test-layer-hash",
+				Hash: randomHash(t),
 			},
 		},
 		{
 			name:  "1000 packages",
 			dists: 1000,
 			layer: &claircore.Layer{
-				Hash: "test-layer-hash",
+				Hash: randomHash(t),
 			},
 		},
 		{
 			name:  "2000 packages",
 			dists: 2000,
 			layer: &claircore.Layer{
-				Hash: "test-layer-hash",
+				Hash: randomHash(t),
 			},
 		},
 		{
 			name:  "3000 packages",
 			dists: 3000,
 			layer: &claircore.Layer{
-				Hash: "test-layer-hash",
+				Hash: randomHash(t),
 			},
 		},
 	}
@@ -145,7 +146,7 @@ func checkDistScanArtifact(t *testing.T, db *sqlx.DB, expectedDists []*claircore
 		}
 		t.Logf("got distID %d", distID.Int64)
 
-		var layer_hash string
+		var layerHash claircore.Digest
 		var dist_id, scanner_id sql.NullInt64
 		row := db.QueryRowx(
 			`SELECT layer_hash, dist_id, scanner_id 
@@ -158,7 +159,7 @@ func checkDistScanArtifact(t *testing.T, db *sqlx.DB, expectedDists []*claircore
 			0,
 		)
 
-		err = row.Scan(&layer_hash, &dist_id, &scanner_id)
+		err = row.Scan(&layerHash, &dist_id, &scanner_id)
 		if err != nil {
 			if err == sql.ErrNoRows {
 				t.Fatalf("failed to find scanartifact for dist %v", dist)
@@ -166,8 +167,8 @@ func checkDistScanArtifact(t *testing.T, db *sqlx.DB, expectedDists []*claircore
 			t.Fatalf("received error selecting scanartifact for dist %v: %v", dist, err)
 		}
 
-		if got, want := layer_hash, layer.Hash; got != want {
-			t.Errorf("got: %q, want: %q", got, want)
+		if got, want := layerHash, layer.Hash; !cmp.Equal(got, want, cmp.AllowUnexported(claircore.Digest{})) {
+			t.Error(cmp.Diff(got, want))
 		}
 		if got, want := dist_id, distID; !got.Valid || got.Int64 != want.Int64 {
 			t.Errorf("got: %v, want: %v", got, want)

--- a/internal/indexer/postgres/indexpackage_benchmark_test.go
+++ b/internal/indexer/postgres/indexpackage_benchmark_test.go
@@ -29,14 +29,14 @@ func Benchmark_IndexPackages(b *testing.B) {
 			name: "10 packages",
 			pkgs: 10,
 			layer: &claircore.Layer{
-				Hash: "test-layer-hash",
+				Hash: randomHash(b),
 			},
 		},
 		{
 			name: "10 packages with duplicates",
 			pkgs: 10,
 			layer: &claircore.Layer{
-				Hash: "test-layer-hash",
+				Hash: randomHash(b),
 			},
 			duplicates: true,
 		},
@@ -44,14 +44,14 @@ func Benchmark_IndexPackages(b *testing.B) {
 			name: "50 packages",
 			pkgs: 50,
 			layer: &claircore.Layer{
-				Hash: "test-layer-hash",
+				Hash: randomHash(b),
 			},
 		},
 		{
 			name: "50 packages with duplicates",
 			pkgs: 50,
 			layer: &claircore.Layer{
-				Hash: "test-layer-hash",
+				Hash: randomHash(b),
 			},
 			duplicates: true,
 		},
@@ -59,14 +59,14 @@ func Benchmark_IndexPackages(b *testing.B) {
 			name: "100 packages",
 			pkgs: 100,
 			layer: &claircore.Layer{
-				Hash: "test-layer-hash",
+				Hash: randomHash(b),
 			},
 		},
 		{
 			name: "100 packages with duplicates",
 			pkgs: 100,
 			layer: &claircore.Layer{
-				Hash: "test-layer-hash",
+				Hash: randomHash(b),
 			},
 			duplicates: true,
 		},
@@ -74,14 +74,14 @@ func Benchmark_IndexPackages(b *testing.B) {
 			name: "250 packages",
 			pkgs: 250,
 			layer: &claircore.Layer{
-				Hash: "test-layer-hash",
+				Hash: randomHash(b),
 			},
 		},
 		{
 			name: "250 packages",
 			pkgs: 250,
 			layer: &claircore.Layer{
-				Hash: "test-layer-hash",
+				Hash: randomHash(b),
 			},
 			duplicates: true,
 		},
@@ -89,14 +89,14 @@ func Benchmark_IndexPackages(b *testing.B) {
 			name: "500 packages",
 			pkgs: 500,
 			layer: &claircore.Layer{
-				Hash: "test-layer-hash",
+				Hash: randomHash(b),
 			},
 		},
 		{
 			name: "500 packages with duplicates",
 			pkgs: 500,
 			layer: &claircore.Layer{
-				Hash: "test-layer-hash",
+				Hash: randomHash(b),
 			},
 			duplicates: true,
 		},
@@ -104,14 +104,14 @@ func Benchmark_IndexPackages(b *testing.B) {
 			name: "1000 packages",
 			pkgs: 1000,
 			layer: &claircore.Layer{
-				Hash: "test-layer-hash",
+				Hash: randomHash(b),
 			},
 		},
 		{
 			name: "1000 packages with duplicates",
 			pkgs: 1000,
 			layer: &claircore.Layer{
-				Hash: "test-layer-hash",
+				Hash: randomHash(b),
 			},
 			duplicates: true,
 		},
@@ -119,14 +119,14 @@ func Benchmark_IndexPackages(b *testing.B) {
 			name: "2000 packages",
 			pkgs: 2000,
 			layer: &claircore.Layer{
-				Hash: "test-layer-hash",
+				Hash: randomHash(b),
 			},
 		},
 		{
 			name: "2000 packages with duplicates",
 			pkgs: 2000,
 			layer: &claircore.Layer{
-				Hash: "test-layer-hash",
+				Hash: randomHash(b),
 			},
 			duplicates: true,
 		},
@@ -134,14 +134,14 @@ func Benchmark_IndexPackages(b *testing.B) {
 			name: "3000 packages",
 			pkgs: 3000,
 			layer: &claircore.Layer{
-				Hash: "test-layer-hash",
+				Hash: randomHash(b),
 			},
 		},
 		{
 			name: "3000 packages with duplicates",
 			pkgs: 3000,
 			layer: &claircore.Layer{
-				Hash: "test-layer-hash",
+				Hash: randomHash(b),
 			},
 			duplicates: true,
 		},
@@ -149,14 +149,14 @@ func Benchmark_IndexPackages(b *testing.B) {
 			name: "4000 packages",
 			pkgs: 4000,
 			layer: &claircore.Layer{
-				Hash: "test-layer-hash",
+				Hash: randomHash(b),
 			},
 		},
 		{
 			name: "4000 packages with duplicates",
 			pkgs: 4000,
 			layer: &claircore.Layer{
-				Hash: "test-layer-hash",
+				Hash: randomHash(b),
 			},
 			duplicates: true,
 		},
@@ -164,14 +164,14 @@ func Benchmark_IndexPackages(b *testing.B) {
 			name: "5000 packages",
 			pkgs: 5000,
 			layer: &claircore.Layer{
-				Hash: "test-layer-hash",
+				Hash: randomHash(b),
 			},
 		},
 		{
 			name: "5000 packages with duplicates",
 			pkgs: 5000,
 			layer: &claircore.Layer{
-				Hash: "test-layer-hash",
+				Hash: randomHash(b),
 			},
 			duplicates: true,
 		},

--- a/internal/indexer/postgres/indexpackage_test.go
+++ b/internal/indexer/postgres/indexpackage_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/jmoiron/sqlx"
 
 	"github.com/quay/claircore"
@@ -39,56 +40,56 @@ func Test_IndexPackages_Success_Parallel(t *testing.T) {
 			name: "10 packages",
 			pkgs: 10,
 			layer: &claircore.Layer{
-				Hash: "test-layer-hash",
+				Hash: randomHash(t),
 			},
 		},
 		{
 			name: "50 packages",
 			pkgs: 50,
 			layer: &claircore.Layer{
-				Hash: "test-layer-hash",
+				Hash: randomHash(t),
 			},
 		},
 		{
 			name: "100 packages",
 			pkgs: 100,
 			layer: &claircore.Layer{
-				Hash: "test-layer-hash",
+				Hash: randomHash(t),
 			},
 		},
 		{
 			name: "250 packages",
 			pkgs: 250,
 			layer: &claircore.Layer{
-				Hash: "test-layer-hash",
+				Hash: randomHash(t),
 			},
 		},
 		{
 			name: "500 packages",
 			pkgs: 500,
 			layer: &claircore.Layer{
-				Hash: "test-layer-hash",
+				Hash: randomHash(t),
 			},
 		},
 		{
 			name: "1000 packages",
 			pkgs: 1000,
 			layer: &claircore.Layer{
-				Hash: "test-layer-hash",
+				Hash: randomHash(t),
 			},
 		},
 		{
 			name: "2000 packages",
 			pkgs: 2000,
 			layer: &claircore.Layer{
-				Hash: "test-layer-hash",
+				Hash: randomHash(t),
 			},
 		},
 		{
 			name: "3000 packages",
 			pkgs: 3000,
 			layer: &claircore.Layer{
-				Hash: "test-layer-hash",
+				Hash: randomHash(t),
 			},
 		},
 	}
@@ -141,56 +142,56 @@ func Test_IndexPackages_Success(t *testing.T) {
 			name: "10 packages",
 			pkgs: 10,
 			layer: &claircore.Layer{
-				Hash: "test-layer-hash",
+				Hash: randomHash(t),
 			},
 		},
 		{
 			name: "50 packages",
 			pkgs: 50,
 			layer: &claircore.Layer{
-				Hash: "test-layer-hash",
+				Hash: randomHash(t),
 			},
 		},
 		{
 			name: "100 packages",
 			pkgs: 100,
 			layer: &claircore.Layer{
-				Hash: "test-layer-hash",
+				Hash: randomHash(t),
 			},
 		},
 		{
 			name: "250 packages",
 			pkgs: 250,
 			layer: &claircore.Layer{
-				Hash: "test-layer-hash",
+				Hash: randomHash(t),
 			},
 		},
 		{
 			name: "500 packages",
 			pkgs: 500,
 			layer: &claircore.Layer{
-				Hash: "test-layer-hash",
+				Hash: randomHash(t),
 			},
 		},
 		{
 			name: "1000 packages",
 			pkgs: 1000,
 			layer: &claircore.Layer{
-				Hash: "test-layer-hash",
+				Hash: randomHash(t),
 			},
 		},
 		{
 			name: "2000 packages",
 			pkgs: 2000,
 			layer: &claircore.Layer{
-				Hash: "test-layer-hash",
+				Hash: randomHash(t),
 			},
 		},
 		{
 			name: "3000 packages",
 			pkgs: 3000,
 			layer: &claircore.Layer{
-				Hash: "test-layer-hash",
+				Hash: randomHash(t),
 			},
 		},
 	}
@@ -242,7 +243,8 @@ func checkPackageScanArtifact(t *testing.T, db *sqlx.DB, expectedPkgs []*clairco
 			t.Fatalf("received error selecting package id %s version %s", pkg.Name, pkg.Version)
 		}
 
-		var layer_hash, package_db, repository_hint string
+		var layerHash claircore.Digest
+		var package_db, repository_hint string
 		var package_id, source_id, scanner_id sql.NullInt64
 		row := db.QueryRowx(
 			`SELECT layer_hash, package_id, source_id, scanner_id, package_db, repository_hint
@@ -255,7 +257,7 @@ func checkPackageScanArtifact(t *testing.T, db *sqlx.DB, expectedPkgs []*clairco
 			0,
 		)
 
-		err = row.Scan(&layer_hash, &package_id, &source_id, &scanner_id, &package_db, &repository_hint)
+		err = row.Scan(&layerHash, &package_id, &source_id, &scanner_id, &package_db, &repository_hint)
 		if err != nil {
 			if err == sql.ErrNoRows {
 				t.Fatalf("failed to find scanartifact for pkg %v", pkg)
@@ -263,8 +265,8 @@ func checkPackageScanArtifact(t *testing.T, db *sqlx.DB, expectedPkgs []*clairco
 			t.Fatalf("received error selecting scanartifact for pkg %v: %v", pkg, err)
 		}
 
-		if got, want := layer_hash, layer.Hash; got != want {
-			t.Errorf("got: %q, want: %q", got, want)
+		if got, want := layerHash, layer.Hash; !cmp.Equal(got, want, cmp.AllowUnexported(claircore.Digest{})) {
+			t.Error(cmp.Diff(got, want))
 		}
 		if got, want := package_id, pkgID; !got.Valid || got.Int64 != want.Int64 {
 			t.Errorf("got: %v, want: %v", got, want)

--- a/internal/indexer/postgres/indexreport.go
+++ b/internal/indexer/postgres/indexreport.go
@@ -14,7 +14,7 @@ const (
 	selectIndexReport = `SELECT scan_result FROM indexreport WHERE manifest_hash = $1`
 )
 
-func indexReport(ctx context.Context, db *sqlx.DB, hash string) (*claircore.IndexReport, bool, error) {
+func indexReport(ctx context.Context, db *sqlx.DB, hash claircore.Digest) (*claircore.IndexReport, bool, error) {
 	// TODO Use passed-in Context.
 	// we scan into a jsonbIndexReport which has value/scan method set
 	// then type convert back to scanner.domain object

--- a/internal/indexer/postgres/indexreport_test.go
+++ b/internal/indexer/postgres/indexreport_test.go
@@ -20,23 +20,23 @@ func Test_IndexReport_Success(t *testing.T) {
 		// the name of the test
 		name string
 		// the hash to lookup
-		hash string
+		hash claircore.Digest
 		// the expected scan result
 		expectedSR *claircore.IndexReport
 		// initialize the database. this test requires us to
 		// create the IndexReport
-		init func(t *testing.T, db *sqlx.DB, sr *claircore.IndexReport, hash string)
+		init func(t *testing.T, db *sqlx.DB, sr *claircore.IndexReport, hash claircore.Digest)
 	}{
 		{
 			name: "full scan result",
-			hash: "test-manifest-hash",
+			hash: randomHash(t),
 			expectedSR: &claircore.IndexReport{
-				Hash:    "test-manifest-hash",
+				Hash:    randomHash(t),
 				State:   "test-state",
 				Success: true,
 				Err:     "",
 			},
-			init: func(t *testing.T, db *sqlx.DB, sr *claircore.IndexReport, hash string) {
+			init: func(t *testing.T, db *sqlx.DB, sr *claircore.IndexReport, hash claircore.Digest) {
 				insertIndexReport(t, db, sr, hash)
 			},
 		},
@@ -59,14 +59,14 @@ func Test_IndexReport_Success(t *testing.T) {
 			if !ok {
 				t.Error("not OK")
 			}
-			if got, want := sr, table.expectedSR; !cmp.Equal(got, want) {
+			if got, want := sr, table.expectedSR; !cmp.Equal(got, want, cmp.AllowUnexported(claircore.Digest{})) {
 				t.Fatal(cmp.Diff(got, want))
 			}
 		})
 	}
 }
 
-func insertIndexReport(t *testing.T, db *sqlx.DB, sr *claircore.IndexReport, hash string) {
+func insertIndexReport(t *testing.T, db *sqlx.DB, sr *claircore.IndexReport, hash claircore.Digest) {
 	_, err := db.Exec(`INSERT INTO indexreport (manifest_hash, scan_result) VALUES ($1, $2)`, hash, jsonbIndexReport(*sr))
 	if err != nil {
 		t.Fatalf("failed to insert test scan result: %v", err)

--- a/internal/indexer/postgres/indexrepository_test.go
+++ b/internal/indexer/postgres/indexrepository_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/jmoiron/sqlx"
 
 	"github.com/quay/claircore"
@@ -121,7 +122,7 @@ func checkRepoScanArtifact(t *testing.T, db *sqlx.DB, expectedRepos []*claircore
 		}
 		t.Logf("repo id: %d", repoID.Int64)
 
-		var layer_hash string
+		var layer_hash claircore.Digest
 		var repo_id, scanner_id sql.NullInt64
 		row := db.QueryRowx(
 			`SELECT layer_hash, repo_id, scanner_id 
@@ -142,8 +143,8 @@ func checkRepoScanArtifact(t *testing.T, db *sqlx.DB, expectedRepos []*claircore
 			t.Fatalf("received error selecting scanartifact for dist %v: %v", repo, err)
 		}
 
-		if got, want := layer_hash, layer.Hash; got != want {
-			t.Errorf("got: %q, want: %q", got, want)
+		if got, want := layer_hash, layer.Hash; !cmp.Equal(got, want, cmp.AllowUnexported(claircore.Digest{})) {
+			t.Error(cmp.Diff(got, want))
 		}
 		if got, want := repo_id, repoID; !got.Valid || got.Int64 != want.Int64 {
 			t.Errorf("got: %v, want: %v", got, want)

--- a/internal/indexer/postgres/layerscanned.go
+++ b/internal/indexer/postgres/layerscanned.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/jmoiron/sqlx"
 
+	"github.com/quay/claircore"
 	"github.com/quay/claircore/internal/indexer"
 )
 
@@ -20,7 +21,7 @@ const (
 	selectRepositoryScanArtifact   = `SELECT layer_hash FROM repo_scanartifact WHERE layer_hash = $1 AND scanner_id = $2 LIMIT 1;`
 )
 
-func layerScanned(ctx context.Context, db *sqlx.DB, hash string, scnr indexer.VersionedScanner) (bool, error) {
+func layerScanned(ctx context.Context, db *sqlx.DB, hash claircore.Digest, scnr indexer.VersionedScanner) (bool, error) {
 	// TODO Use passed-in Context.
 	var scannerID int64
 	err := db.Get(&scannerID, selectScannerID, scnr.Name(), scnr.Version())
@@ -32,7 +33,7 @@ func layerScanned(ctx context.Context, db *sqlx.DB, hash string, scnr indexer.Ve
 		return false, err
 	}
 
-	var layerHash string
+	var layerHash claircore.Digest
 	var query string
 	switch scnr.Kind() {
 	case "package":

--- a/internal/indexer/postgres/layerscanned_test.go
+++ b/internal/indexer/postgres/layerscanned_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/quay/claircore"
 	"github.com/quay/claircore/test"
 	"github.com/quay/claircore/test/integration"
 	"github.com/quay/claircore/test/log"
@@ -18,7 +19,7 @@ func Test_LayerScanned_Packages_False(t *testing.T) {
 		// the name of the test
 		name string
 		// the layer's hash we are testing
-		hash string
+		hash claircore.Digest
 		// the number of scanners to create and linke with the layer_hash
 		scnrs int
 		// the number of packages to be associated with the scanartifacts and layer hash
@@ -26,19 +27,19 @@ func Test_LayerScanned_Packages_False(t *testing.T) {
 	}{
 		{
 			name:  "single scanner, single package",
-			hash:  "test-layer-hash",
+			hash:  randomHash(t),
 			scnrs: 1,
 			pkgs:  1,
 		},
 		{
 			name:  "4 scanners, 4 packages",
-			hash:  "test-layer-hash",
+			hash:  randomHash(t),
 			scnrs: 4,
 			pkgs:  4,
 		},
 		{
 			name:  "4 scanners, 8 packages",
-			hash:  "test-layer-hash",
+			hash:  randomHash(t),
 			scnrs: 4,
 			pkgs:  8,
 		},
@@ -82,7 +83,7 @@ func Test_LayerScanned_Distributions_False(t *testing.T) {
 		// the name of the test
 		name string
 		// the layer's hash we are testing
-		hash string
+		hash claircore.Digest
 		// the number of scanners to create and linke with the layer_hash
 		scnrs int
 		// the number of distributions to be associated with the scanartifacts and layer hash
@@ -90,19 +91,19 @@ func Test_LayerScanned_Distributions_False(t *testing.T) {
 	}{
 		{
 			name:  "single scanner, single distribution",
-			hash:  "test-layer-hash",
+			hash:  randomHash(t),
 			scnrs: 1,
 			dists: 1,
 		},
 		{
 			name:  "4 scanners, 4 distributions",
-			hash:  "test-layer-hash",
+			hash:  randomHash(t),
 			scnrs: 4,
 			dists: 4,
 		},
 		{
 			name:  "4 scanners, 8 distributions",
-			hash:  "test-layer-hash",
+			hash:  randomHash(t),
 			scnrs: 4,
 			dists: 8,
 		},
@@ -147,7 +148,7 @@ func Test_LayerScanned_Repository_False(t *testing.T) {
 		// the name of the test
 		name string
 		// the layer's hash we are testing
-		hash string
+		hash claircore.Digest
 		// the number of scanners to create and linke with the layer_hash
 		scnrs int
 		// the number of repositories to be associated with the scanartifacts and layer hash
@@ -155,19 +156,19 @@ func Test_LayerScanned_Repository_False(t *testing.T) {
 	}{
 		{
 			name:  "single scanner, single repositories",
-			hash:  "test-layer-hash",
+			hash:  randomHash(t),
 			scnrs: 1,
 			repos: 1,
 		},
 		{
 			name:  "4 scanners, 4 repositories",
-			hash:  "test-layer-hash",
+			hash:  randomHash(t),
 			scnrs: 4,
 			repos: 4,
 		},
 		{
 			name:  "4 scanners, 8 repositories",
-			hash:  "test-layer-hash",
+			hash:  randomHash(t),
 			scnrs: 4,
 			repos: 8,
 		},
@@ -211,7 +212,7 @@ func Test_LayerScanned_Packages_True(t *testing.T) {
 		// the name of the test
 		name string
 		// the layer's hash we are testing
-		hash string
+		hash claircore.Digest
 		// the number of scanners to create and linke with the layer_hash
 		scnrs int
 		// the number of packages to be associated with the scanartifacts and layer hash
@@ -219,19 +220,19 @@ func Test_LayerScanned_Packages_True(t *testing.T) {
 	}{
 		{
 			name:  "single scanner, single package",
-			hash:  "test-layer-hash",
+			hash:  randomHash(t),
 			scnrs: 1,
 			pkgs:  1,
 		},
 		{
 			name:  "4 scanners, 4 packages",
-			hash:  "test-layer-hash",
+			hash:  randomHash(t),
 			scnrs: 4,
 			pkgs:  4,
 		},
 		{
 			name:  "4 scanners, 8 packages",
-			hash:  "test-layer-hash",
+			hash:  randomHash(t),
 			scnrs: 4,
 			pkgs:  8,
 		},
@@ -280,7 +281,7 @@ func Test_LayerScanned_Distribution_True(t *testing.T) {
 		// the name of the test
 		name string
 		// the layer's hash we are testing
-		hash string
+		hash claircore.Digest
 		// the number of scanners to create and linke with the layer_hash
 		scnrs int
 		// the number of distributions to be associated with the scanartifacts and layer hash
@@ -288,19 +289,19 @@ func Test_LayerScanned_Distribution_True(t *testing.T) {
 	}{
 		{
 			name:  "single scanner, single package",
-			hash:  "test-layer-hash",
+			hash:  randomHash(t),
 			scnrs: 1,
 			dists: 1,
 		},
 		{
 			name:  "4 scanners, 4 distributions",
-			hash:  "test-layer-hash",
+			hash:  randomHash(t),
 			scnrs: 4,
 			dists: 4,
 		},
 		{
 			name:  "4 scanners, 8 distributions",
-			hash:  "test-layer-hash",
+			hash:  randomHash(t),
 			scnrs: 4,
 			dists: 8,
 		},
@@ -349,7 +350,7 @@ func Test_LayerScanned_Repository_True(t *testing.T) {
 		// the name of the test
 		name string
 		// the layer's hash we are testing
-		hash string
+		hash claircore.Digest
 		// the number of scanners to create and linke with the layer_hash
 		scnrs int
 		// the number of repositories to be associated with the scanartifacts and layer hash
@@ -357,19 +358,19 @@ func Test_LayerScanned_Repository_True(t *testing.T) {
 	}{
 		{
 			name:  "single scanner, single repository",
-			hash:  "test-layer-hash",
+			hash:  randomHash(t),
 			scnrs: 1,
 			dists: 1,
 		},
 		{
 			name:  "4 scanners, 4 repository",
-			hash:  "test-layer-hash",
+			hash:  randomHash(t),
 			scnrs: 4,
 			dists: 4,
 		},
 		{
 			name:  "4 scanners, 8 repository",
-			hash:  "test-layer-hash",
+			hash:  randomHash(t),
 			scnrs: 4,
 			dists: 8,
 		},

--- a/internal/indexer/postgres/manifestscanned.go
+++ b/internal/indexer/postgres/manifestscanned.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/jmoiron/sqlx"
 
+	"github.com/quay/claircore"
 	"github.com/quay/claircore/internal/indexer"
 )
 
@@ -16,7 +17,7 @@ const (
 
 // manifestScanned determines if a manifest has been scanned by ALL the provided
 // scnrs.
-func manifestScanned(ctx context.Context, db *sqlx.DB, hash string, scnrs indexer.VersionedScanners) (bool, error) {
+func manifestScanned(ctx context.Context, db *sqlx.DB, hash claircore.Digest, scnrs indexer.VersionedScanners) (bool, error) {
 	// TODO Use passed-in Context.
 	// get the ids of the scanners we are testing for.
 	var expectedIDs []int64

--- a/internal/indexer/postgres/manifestscanned_test.go
+++ b/internal/indexer/postgres/manifestscanned_test.go
@@ -4,44 +4,46 @@ import (
 	"context"
 	"testing"
 
+	"github.com/quay/claircore"
 	"github.com/quay/claircore/test"
 	"github.com/quay/claircore/test/integration"
 	"github.com/quay/claircore/test/log"
 	pgtest "github.com/quay/claircore/test/postgres"
 )
 
+type scannerTestcase struct {
+	// the name of this test
+	name string
+	// the manifest hash
+	hash claircore.Digest
+	// the number of scanners linked to a manifest
+	scanners int
+}
+
 func Test_ManifestScanned_Failure(t *testing.T) {
 	integration.Skip(t)
 	ctx, done := context.WithCancel(context.Background())
 	defer done()
-	const hash = `deadbeef`
 
-	var tt = []struct {
-		// the name of this test
-		name string
-		// the manifest hash
-		hash string
-		// the number of scanners linked to a manifest
-		scanners int
-	}{
+	var tt = []scannerTestcase{
 		{
 			name:     "one scanner",
-			hash:     hash,
+			hash:     randomHash(t),
 			scanners: 1,
 		},
 		{
 			name:     "two scanners",
-			hash:     hash,
+			hash:     randomHash(t),
 			scanners: 2,
 		},
 		{
 			name:     "five scanners",
-			hash:     hash,
+			hash:     randomHash(t),
 			scanners: 5,
 		},
 		{
 			name:     "ten scanners",
-			hash:     hash,
+			hash:     randomHash(t),
 			scanners: 10,
 		},
 	}
@@ -75,34 +77,26 @@ func Test_ManifestScanned_Success(t *testing.T) {
 	integration.Skip(t)
 	ctx, done := context.WithCancel(context.Background())
 	defer done()
-	const hash = `deafbeef`
 
-	var tt = []struct {
-		// the name of this test
-		name string
-		// the manifest hash
-		hash string
-		// the number of scanners linked to a manifest
-		scanners int
-	}{
+	var tt = []scannerTestcase{
 		{
 			name:     "one scanner",
-			hash:     hash,
+			hash:     randomHash(t),
 			scanners: 1,
 		},
 		{
 			name:     "two scanners",
-			hash:     hash,
+			hash:     randomHash(t),
 			scanners: 2,
 		},
 		{
 			name:     "five scanners",
-			hash:     hash,
+			hash:     randomHash(t),
 			scanners: 5,
 		},
 		{
 			name:     "ten scanners",
-			hash:     hash,
+			hash:     randomHash(t),
 			scanners: 10,
 		},
 	}

--- a/internal/indexer/postgres/packagesbylayer.go
+++ b/internal/indexer/postgres/packagesbylayer.go
@@ -35,7 +35,7 @@ WHERE
   package_scanartifact.layer_hash = '%s' AND package_scanartifact.scanner_id IN (?);`
 )
 
-func packagesByLayer(ctx context.Context, db *sqlx.DB, hash string, scnrs indexer.VersionedScanners) ([]*claircore.Package, error) {
+func packagesByLayer(ctx context.Context, db *sqlx.DB, hash claircore.Digest, scnrs indexer.VersionedScanners) ([]*claircore.Package, error) {
 	// TODO Use passed-in Context.
 	// get scanner ids
 	scannerIDs := []int64{}

--- a/internal/indexer/postgres/packagesbylayer_benchmark_test.go
+++ b/internal/indexer/postgres/packagesbylayer_benchmark_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/quay/claircore"
 	"github.com/quay/claircore/test"
 	"github.com/quay/claircore/test/integration"
 	"github.com/quay/claircore/test/log"
@@ -16,73 +17,73 @@ func Benchmark_PackagesByLayer(b *testing.B) {
 	defer done()
 	benchmarks := []struct {
 		name  string
-		hash  string
+		hash  claircore.Digest
 		pkgs  int
 		scnrs int
 	}{
 		{
 			name:  "10 package, 5 scanners",
-			hash:  "test-layer-hash",
+			hash:  randomHash(b),
 			pkgs:  10,
 			scnrs: 5,
 		},
 		{
 			name:  "50 packages, 25 scanners",
-			hash:  "test-layer-hash",
+			hash:  randomHash(b),
 			pkgs:  50,
 			scnrs: 25,
 		},
 		{
 			name:  "100 packages, 50 scanners",
-			hash:  "test-layer-hash",
+			hash:  randomHash(b),
 			pkgs:  100,
 			scnrs: 50,
 		},
 		{
 			name:  "500 packages, 250 scanners",
-			hash:  "test-layer-hash",
+			hash:  randomHash(b),
 			pkgs:  500,
 			scnrs: 250,
 		},
 		{
 			name:  "1000 packages, 500 scanners",
-			hash:  "test-layer-hash",
+			hash:  randomHash(b),
 			pkgs:  1000,
 			scnrs: 500,
 		},
 		{
 			name:  "2000 packages, 1000 scanners",
-			hash:  "test-layer-hash",
+			hash:  randomHash(b),
 			pkgs:  2000,
 			scnrs: 1000,
 		},
 		{
 			name:  "3000 packages, 2000 scanners",
-			hash:  "test-layer-hash",
+			hash:  randomHash(b),
 			pkgs:  3000,
 			scnrs: 1000,
 		},
 		{
 			name:  "3000 packages, 500 scanners",
-			hash:  "test-layer-hash",
+			hash:  randomHash(b),
 			pkgs:  3000,
 			scnrs: 500,
 		},
 		{
 			name:  "3000 packages, 250 scanners",
-			hash:  "test-layer-hash",
+			hash:  randomHash(b),
 			pkgs:  3000,
 			scnrs: 250,
 		},
 		{
 			name:  "3000 packages, 50 scanners",
-			hash:  "test-layer-hash",
+			hash:  randomHash(b),
 			pkgs:  2000,
 			scnrs: 50,
 		},
 		{
 			name:  "3000 packages, 10 scanners",
-			hash:  "test-layer-hash",
+			hash:  randomHash(b),
 			pkgs:  2000,
 			scnrs: 10,
 		},

--- a/internal/indexer/postgres/packagesbylayer_test.go
+++ b/internal/indexer/postgres/packagesbylayer_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	"github.com/quay/claircore"
 	"github.com/quay/claircore/test"
 	"github.com/quay/claircore/test/integration"
 	"github.com/quay/claircore/test/log"
@@ -21,7 +22,7 @@ func Test_PackagesByLayer_Success(t *testing.T) {
 		// name of the test
 		name string
 		// the layer hash we want to test
-		hash string
+		hash claircore.Digest
 		// number packages to create
 		pkgs int
 		// number scnrs to create
@@ -29,37 +30,37 @@ func Test_PackagesByLayer_Success(t *testing.T) {
 	}{
 		{
 			name:  "10 package, 5 scanners",
-			hash:  "test-layer-hash",
+			hash:  randomHash(t),
 			pkgs:  10,
 			scnrs: 5,
 		},
 		{
 			name:  "50 packages, 25 scanners",
-			hash:  "test-layer-hash",
+			hash:  randomHash(t),
 			pkgs:  50,
 			scnrs: 25,
 		},
 		{
 			name:  "100 packages, 50 scanners",
-			hash:  "test-layer-hash",
+			hash:  randomHash(t),
 			pkgs:  100,
 			scnrs: 50,
 		},
 		{
 			name:  "500 packages, 250 scanners",
-			hash:  "test-layer-hash",
+			hash:  randomHash(t),
 			pkgs:  500,
 			scnrs: 250,
 		},
 		{
 			name:  "1000 packages, 500 scanners",
-			hash:  "test-layer-hash",
+			hash:  randomHash(t),
 			pkgs:  1000,
 			scnrs: 500,
 		},
 		{
 			name:  "2000 packages, 1000 scanners",
-			hash:  "test-layer-hash",
+			hash:  randomHash(t),
 			pkgs:  2000,
 			scnrs: 1000,
 		},

--- a/internal/indexer/postgres/postgres_test.go
+++ b/internal/indexer/postgres/postgres_test.go
@@ -1,0 +1,23 @@
+package postgres
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"io"
+	"testing"
+
+	"github.com/quay/claircore"
+)
+
+// RandomHash returns a random Digest.
+func randomHash(t testing.TB) claircore.Digest {
+	b := make([]byte, sha256.Size)
+	if _, err := io.ReadFull(rand.Reader, b); err != nil {
+		t.Fatal(err)
+	}
+	d, err := claircore.NewDigest("sha256", b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return d
+}

--- a/internal/indexer/postgres/repositoriesbylayer.go
+++ b/internal/indexer/postgres/repositoriesbylayer.go
@@ -25,7 +25,7 @@ WHERE
 	repo_scanartifact.layer_hash = '%s' AND repo_scanartifact.scanner_id IN (?);`
 )
 
-func repositoriesByLayer(ctx context.Context, db *sqlx.DB, hash string, scnrs indexer.VersionedScanners) ([]*claircore.Repository, error) {
+func repositoriesByLayer(ctx context.Context, db *sqlx.DB, hash claircore.Digest, scnrs indexer.VersionedScanners) ([]*claircore.Repository, error) {
 	// TODO Use passed-in Context.
 	// get scanner ids
 	scannerIDs := []int64{}

--- a/internal/indexer/postgres/repositoriesbylayer_test.go
+++ b/internal/indexer/postgres/repositoriesbylayer_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	"github.com/quay/claircore"
 	"github.com/quay/claircore/test"
 	"github.com/quay/claircore/test/integration"
 	"github.com/quay/claircore/test/log"
@@ -21,7 +22,7 @@ func Test_RepositoriesByLayer_Success(t *testing.T) {
 		// name of the test
 		name string
 		// the layer hash we want to test
-		hash string
+		hash claircore.Digest
 		// number repos to create
 		repos int
 		// number scnrs to create
@@ -29,37 +30,37 @@ func Test_RepositoriesByLayer_Success(t *testing.T) {
 	}{
 		{
 			name:  "10 repos, 5 scanners",
-			hash:  "test-layer-hash",
+			hash:  randomHash(t),
 			repos: 10,
 			scnrs: 5,
 		},
 		{
 			name:  "50 repos, 25 scanners",
-			hash:  "test-layer-hash",
+			hash:  randomHash(t),
 			repos: 50,
 			scnrs: 25,
 		},
 		{
 			name:  "100 repos, 50 scanners",
-			hash:  "test-layer-hash",
+			hash:  randomHash(t),
 			repos: 100,
 			scnrs: 50,
 		},
 		{
 			name:  "500 repos, 250 scanners",
-			hash:  "test-layer-hash",
+			hash:  randomHash(t),
 			repos: 500,
 			scnrs: 250,
 		},
 		{
 			name:  "1000 repos, 500 scanners",
-			hash:  "test-layer-hash",
+			hash:  randomHash(t),
 			repos: 1000,
 			scnrs: 500,
 		},
 		{
 			name:  "2000 repos, 1000 scanners",
-			hash:  "test-layer-hash",
+			hash:  randomHash(t),
 			repos: 2000,
 			scnrs: 1000,
 		},

--- a/internal/indexer/postgres/setindexfinished_test.go
+++ b/internal/indexer/postgres/setindexfinished_test.go
@@ -19,7 +19,7 @@ func Test_SetScanFinished_Success(t *testing.T) {
 	defer done()
 	// function to initialize database. we must add all scanners to they are available in the database. we must then
 	// create scannlist records for any of the previousScnrs to prove we deleted them and linked the updatedScnrs
-	var init = func(t *testing.T, db *sqlx.DB, hash string, previousScnrs []scnrInfo, updatedScnrs []scnrInfo) {
+	var init = func(t *testing.T, db *sqlx.DB, hash claircore.Digest, previousScnrs []scnrInfo, updatedScnrs []scnrInfo) {
 		var temp = []scnrInfo{}
 		temp = append(temp, previousScnrs...)
 		temp = append(temp, updatedScnrs...)
@@ -46,17 +46,17 @@ func Test_SetScanFinished_Success(t *testing.T) {
 		// the name of this test
 		name string
 		// the manifest hash we are setting scanners for
-		hash string
+		hash claircore.Digest
 		// scnrs to insert for initialization information
 		previousScnrs []scnrInfo
 		// scnrs to call store.SetScannerList
 		updatedScnrs []scnrInfo
 		// initialize our database
-		init func(t *testing.T, db *sqlx.DB, hash string, previousScnrs []scnrInfo, updatedScnrs []scnrInfo)
+		init func(t *testing.T, db *sqlx.DB, hash claircore.Digest, previousScnrs []scnrInfo, updatedScnrs []scnrInfo)
 	}{
 		{
 			name:          "no previous scanners",
-			hash:          "test-manifest-hash",
+			hash:          randomHash(t),
 			previousScnrs: []scnrInfo{},
 			updatedScnrs: []scnrInfo{
 				scnrInfo{
@@ -117,7 +117,7 @@ func Test_SetScanFinished_Success(t *testing.T) {
 	}
 }
 
-func checkUpdatedScannerList(t *testing.T, db *sqlx.DB, hash string, updatedScnrs []scnrInfo) {
+func checkUpdatedScannerList(t *testing.T, db *sqlx.DB, hash claircore.Digest, updatedScnrs []scnrInfo) {
 	var foundIDs []int64
 	err := db.Select(&foundIDs, `SELECT scanner_id FROM scannerlist WHERE manifest_hash = $1`, hash)
 	if err != nil {

--- a/internal/indexer/postgres/setindexreport_test.go
+++ b/internal/indexer/postgres/setindexreport_test.go
@@ -15,6 +15,8 @@ func Test_SetIndexReport_StateUpdate(t *testing.T) {
 	integration.Skip(t)
 	ctx, done := context.WithCancel(context.Background())
 	defer done()
+
+	hash := randomHash(t)
 	var tt = []struct {
 		// the name of the test
 		name string
@@ -26,11 +28,11 @@ func Test_SetIndexReport_StateUpdate(t *testing.T) {
 		{
 			name: "single package. no nested source",
 			initState: &claircore.IndexReport{
-				Hash:  "test-manifest-hash",
+				Hash:  hash,
 				State: "initial-state",
 			},
 			transitionState: &claircore.IndexReport{
-				Hash:  "test-manifest-hash",
+				Hash:  hash,
 				State: "transitioned-state",
 			},
 		},
@@ -64,7 +66,7 @@ func Test_SetIndexReport_StateUpdate(t *testing.T) {
 	}
 }
 
-func getIndexReport(t *testing.T, db *sqlx.DB, hash string) claircore.IndexReport {
+func getIndexReport(t *testing.T, db *sqlx.DB, hash claircore.Digest) claircore.IndexReport {
 	// jsonbIndexReport is a type definition based on scanner.IndexReport but with jsonb Value/Scan methods
 	var sr jsonbIndexReport
 	row := db.QueryRow(`SELECT scan_result FROM indexreport WHERE manifest_hash = $1`, hash)
@@ -88,7 +90,7 @@ func Test_SetIndexReport_Success(t *testing.T) {
 		{
 			name: "single package. no nested source",
 			sr: &claircore.IndexReport{
-				Hash:    "test-manifest-hash",
+				Hash:    randomHash(t),
 				State:   "test-state",
 				Success: true,
 				Err:     "",
@@ -97,7 +99,7 @@ func Test_SetIndexReport_Success(t *testing.T) {
 		{
 			name: "single package nested source",
 			sr: &claircore.IndexReport{
-				Hash:    "test-manifest-hash",
+				Hash:    randomHash(t),
 				State:   "test-state",
 				Success: true,
 				Err:     "",

--- a/internal/indexer/postgres/store.go
+++ b/internal/indexer/postgres/store.go
@@ -27,12 +27,12 @@ func NewStore(db *sqlx.DB, pool *pgxpool.Pool) *store {
 	}
 }
 
-func (s *store) ManifestScanned(ctx context.Context, hash string, scnrs indexer.VersionedScanners) (bool, error) {
+func (s *store) ManifestScanned(ctx context.Context, hash claircore.Digest, scnrs indexer.VersionedScanners) (bool, error) {
 	b, err := manifestScanned(ctx, s.db, hash, scnrs)
 	return b, err
 }
 
-func (s *store) LayerScanned(ctx context.Context, hash string, scnr indexer.VersionedScanner) (bool, error) {
+func (s *store) LayerScanned(ctx context.Context, hash claircore.Digest, scnr indexer.VersionedScanner) (bool, error) {
 	b, err := layerScanned(ctx, s.db, hash, scnr)
 	return b, err
 }
@@ -52,17 +52,17 @@ func (s *store) IndexRepositories(ctx context.Context, repos []*claircore.Reposi
 	return err
 }
 
-func (s *store) PackagesByLayer(ctx context.Context, hash string, scnrs indexer.VersionedScanners) ([]*claircore.Package, error) {
+func (s *store) PackagesByLayer(ctx context.Context, hash claircore.Digest, scnrs indexer.VersionedScanners) ([]*claircore.Package, error) {
 	pkgs, err := packagesByLayer(ctx, s.db, hash, scnrs)
 	return pkgs, err
 }
 
-func (s *store) DistributionsByLayer(ctx context.Context, hash string, scnrs indexer.VersionedScanners) ([]*claircore.Distribution, error) {
+func (s *store) DistributionsByLayer(ctx context.Context, hash claircore.Digest, scnrs indexer.VersionedScanners) ([]*claircore.Distribution, error) {
 	dists, err := distributionsByLayer(ctx, s.db, hash, scnrs)
 	return dists, err
 }
 
-func (s *store) RepositoriesByLayer(ctx context.Context, hash string, scnrs indexer.VersionedScanners) ([]*claircore.Repository, error) {
+func (s *store) RepositoriesByLayer(ctx context.Context, hash claircore.Digest, scnrs indexer.VersionedScanners) ([]*claircore.Repository, error) {
 	repos, err := repositoriesByLayer(ctx, s.db, hash, scnrs)
 	return repos, err
 }
@@ -72,7 +72,7 @@ func (s *store) RegisterScanners(ctx context.Context, scnrs indexer.VersionedSca
 	return err
 }
 
-func (s *store) IndexReport(ctx context.Context, hash string) (*claircore.IndexReport, bool, error) {
+func (s *store) IndexReport(ctx context.Context, hash claircore.Digest) (*claircore.IndexReport, bool, error) {
 	sr, b, err := indexReport(ctx, s.db, hash)
 	return sr, b, err
 }

--- a/internal/indexer/store.go
+++ b/internal/indexer/store.go
@@ -10,9 +10,9 @@ import (
 // Stores may be implemented per storage backend.
 type Store interface {
 	// ManifestScanned returns whether the given manifest was scanned by the provided scanners
-	ManifestScanned(ctx context.Context, hash string, scnrs VersionedScanners) (bool, error)
+	ManifestScanned(ctx context.Context, hash claircore.Digest, scnrs VersionedScanners) (bool, error)
 	// LayerScanned returns whether the given layer was scanned by the provided scanner.
-	LayerScanned(ctx context.Context, hash string, scnr VersionedScanner) (bool, error)
+	LayerScanned(ctx context.Context, hash claircore.Digest, scnr VersionedScanner) (bool, error)
 	// IndexPackages indexes a package into the persistence layer.
 	IndexPackages(ctx context.Context, pkgs []*claircore.Package, layer *claircore.Layer, scnr VersionedScanner) error
 	// IndexDistributions indexes distributions into the persistence layer
@@ -20,15 +20,15 @@ type Store interface {
 	// IndexRepositories indexes repositories into the persistence layer
 	IndexRepositories(ctx context.Context, repos []*claircore.Repository, layer *claircore.Layer, scnr VersionedScanner) error
 	// PackagesByLayer gets all the packages found in a layer limited by the provided scanners
-	PackagesByLayer(ctx context.Context, hash string, scnrs VersionedScanners) ([]*claircore.Package, error)
+	PackagesByLayer(ctx context.Context, hash claircore.Digest, scnrs VersionedScanners) ([]*claircore.Package, error)
 	// DistributionsByLayer gets all the distributions found in a layer limited by the provided scanners
-	DistributionsByLayer(ctx context.Context, hash string, scnrs VersionedScanners) ([]*claircore.Distribution, error)
+	DistributionsByLayer(ctx context.Context, hash claircore.Digest, scnrs VersionedScanners) ([]*claircore.Distribution, error)
 	// RepositoriesByLayer gets all the repositories found in a layer limited by the provided scanners
-	RepositoriesByLayer(ctx context.Context, hash string, scnrs VersionedScanners) ([]*claircore.Repository, error)
+	RepositoriesByLayer(ctx context.Context, hash claircore.Digest, scnrs VersionedScanners) ([]*claircore.Repository, error)
 	// RegisterPackageScanners registers the provided scanners with the persistence layer
 	RegisterScanners(ctx context.Context, scnrs VersionedScanners) error
 	// IndexReport attempts to retrieve a persisted IndexReport.
-	IndexReport(ctx context.Context, hash string) (*claircore.IndexReport, bool, error)
+	IndexReport(ctx context.Context, hash claircore.Digest) (*claircore.IndexReport, bool, error)
 	// SetIndexReport persists the current state of the IndexReport. IndexReports may
 	// be in intermediate states to provide feedback for clients. this method should be
 	// used to communicate scanning state updates. to signal the scan has completely successfully

--- a/internal/indexer/store_mock.go
+++ b/internal/indexer/store_mock.go
@@ -35,7 +35,7 @@ func (m *MockStore) EXPECT() *MockStoreMockRecorder {
 }
 
 // DistributionsByLayer mocks base method
-func (m *MockStore) DistributionsByLayer(arg0 context.Context, arg1 string, arg2 VersionedScanners) ([]*claircore.Distribution, error) {
+func (m *MockStore) DistributionsByLayer(arg0 context.Context, arg1 claircore.Digest, arg2 VersionedScanners) ([]*claircore.Distribution, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DistributionsByLayer", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]*claircore.Distribution)
@@ -78,7 +78,7 @@ func (mr *MockStoreMockRecorder) IndexPackages(arg0, arg1, arg2, arg3 interface{
 }
 
 // IndexReport mocks base method
-func (m *MockStore) IndexReport(arg0 context.Context, arg1 string) (*claircore.IndexReport, bool, error) {
+func (m *MockStore) IndexReport(arg0 context.Context, arg1 claircore.Digest) (*claircore.IndexReport, bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IndexReport", arg0, arg1)
 	ret0, _ := ret[0].(*claircore.IndexReport)
@@ -108,7 +108,7 @@ func (mr *MockStoreMockRecorder) IndexRepositories(arg0, arg1, arg2, arg3 interf
 }
 
 // LayerScanned mocks base method
-func (m *MockStore) LayerScanned(arg0 context.Context, arg1 string, arg2 VersionedScanner) (bool, error) {
+func (m *MockStore) LayerScanned(arg0 context.Context, arg1 claircore.Digest, arg2 VersionedScanner) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LayerScanned", arg0, arg1, arg2)
 	ret0, _ := ret[0].(bool)
@@ -123,7 +123,7 @@ func (mr *MockStoreMockRecorder) LayerScanned(arg0, arg1, arg2 interface{}) *gom
 }
 
 // ManifestScanned mocks base method
-func (m *MockStore) ManifestScanned(arg0 context.Context, arg1 string, arg2 VersionedScanners) (bool, error) {
+func (m *MockStore) ManifestScanned(arg0 context.Context, arg1 claircore.Digest, arg2 VersionedScanners) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ManifestScanned", arg0, arg1, arg2)
 	ret0, _ := ret[0].(bool)
@@ -138,7 +138,7 @@ func (mr *MockStoreMockRecorder) ManifestScanned(arg0, arg1, arg2 interface{}) *
 }
 
 // PackagesByLayer mocks base method
-func (m *MockStore) PackagesByLayer(arg0 context.Context, arg1 string, arg2 VersionedScanners) ([]*claircore.Package, error) {
+func (m *MockStore) PackagesByLayer(arg0 context.Context, arg1 claircore.Digest, arg2 VersionedScanners) ([]*claircore.Package, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PackagesByLayer", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]*claircore.Package)
@@ -167,7 +167,7 @@ func (mr *MockStoreMockRecorder) RegisterScanners(arg0, arg1 interface{}) *gomoc
 }
 
 // RepositoriesByLayer mocks base method
-func (m *MockStore) RepositoriesByLayer(arg0 context.Context, arg1 string, arg2 VersionedScanners) ([]*claircore.Repository, error) {
+func (m *MockStore) RepositoriesByLayer(arg0 context.Context, arg1 claircore.Digest, arg2 VersionedScanners) ([]*claircore.Repository, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RepositoriesByLayer", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]*claircore.Repository)

--- a/layer.go
+++ b/layer.go
@@ -15,7 +15,7 @@ import (
 type Layer struct {
 	// Hash is a content addressable hash uniqely identifying this layer.
 	// Libindex will treat layers with this same hash as identical.
-	Hash    string              `json:"hash"`
+	Hash    Digest              `json:"hash"`
 	URI     string              `json:"uri"`
 	Headers map[string][]string `json:"headers"`
 

--- a/layer_integration_test.go
+++ b/layer_integration_test.go
@@ -7,7 +7,6 @@ package claircore_test
 import (
 	"bytes"
 	"context"
-	"encoding/hex"
 	"testing"
 	"time"
 
@@ -19,7 +18,7 @@ import (
 var goldenLayers []test.LayerSpec
 
 func init() {
-	ck, err := hex.DecodeString("35c102085707f703de2d9eaad8752d6fe1b8f02b5d2149f1d8357c9cc7fb7d0a")
+	id, err := claircore.ParseDigest("sha256:35c102085707f703de2d9eaad8752d6fe1b8f02b5d2149f1d8357c9cc7fb7d0a")
 	if err != nil {
 		panic(err)
 	}
@@ -27,7 +26,7 @@ func init() {
 		{
 			Domain: "docker.io",
 			Repo:   "library/ubuntu",
-			ID:     claircore.NewDigest("sha256", ck),
+			ID:     id,
 		},
 	}
 }

--- a/libindex/libindex.go
+++ b/libindex/libindex.go
@@ -95,7 +95,7 @@ func New(ctx context.Context, opts *Opts) (*Libindex, error) {
 func (l *Libindex) Index(ctx context.Context, manifest *claircore.Manifest) (*claircore.IndexReport, error) {
 	log := zerolog.Ctx(ctx).With().
 		Str("component", "libindex/Libindex.Index").
-		Str("maifest", manifest.Hash).
+		Str("manifest", manifest.Hash.String()).
 		Logger()
 	ctx = log.WithContext(ctx)
 	log.Info().Msg("index request start")
@@ -125,7 +125,7 @@ func (l *Libindex) index(ctx context.Context, s *controller.Controller, m *clair
 	// attempt to get lock
 	log.Debug().Msg("locking")
 	// will block until available or ctx times out
-	err := s.Lock(ctx, m.Hash)
+	err := s.Lock(ctx, m.Hash.String())
 	if err != nil {
 		// something went wrong with getting a lock
 		// this is not an error saying another process has the lock
@@ -148,7 +148,7 @@ func (l *Libindex) index(ctx context.Context, s *controller.Controller, m *clair
 }
 
 // IndexReport retrieves an IndexReport for a particular manifest hash, if it exists.
-func (l *Libindex) IndexReport(ctx context.Context, hash string) (*claircore.IndexReport, bool, error) {
+func (l *Libindex) IndexReport(ctx context.Context, hash claircore.Digest) (*claircore.IndexReport, bool, error) {
 	res, ok, err := l.store.IndexReport(ctx, hash)
 	return res, ok, err
 }

--- a/libvuln/libvuln.go
+++ b/libvuln/libvuln.go
@@ -65,5 +65,12 @@ func New(ctx context.Context, opts *Opts) (*Libvuln, error) {
 
 // Scan creates a VulnerabilityReport given a manifest's IndexReport.
 func (l *Libvuln) Scan(ctx context.Context, ir *claircore.IndexReport) (*claircore.VulnerabilityReport, error) {
+	log := zerolog.Ctx(ctx).With().
+		Str("component", "libvuln/Libvuln.Scan").
+		Str("manifest", ir.Hash.String()).
+		Logger()
+	ctx = log.WithContext(ctx)
+	log.Info().Msg("match request start")
+	defer log.Info().Msg("match request done")
 	return matcher.Match(ctx, ir, l.matchers, l.store)
 }

--- a/manifest.go
+++ b/manifest.go
@@ -5,7 +5,7 @@ package claircore
 type Manifest struct {
 	// content addressable hash. should be able to be computed via
 	// the hashes of all included layers
-	Hash string `json:"hash"`
+	Hash Digest `json:"hash"`
 	// an array of filesystem layers indexed in the same order as the cooresponding image
 	Layers []*Layer `json:"layers"`
 }

--- a/oracle/distributionscanner.go
+++ b/oracle/distributionscanner.go
@@ -6,9 +6,10 @@ import (
 	"regexp"
 	"runtime/trace"
 
+	"github.com/rs/zerolog"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/internal/indexer"
-	"github.com/rs/zerolog"
 )
 
 // Oracle Linux has minor releases such as 7.7 and 6.10
@@ -79,7 +80,7 @@ func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]
 	log := zerolog.Ctx(ctx).With().
 		Str("component", "oracle/DistributionScanner.Scan").
 		Str("version", ds.Version()).
-		Str("layer", l.Hash).
+		Str("layer", l.Hash.String()).
 		Logger()
 	log.Debug().Msg("start")
 	defer log.Debug().Msg("done")

--- a/osrelease/scanner.go
+++ b/osrelease/scanner.go
@@ -55,7 +55,7 @@ func (s *Scanner) Scan(ctx context.Context, l *claircore.Layer) ([]*claircore.Di
 	log := zerolog.Ctx(ctx).With().
 		Str("component", "osrelease/Scanner.Scan").
 		Str("version", s.Version()).
-		Str("layer", l.Hash).
+		Str("layer", l.Hash.String()).
 		Logger()
 	ctx = log.WithContext(ctx)
 	log.Debug().Msg("start")

--- a/rhel/distributionscanner.go
+++ b/rhel/distributionscanner.go
@@ -6,9 +6,10 @@ import (
 	"regexp"
 	"runtime/trace"
 
+	"github.com/rs/zerolog"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/internal/indexer"
-	"github.com/rs/zerolog"
 )
 
 const osReleasePath = `etc/os-release`
@@ -83,7 +84,7 @@ func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]
 	log := zerolog.Ctx(ctx).With().
 		Str("component", "rhel/DistributionScanner.Scan").
 		Str("version", ds.Version()).
-		Str("layer", l.Hash).
+		Str("layer", l.Hash.String()).
 		Logger()
 	log.Debug().Msg("start")
 	defer log.Debug().Msg("done")

--- a/rhel/testdata/rhel-report.json
+++ b/rhel/testdata/rhel-report.json
@@ -1,5 +1,5 @@
 {
-  "manifest_hash": "cb642e6a9917b31752aa281373a2726152e0b4512abcdd8fabbbd96635c0d8f4",
+  "manifest_hash": "sha256:cb642e6a9917b31752aa281373a2726152e0b4512abcdd8fabbbd96635c0d8f4",
   "state": "IndexFinished",
   "packages": {
     "1": {
@@ -1821,7 +1821,7 @@
     "1": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -1829,7 +1829,7 @@
     "10": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -1837,7 +1837,7 @@
     "100": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -1845,7 +1845,7 @@
     "101": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -1853,7 +1853,7 @@
     "103": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -1861,7 +1861,7 @@
     "105": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -1869,7 +1869,7 @@
     "108": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -1877,7 +1877,7 @@
     "11": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -1885,7 +1885,7 @@
     "110": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -1893,7 +1893,7 @@
     "111": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -1901,7 +1901,7 @@
     "116": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -1909,7 +1909,7 @@
     "118": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -1917,7 +1917,7 @@
     "120": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -1925,7 +1925,7 @@
     "122": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -1933,7 +1933,7 @@
     "124": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -1941,7 +1941,7 @@
     "125": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -1949,7 +1949,7 @@
     "126": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -1957,7 +1957,7 @@
     "127": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -1965,7 +1965,7 @@
     "129": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -1973,7 +1973,7 @@
     "131": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -1981,7 +1981,7 @@
     "133": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -1989,7 +1989,7 @@
     "135": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -1997,7 +1997,7 @@
     "137": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2005,7 +2005,7 @@
     "139": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2013,7 +2013,7 @@
     "14": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2021,7 +2021,7 @@
     "140": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2029,7 +2029,7 @@
     "141": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2037,7 +2037,7 @@
     "142": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2045,7 +2045,7 @@
     "143": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2053,7 +2053,7 @@
     "144": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2061,7 +2061,7 @@
     "145": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2069,7 +2069,7 @@
     "147": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2077,7 +2077,7 @@
     "149": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2085,7 +2085,7 @@
     "15": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2093,7 +2093,7 @@
     "150": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2101,7 +2101,7 @@
     "152": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2109,7 +2109,7 @@
     "154": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2117,7 +2117,7 @@
     "156": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2125,7 +2125,7 @@
     "158": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2133,7 +2133,7 @@
     "16": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2141,7 +2141,7 @@
     "160": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2149,7 +2149,7 @@
     "161": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2157,7 +2157,7 @@
     "164": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2165,7 +2165,7 @@
     "165": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2173,7 +2173,7 @@
     "166": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2181,7 +2181,7 @@
     "168": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2189,7 +2189,7 @@
     "17": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2197,7 +2197,7 @@
     "170": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2205,7 +2205,7 @@
     "172": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2213,7 +2213,7 @@
     "174": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2221,7 +2221,7 @@
     "176": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2229,7 +2229,7 @@
     "177": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2237,7 +2237,7 @@
     "180": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2245,7 +2245,7 @@
     "182": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2253,7 +2253,7 @@
     "184": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2261,7 +2261,7 @@
     "186": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2269,7 +2269,7 @@
     "187": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2277,7 +2277,7 @@
     "189": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2285,7 +2285,7 @@
     "19": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2293,7 +2293,7 @@
     "192": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2301,7 +2301,7 @@
     "193": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2309,7 +2309,7 @@
     "196": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2317,7 +2317,7 @@
     "199": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2325,7 +2325,7 @@
     "202": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2333,7 +2333,7 @@
     "203": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2341,7 +2341,7 @@
     "206": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2349,7 +2349,7 @@
     "207": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2357,7 +2357,7 @@
     "210": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2365,7 +2365,7 @@
     "211": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2373,7 +2373,7 @@
     "213": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2381,7 +2381,7 @@
     "216": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2389,7 +2389,7 @@
     "218": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2397,7 +2397,7 @@
     "219": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2405,7 +2405,7 @@
     "22": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2413,7 +2413,7 @@
     "220": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2421,7 +2421,7 @@
     "222": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2429,7 +2429,7 @@
     "223": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2437,7 +2437,7 @@
     "226": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2445,7 +2445,7 @@
     "229": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2453,7 +2453,7 @@
     "23": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2461,7 +2461,7 @@
     "231": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2469,7 +2469,7 @@
     "234": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2477,7 +2477,7 @@
     "235": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2485,7 +2485,7 @@
     "238": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2493,7 +2493,7 @@
     "239": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2501,7 +2501,7 @@
     "241": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2509,7 +2509,7 @@
     "244": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2517,7 +2517,7 @@
     "245": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2525,7 +2525,7 @@
     "248": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2533,7 +2533,7 @@
     "249": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2541,7 +2541,7 @@
     "25": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2549,7 +2549,7 @@
     "252": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2557,7 +2557,7 @@
     "254": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2565,7 +2565,7 @@
     "256": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2573,7 +2573,7 @@
     "258": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2581,7 +2581,7 @@
     "259": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2589,7 +2589,7 @@
     "261": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2597,7 +2597,7 @@
     "265": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2605,7 +2605,7 @@
     "267": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2613,7 +2613,7 @@
     "269": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2621,7 +2621,7 @@
     "27": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2629,7 +2629,7 @@
     "271": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2637,7 +2637,7 @@
     "273": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2645,7 +2645,7 @@
     "275": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2653,7 +2653,7 @@
     "278": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2661,7 +2661,7 @@
     "280": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2669,7 +2669,7 @@
     "281": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2677,7 +2677,7 @@
     "283": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2685,7 +2685,7 @@
     "286": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2693,7 +2693,7 @@
     "287": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2701,7 +2701,7 @@
     "290": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2709,7 +2709,7 @@
     "292": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2717,7 +2717,7 @@
     "293": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2725,7 +2725,7 @@
     "296": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2733,7 +2733,7 @@
     "298": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2741,7 +2741,7 @@
     "30": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2749,7 +2749,7 @@
     "300": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2757,7 +2757,7 @@
     "302": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2765,7 +2765,7 @@
     "304": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2773,7 +2773,7 @@
     "306": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2781,7 +2781,7 @@
     "308": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2789,7 +2789,7 @@
     "309": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2797,7 +2797,7 @@
     "31": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2805,7 +2805,7 @@
     "311": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2813,7 +2813,7 @@
     "314": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2821,7 +2821,7 @@
     "315": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2829,7 +2829,7 @@
     "318": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2837,7 +2837,7 @@
     "319": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2845,7 +2845,7 @@
     "328": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2853,7 +2853,7 @@
     "332": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2861,7 +2861,7 @@
     "334": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2869,7 +2869,7 @@
     "336": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2877,7 +2877,7 @@
     "338": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2885,7 +2885,7 @@
     "34": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2893,7 +2893,7 @@
     "340": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2901,7 +2901,7 @@
     "342": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2909,7 +2909,7 @@
     "344": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2917,7 +2917,7 @@
     "346": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2925,7 +2925,7 @@
     "35": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2933,7 +2933,7 @@
     "350": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2941,7 +2941,7 @@
     "354": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2949,7 +2949,7 @@
     "356": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2957,7 +2957,7 @@
     "358": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2965,7 +2965,7 @@
     "360": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2973,7 +2973,7 @@
     "38": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2981,7 +2981,7 @@
     "4": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2989,7 +2989,7 @@
     "40": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -2997,7 +2997,7 @@
     "41": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -3005,7 +3005,7 @@
     "42": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -3013,7 +3013,7 @@
     "44": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -3021,7 +3021,7 @@
     "46": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -3029,7 +3029,7 @@
     "47": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -3037,7 +3037,7 @@
     "49": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -3045,7 +3045,7 @@
     "5": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -3053,7 +3053,7 @@
     "51": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -3061,7 +3061,7 @@
     "54": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -3069,7 +3069,7 @@
     "56": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -3077,7 +3077,7 @@
     "58": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -3085,7 +3085,7 @@
     "59": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -3093,7 +3093,7 @@
     "60": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -3101,7 +3101,7 @@
     "61": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -3109,7 +3109,7 @@
     "64": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -3117,7 +3117,7 @@
     "65": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -3125,7 +3125,7 @@
     "67": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -3133,7 +3133,7 @@
     "7": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -3141,7 +3141,7 @@
     "70": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -3149,7 +3149,7 @@
     "71": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -3157,7 +3157,7 @@
     "73": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -3165,7 +3165,7 @@
     "75": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -3173,7 +3173,7 @@
     "77": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -3181,7 +3181,7 @@
     "80": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -3189,7 +3189,7 @@
     "81": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -3197,7 +3197,7 @@
     "83": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -3205,7 +3205,7 @@
     "85": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -3213,7 +3213,7 @@
     "87": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -3221,7 +3221,7 @@
     "89": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -3229,7 +3229,7 @@
     "91": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -3237,7 +3237,7 @@
     "93": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -3245,7 +3245,7 @@
     "96": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }
@@ -3253,7 +3253,7 @@
     "97": [
       {
         "package_db": "/var/lib/rpm",
-        "introduced_in": "340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
+        "introduced_in": "sha256:340ff6d7f58c908c438ce89bb845caee3649de828a81569317ed0fe169a97de2",
         "distribution_id": "1",
         "repository_id": ""
       }

--- a/rpm/packagescanner.go
+++ b/rpm/packagescanner.go
@@ -78,11 +78,11 @@ func (ps *Scanner) Scan(ctx context.Context, layer *claircore.Layer) ([]*clairco
 		return nil, err
 	}
 	defer trace.StartRegion(ctx, "Scanner.Scan").End()
-	trace.Log(ctx, "layer:sha256", layer.Hash)
+	trace.Log(ctx, "layer", layer.Hash.String())
 	log := zerolog.Ctx(ctx).With().
 		Str("component", "rpm/Scanner.Scan").
 		Str("version", ps.Version()).
-		Str("layer", layer.Hash).
+		Str("layer", layer.Hash.String()).
 		Logger()
 	ctx = log.WithContext(ctx)
 	log.Debug().Msg("start")

--- a/rpm/packagescanner_test.go
+++ b/rpm/packagescanner_test.go
@@ -15,7 +15,10 @@ import (
 )
 
 func TestScan(t *testing.T) {
-	const hash = `729ec3a6ada3a6d26faca9b4779a037231f1762f759ef34c08bdd61bf52cd704`
+	hash, err := claircore.ParseDigest("sha256:729ec3a6ada3a6d26faca9b4779a037231f1762f759ef34c08bdd61bf52cd704")
+	if err != nil {
+		t.Fatal(err)
+	}
 	want := []*claircore.Package{
 		&claircore.Package{
 			Name:           "tzdata",

--- a/suse/distributionscanner.go
+++ b/suse/distributionscanner.go
@@ -6,9 +6,10 @@ import (
 	"regexp"
 	"runtime/trace"
 
+	"github.com/rs/zerolog"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/internal/indexer"
-	"github.com/rs/zerolog"
 )
 
 // Suse Enterprise Server has service pack releases however their security database files are bundled together
@@ -85,7 +86,7 @@ func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]
 	log := zerolog.Ctx(ctx).With().
 		Str("component", "suse/DistributionScanner.Scan").
 		Str("version", ds.Version()).
-		Str("layer", l.Hash).
+		Str("layer", l.Hash.String()).
 		Logger()
 	log.Debug().Msg("start")
 	defer log.Debug().Msg("done")

--- a/tar_test.go
+++ b/tar_test.go
@@ -2,6 +2,7 @@ package claircore
 
 import (
 	"archive/tar"
+	"crypto/sha256"
 	"os"
 	"path/filepath"
 	"strings"
@@ -86,8 +87,12 @@ func (tc tarTestCase) Generate(t *testing.T) {
 func (tc tarTestCase) Layer(t *testing.T) *Layer {
 	tc.Generate(t)
 	l := Layer{
-		Hash: "deadbeef",
-		URI:  "file:///dev/null",
+		URI: "file:///dev/null",
+	}
+	var err error
+	l.Hash, err = NewDigest("sha256", make([]byte, sha256.Size))
+	if err != nil {
+		t.Fatal(err)
 	}
 	if err := l.SetLocal(tc.filename()); err != nil {
 		t.Fatal(err)

--- a/test/fetch/layer.go
+++ b/test/fetch/layer.go
@@ -12,9 +12,9 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"strings"
 	"testing"
 
+	"github.com/quay/claircore"
 	"github.com/quay/claircore/test/integration"
 )
 
@@ -32,12 +32,8 @@ var registry = map[string]struct {
 	},
 }
 
-func Layer(ctx context.Context, t *testing.T, c *http.Client, from, repo, blob string) (*os.File, error) {
-	// This is a hack from the initial version, which hard-coded sha256.
-	if strings.IndexByte(blob, ':') == -1 {
-		blob = "sha256:" + blob
-	}
-	cachefile := filepath.Join("testdata", blob+".layer")
+func Layer(ctx context.Context, t *testing.T, c *http.Client, from, repo string, blob claircore.Digest) (*os.File, error) {
+	cachefile := filepath.Join("testdata", blob.String()+".layer")
 	switch _, err := os.Stat(cachefile); {
 	case err == nil:
 		return os.Open(cachefile)
@@ -102,7 +98,7 @@ func Layer(ctx context.Context, t *testing.T, c *http.Client, from, repo, blob s
 	if err != nil {
 		return nil, err
 	}
-	u, err = u.Parse(path.Join("v2", repo, "blobs", blob))
+	u, err = u.Parse(path.Join("v2", repo, "blobs", blob.String()))
 	if err != nil {
 		return nil, err
 	}

--- a/test/postgres/distribution_scanartifact.go
+++ b/test/postgres/distribution_scanartifact.go
@@ -12,7 +12,7 @@ import (
 // InsertDistScanArtifacts will create DistributionScanArtifacts linking the layer hash, dists, and scnr artifacts.
 // if multiple scnrs are provided they will be liked in i % n fashion where i is the current index
 // of the Dists array and n is the len of the scnrs array.
-func InsertDistScanArtifacts(db *sqlx.DB, layerHash string, dists []*claircore.Distribution, scnrs indexer.VersionedScanners) error {
+func InsertDistScanArtifacts(db *sqlx.DB, layerHash claircore.Digest, dists []*claircore.Distribution, scnrs indexer.VersionedScanners) error {
 	n := len(scnrs)
 	for i, dist := range dists {
 		nn := i % n

--- a/test/postgres/package_scanartifact.go
+++ b/test/postgres/package_scanartifact.go
@@ -12,7 +12,7 @@ import (
 // InsertPackageScanArtifacts will create ScanArtifacts linking the layer hash, packages, and scnr artifacts.
 // if multiple scnrs are provided they will be liked in i % n fashion where i is the current index
 // of the Packages array and n is the len of the scnrs array.
-func InsertPackageScanArtifacts(db *sqlx.DB, layerHash string, pkgs []*claircore.Package, scnrs indexer.VersionedScanners) error {
+func InsertPackageScanArtifacts(db *sqlx.DB, layerHash claircore.Digest, pkgs []*claircore.Package, scnrs indexer.VersionedScanners) error {
 	n := len(scnrs)
 	for i, pkg := range pkgs {
 		nn := i % n

--- a/test/postgres/repository_scanartifact.go
+++ b/test/postgres/repository_scanartifact.go
@@ -9,7 +9,7 @@ import (
 	"github.com/quay/claircore/internal/indexer"
 )
 
-func InsertRepoScanArtifact(db *sqlx.DB, layerHash string, repos []*claircore.Repository, scnrs indexer.VersionedScanners) error {
+func InsertRepoScanArtifact(db *sqlx.DB, layerHash claircore.Digest, repos []*claircore.Repository, scnrs indexer.VersionedScanners) error {
 	n := len(scnrs)
 	for i, repo := range repos {
 		nn := i % n

--- a/test/postgres/scannerlist.go
+++ b/test/postgres/scannerlist.go
@@ -1,10 +1,14 @@
 package postgres
 
-import "github.com/jmoiron/sqlx"
+import (
+	"github.com/jmoiron/sqlx"
+
+	"github.com/quay/claircore"
+)
 
 // InsertScannerList is to be used with `claircore.test.GenUniqueScanners()`. Inserts
 // a ScannerList record for scanner IDs 0...n associated with provided manifest hash
-func InsertScannerList(db *sqlx.DB, hash string, n int) error {
+func InsertScannerList(db *sqlx.DB, hash claircore.Digest, n int) error {
 	for i := 0; i < n; i++ {
 		_, err := db.Exec(
 			`INSERT INTO scannerlist

--- a/ubuntu/distributionscanner.go
+++ b/ubuntu/distributionscanner.go
@@ -6,9 +6,10 @@ import (
 	"regexp"
 	"runtime/trace"
 
+	"github.com/rs/zerolog"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/internal/indexer"
-	"github.com/rs/zerolog"
 )
 
 const (
@@ -82,7 +83,7 @@ func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]
 	log := zerolog.Ctx(ctx).With().
 		Str("component", "ubuntu/DistributionScanner.Scan").
 		Str("version", ds.Version()).
-		Str("layer", l.Hash).
+		Str("layer", l.Hash.String()).
 		Logger()
 	log.Debug().Msg("start")
 	defer log.Debug().Msg("done")

--- a/vulnerabilityreport.go
+++ b/vulnerabilityreport.go
@@ -4,7 +4,7 @@ package claircore
 // associated vulnerabilities.
 type VulnerabilityReport struct {
 	// the manifest hash this vulnerability report is describing
-	Hash string `json:"manifest_hash"`
+	Hash Digest `json:"manifest_hash"`
 	// all discovered packages in this manifest keyed by package id
 	Packages map[string]*Package `json:"packages"`
 	// all discovered distributions in this manifest keyed by distribution id


### PR DESCRIPTION
These commits switch uses of a bare hex string as a digest to a new `Digest` datatype that ensures the digest has an algorithm associated with it and is correctly formed on creation. It's also the same representation that other container tooling already uses to describe digests.

This PR should be squashed and is only split for easier reviewing.

This closes PROJQUAY-73.