### PR TITLE
Bump Go-Cmp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/docker/docker v1.13.1 // indirect
 	github.com/doug-martin/goqu/v8 v8.6.0
 	github.com/golang/mock v1.3.1
-	github.com/google/go-cmp v0.3.1
+	github.com/google/go-cmp v0.4.0
 	github.com/google/go-containerregistry v0.0.0-20191206185556-eb7c14b719c6
 	github.com/google/uuid v1.1.1
 	github.com/jackc/pgx/v4 v4.0.0

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,8 @@ github.com/google/btree v0.0.0-20180124185431-e89373fe6b4a/go.mod h1:lNA+9X1NB3Z
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
+github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-containerregistry v0.0.0-20191206185556-eb7c14b719c6 h1:G+394moNSOPMULZX40YUbVJ4rVuIkmLNvJG5qEX3tTM=
 github.com/google/go-containerregistry v0.0.0-20191206185556-eb7c14b719c6/go.mod h1:rodaC7jYStJ2mjR8Y+5a/jCzcRPFRH74KmqSnJC88co=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
@@ -341,6 +343,8 @@ golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gonum.org/v1/gonum v0.0.0-20190331200053-3d26580ed485/go.mod h1:2ltnJ7xHfj0zHS40VVPYEAAMTa3ZGguvHGBSJeRWqE0=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
 gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e/go.mod h1:kS+toOQn6AQKjmKJ7gzohV1XkqsFehRA2FbsbkopSuQ=

--- a/internal/indexer/postgres/teststore.go
+++ b/internal/indexer/postgres/teststore.go
@@ -26,7 +26,7 @@ func TestStore(ctx context.Context, t testing.TB) (*sqlx.DB, *store, string, fun
 
 	db, err := integration.NewDB(ctx, t)
 	if err != nil {
-		t.Fatalf("unable to create test database: %w", err)
+		t.Fatalf("unable to create test database: %v", err)
 	}
 	cfg := db.Config()
 	// we are going to use pgx for more control over connection pool and
@@ -48,7 +48,7 @@ func TestStore(ctx context.Context, t testing.TB) (*sqlx.DB, *store, string, fun
 	migrator.Table = migrations.MigrationTable
 	err = migrator.Exec(migrate.Up, migrations.Migrations...)
 	if err != nil {
-		t.Fatalf("failed to perform migrations: %w", err)
+		t.Fatalf("failed to perform migrations: %v", err)
 	}
 
 	s := NewStore(sx, pool)

--- a/internal/vulnstore/postgres/testvulnstore.go
+++ b/internal/vulnstore/postgres/testvulnstore.go
@@ -28,7 +28,7 @@ func TestStore(ctx context.Context, t testing.TB) (*sqlx.DB, *Store, string, fun
 
 	db, err := integration.NewDB(ctx, t)
 	if err != nil {
-		t.Fatalf("unable to create test database: %w", err)
+		t.Fatalf("unable to create test database: %v", err)
 	}
 	cfg := db.Config()
 	cfg.ConnConfig.LogLevel = pgx.LogLevelError
@@ -51,7 +51,7 @@ func TestStore(ctx context.Context, t testing.TB) (*sqlx.DB, *Store, string, fun
 	migrator.Table = migrations.MigrationTable
 	err = migrator.Exec(migrate.Up, migrations.Migrations...)
 	if err != nil {
-		t.Fatalf("failed to perform migrations: %w", err)
+		t.Fatalf("failed to perform migrations: %v", err)
 	}
 
 	s := NewVulnStore(sx, pool)


### PR DESCRIPTION
This PR bumps go-cmp to remove a race detector bug and fixes up some
go1.14 error formating issues

This PR bumps go-cmp to latest version and voids a race detector test