### PR TITLE
Static Typing for Vulnerability Severity Level

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -5,6 +5,7 @@
 - [Indexer Architecture](./indexer_architecture.md)  
 - [Matching Architecture](./matcher_architecture.md)  
 - [Content-Addressability](./content_addressability.md)  
+- [Severity Mapping](./severity_mapping.md)
 - [Contributors](./contributor.md)
   - [Logging](./contributor/logging.md)
   - [Local Development](./local-dev.md)

--- a/docs/severity_mapping.md
+++ b/docs/severity_mapping.md
@@ -1,0 +1,97 @@
+# Severity Mapping
+
+ClairCore will normalize a security databases's severity string to a set of defined values.  
+Clients may use the `NormalizedSeverity` field on a `claircore.Vulnerability` to react to vulnerability severities without needing to know each security database's severity strings.  
+All strings used in the mapping tables are identical to the strings found within the relevant security database.  
+
+## ClairCore Severity Strings
+The following are severity strings ClairCore will normalize others to.  
+Clients can guarantee one of these strings will be associated with a claircore.Vulnerability.  
+```
+Unknown
+Negligible
+Low
+Medium
+High
+Critical
+Defcon1
+```
+
+## Alpine Mapping
+
+Alpine SecDB database does not provide severity information.  
+All vulnerability severities will be Unknown.  
+
+| Alpine Severity | Clair Severity |
+| - | - |
+| * | Unknown |
+
+## AWS Mapping
+
+AWS UpdateInfo database provides severity information.  
+
+| AWS Severity | Clair Severity |
+| - | - |
+| low | Low |
+| medium | Medium |
+| important | High |
+| critical | Critical |
+
+## Debian Mapping
+
+Debian Oval database does not provide severity information.  
+All vulnerability severities will be Unknown.  
+
+| Debian Severity | Clair Severity |
+| - | - |
+| * | Unknown |
+
+## Oracle Mapping
+
+Oracle Oval database provides severity information.  
+
+| Oracle Severity | Clair Severity |
+| - | - |
+| N/A | Unknown |
+| LOW | Low |
+| MODERATE | Medium |
+| IMPORTANT | High |
+| CRITICAL | Critical
+
+## RHEL Mapping
+
+RHEL Oval database provides severity information.  
+
+| RHEL Severity | Clair Severity |
+| - | - |
+| None | Unknown |
+| Low | Low |
+| Moderate | Medium |
+| Important | High |
+| Critical | Critical |
+
+## SUSE Mapping
+
+SUSE Oval database provides severity information.  
+
+| SUSE Severity | Clair Severity |
+| - | - |
+| None | Unknown |
+| Low | Low |
+| Moderate | Medium |
+| Important | High |
+| Critical | Critical |
+
+## Ubuntu Mapping
+
+Ubuntu Oval database provides severity information.   
+
+| Ubuntu Severity | Clair Severity |
+| - | - |
+| Untriaged | Unknown |
+| Negligible | Negligible |
+| Low | Low |
+| Medium | Medium |
+| High | High |
+| Critical | Critical |
+

--- a/vulnerability.go
+++ b/vulnerability.go
@@ -1,5 +1,17 @@
 package claircore
 
+type SeverityLevel string
+
+const (
+	SeverityUnknown    SeverityLevel = "Unknown"
+	SeverityNegligible SeverityLevel = "Negligible"
+	SeverityLow        SeverityLevel = "Low"
+	SeverityMedium     SeverityLevel = "Medium"
+	SeverityHigh       SeverityLevel = "High"
+	SeverityCritical   SeverityLevel = "Critical"
+	SeverityDefcon1    SeverityLevel = "Defcon1"
+)
+
 type Vulnerability struct {
 	// unique ID of this vulnerability. this will be created as discovered by the library
 	// and used for persistence and hash map indexes
@@ -14,7 +26,7 @@ type Vulnerability struct {
 	// any links to more details about the vulnerability
 	Links string `json:"links"`
 	// the severity of the vulnerability
-	Severity string `json:"severity"`
+	Severity SeverityLevel `json:"severity"`
 	// the package information associated with the vulnerability. ideally these fields can be matched
 	// to packages discovered by libindex PackageScanner structs.
 	Package *Package `json:"-"`


### PR DESCRIPTION
### Description

Add Go-style string type alias enum for vulnerability severity field.

Fixes #119 