### PR TITLE
distro scanner fixes

### DIFF
--- a/alpine/distributionscanner.go
+++ b/alpine/distributionscanner.go
@@ -111,7 +111,7 @@ func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]
 			return []*claircore.Distribution{dist}, nil
 		}
 	}
-	return []*claircore.Distribution{&claircore.Distribution{}}, nil
+	return nil, nil
 }
 
 // parse attempts to match all alpine release regexp and returns the associated

--- a/aws/distributionscanner.go
+++ b/aws/distributionscanner.go
@@ -83,7 +83,7 @@ func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]
 			return []*claircore.Distribution{dist}, nil
 		}
 	}
-	return []*claircore.Distribution{&claircore.Distribution{}}, nil
+	return nil, nil
 }
 
 // parse attempts to match all AWS release regexp and returns the associated

--- a/debian/distributionscanner.go
+++ b/debian/distributionscanner.go
@@ -86,7 +86,7 @@ func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]
 			return []*claircore.Distribution{dist}, nil
 		}
 	}
-	return []*claircore.Distribution{&claircore.Distribution{}}, nil
+	return nil, nil
 }
 
 // parse attempts to match all Debian release regexp and returns the associated

--- a/internal/indexer/layerscanner/layerscanner.go
+++ b/internal/indexer/layerscanner/layerscanner.go
@@ -124,6 +124,9 @@ func (ls *layerScanner) scanPackages(ctx context.Context, layer *claircore.Layer
 	if err != nil {
 		return fmt.Errorf("scanner: %v error: %v", s.Name(), err)
 	}
+	if v == nil {
+		return nil
+	}
 	return ls.Store.IndexPackages(ctx, v, layer, s)
 }
 
@@ -145,6 +148,9 @@ func (ls *layerScanner) scanDists(ctx context.Context, layer *claircore.Layer, s
 	if err != nil {
 		return fmt.Errorf("scanner: %v error: %v", s.Name(), err)
 	}
+	if v == nil {
+		return nil
+	}
 	return ls.Store.IndexDistributions(ctx, v, layer, s)
 }
 
@@ -165,6 +171,9 @@ func (ls *layerScanner) scanRepos(ctx context.Context, layer *claircore.Layer, s
 	v, err := s.Scan(ctx, layer)
 	if err != nil {
 		return fmt.Errorf("scanner: %v error: %v", s.Name(), err)
+	}
+	if v == nil {
+		return nil
 	}
 	return ls.Store.IndexRepositories(ctx, v, layer, s)
 }

--- a/oracle/distributionscanner.go
+++ b/oracle/distributionscanner.go
@@ -95,7 +95,7 @@ func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]
 			return []*claircore.Distribution{dist}, nil
 		}
 	}
-	return []*claircore.Distribution{&claircore.Distribution{}}, nil
+	return nil, nil
 }
 
 // parse attempts to match all Oracle release regexp and returns the associated

--- a/rhel/distributionscanner.go
+++ b/rhel/distributionscanner.go
@@ -99,7 +99,7 @@ func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]
 			return []*claircore.Distribution{dist}, nil
 		}
 	}
-	return []*claircore.Distribution{&claircore.Distribution{}}, nil
+	return nil, nil
 }
 
 // parse attempts to match all Oracle release regexp and returns the associated

--- a/suse/distributionscanner.go
+++ b/suse/distributionscanner.go
@@ -101,7 +101,7 @@ func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]
 			return []*claircore.Distribution{dist}, nil
 		}
 	}
-	return []*claircore.Distribution{&claircore.Distribution{}}, nil
+	return nil, nil
 }
 
 // parse attempts to match all Suse release regexp and returns the associated

--- a/ubuntu/distributionscanner.go
+++ b/ubuntu/distributionscanner.go
@@ -98,7 +98,7 @@ func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]
 			return []*claircore.Distribution{dist}, nil
 		}
 	}
-	return []*claircore.Distribution{&claircore.Distribution{}}, nil
+	return nil, nil
 }
 
 // parse attempts to match all Ubuntu release regexp and returns the associated


### PR DESCRIPTION
This PR fixes an issue where distro scanners were returning an empty
struct when the os-release file was found, but was not able to be parsed 
by the distribution scanner.