### PR TITLE
make state method consistent

### DIFF
--- a/libindex/handler.go
+++ b/libindex/handler.go
@@ -30,8 +30,15 @@ func NewHandler(l *Libindex) *HTTP {
 }
 
 func (h *HTTP) State(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	log := zerolog.Ctx(ctx).With().
+		Str("method", "index").
+		Logger()
+	ctx = log.WithContext(ctx)
+
 	w.Header().Set("content-type", "text/plain")
-	fmt.Fprintln(w, h.l.State())
+	s, _ := h.l.State(ctx)
+	fmt.Fprintln(w, s)
 }
 
 func (h *HTTP) Index(w http.ResponseWriter, r *http.Request) {

--- a/libindex/libindex.go
+++ b/libindex/libindex.go
@@ -119,8 +119,8 @@ func (l *Libindex) Index(ctx context.Context, manifest *claircore.Manifest) (*cl
 //
 // If the identifier has changed, clients should arrange for layers to be
 // re-indexed.
-func (l *Libindex) State() string {
-	return l.state
+func (l *Libindex) State(ctx context.Context) (string, error) {
+	return l.state, nil
 }
 
 func (l *Libindex) index(ctx context.Context, s *controller.Controller, m *claircore.Manifest) *claircore.IndexReport {


### PR DESCRIPTION
This PR makes the state endpoint look like the others.
This also fixes an issue where you cannot create an interface that wraps
libindex easily due to usually wanting ctx and an error when
implementing a remote service