### PR TITLE
pkgconfig: add pkg-config scanner

### DIFF
--- a/scanner/pkgconfig/scanner.go
+++ b/scanner/pkgconfig/scanner.go
@@ -1,0 +1,176 @@
+// Package pkgconfig implements a scanner that finds pkg-config files.
+//
+// Pkg-config is a widely-used package for finding linker and compiler flags on
+// Linux systems.
+package pkgconfig
+
+import (
+	"archive/tar"
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime/trace"
+
+	"github.com/rs/zerolog"
+
+	"github.com/quay/claircore"
+	"github.com/quay/claircore/internal/indexer"
+)
+
+var _ indexer.PackageScanner = (*Scanner)(nil)
+
+const (
+	pkgName    = `pkgconfig`
+	pkgVersion = `0.0.1`
+	pkgKind    = `package`
+)
+
+// Scanner finds pkg-config files in layers.
+type Scanner struct{}
+
+// Name implements scanner.VersionedScanner.
+func (*Scanner) Name() string { return pkgName }
+
+// Version implements scanner.VersionedScanner.
+func (*Scanner) Version() string { return pkgVersion }
+
+// Kind implements scanner.VersionedScanner.
+func (*Scanner) Kind() string { return pkgKind }
+
+// Scan attempts to find and enumerate pkg-config files.
+func (ps *Scanner) Scan(ctx context.Context, layer *claircore.Layer) ([]*claircore.Package, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	defer trace.StartRegion(ctx, "Scanner.Scan").End()
+	trace.Log(ctx, "layer", layer.Hash.String())
+	log := zerolog.Ctx(ctx).With().
+		Str("component", "scanner/pkgconfig/Scanner.Scan").
+		Str("version", ps.Version()).
+		Str("layer", layer.Hash.String()).
+		Logger()
+	ctx = log.WithContext(ctx)
+	log.Debug().Msg("start")
+	defer log.Debug().Msg("done")
+
+	r, err := layer.Reader()
+	if err != nil {
+		return nil, err
+	}
+	tr := tar.NewReader(r)
+	var h *tar.Header
+	var buf bytes.Buffer
+	var ret []*claircore.Package
+
+	for h, err = tr.Next(); err == nil; h, err = tr.Next() {
+		n, err := filepath.Rel("/", filepath.Join("/", h.Name))
+		if err != nil {
+			return nil, err
+		}
+		if filepath.Ext(n) != ".pc" {
+			continue
+		}
+		log.Debug().
+			Str("path", n).
+			Msg("found possible pkg-config file")
+		if _, err := buf.ReadFrom(tr); err != nil {
+			return nil, err
+		}
+		var pc pc
+		switch err := pc.Scan(&buf); err {
+		case nil:
+		case errInvalid: // skip
+			log.Info().
+				Str("path", n).
+				Msg("invalid pkg-config file")
+			continue
+		default:
+			return nil, err
+		}
+		ret = append(ret, &claircore.Package{
+			Name:           pc.Name,
+			Version:        pc.Version,
+			PackageDB:      filepath.Dir(n),
+			RepositoryHint: pc.URL,
+		})
+	}
+
+	if err != io.EOF {
+		return nil, err
+	}
+	return ret, nil
+}
+
+/*
+Below implements a subset of a pkg-config file scanner.
+
+In theory, we could just look for the Name an Version fields, extract the value,
+and be on our way. But the C source (https://cgit.freedesktop.org/pkg-config/tree/parse.c)
+makes sure to run all values through trim_and_sub, so we should do the same.
+*/
+
+type pc struct {
+	Name    string
+	Version string
+	URL     string
+}
+
+func (pc *pc) Done() bool {
+	return pc.Name != "" &&
+		pc.Version != "" &&
+		pc.URL != ""
+}
+
+func (pc *pc) Err() bool {
+	return pc.Name != "" && pc.Version != ""
+}
+
+var errInvalid = errors.New("")
+
+func (pc *pc) Scan(r io.Reader) error {
+	vs := make(map[string]string)
+	expand := func(k string) string { return vs[k] }
+	s := bufio.NewScanner(r)
+
+	for s.Scan() && !pc.Done() {
+		b := s.Bytes()
+		i := bytes.IndexAny(b, ":=")
+		if i == -1 {
+			continue
+		}
+		tag := string(bytes.TrimSpace(b[:i]))
+		val := string(bytes.TrimSpace(b[i+1:]))
+		switch b[i] {
+		case '=': // Variable assignment
+			if _, exists := vs[tag]; exists {
+				return fmt.Errorf("duplicate variable assignment: %q", tag)
+			}
+			val = os.Expand(val, expand)
+			vs[tag] = val
+		case ':': // Key-Value
+			switch tag {
+			case "Name":
+				pc.Name = os.Expand(val, expand)
+			case "Version":
+				pc.Version = os.Expand(val, expand)
+			case "URL":
+				pc.URL = os.Expand(val, expand)
+			default: // skip
+			}
+		default:
+			panic("unreachable")
+		}
+	}
+	if err := s.Err(); err != nil {
+		return err
+	}
+	if !pc.Err() {
+		return errInvalid
+	}
+	return nil
+}

--- a/scanner/pkgconfig/scanner_test.go
+++ b/scanner/pkgconfig/scanner_test.go
@@ -1,0 +1,75 @@
+package pkgconfig
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+type scannerTestcase struct {
+	File string
+	Want pc
+}
+
+func (tc scannerTestcase) Run(t *testing.T) {
+	t.Parallel()
+	var got pc
+	f, err := os.Open(tc.File)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	if err := got.Scan(f); err != nil {
+		t.Error(err)
+	}
+	if !cmp.Equal(tc.Want, got) {
+		t.Error(cmp.Diff(tc.Want, got))
+	}
+}
+
+func TestScanner(t *testing.T) {
+	tt := []scannerTestcase{
+		scannerTestcase{
+			File: "testdata/bash-completion.pc",
+			Want: pc{
+				Name:    "bash-completion",
+				Version: "2.8",
+				URL:     "https://github.com/scop/bash-completion",
+			},
+		},
+		scannerTestcase{
+			File: "testdata/dracut.pc",
+			Want: pc{
+				Name:    "dracut",
+				Version: "64fefc221cf13e858d4921be7f0b1eea86c364d2",
+			},
+		},
+		scannerTestcase{
+			File: "testdata/libpng.pc",
+			Want: pc{Name: "libpng", Version: "1.6.37"},
+		},
+		scannerTestcase{
+			File: "testdata/shared-mime-info.pc",
+			Want: pc{Name: "shared-mime-info", Version: "1.15"},
+		},
+		scannerTestcase{
+			File: "testdata/systemd.pc",
+			Want: pc{
+				Name:    "systemd",
+				Version: "243",
+				URL:     "https://www.freedesktop.org/wiki/Software/systemd",
+			},
+		},
+		scannerTestcase{
+			File: "testdata/udev.pc",
+			Want: pc{Name: "udev", Version: "243"},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(path.Base(tc.File), tc.Run)
+	}
+}

--- a/scanner/pkgconfig/testdata/bash-completion.pc
+++ b/scanner/pkgconfig/testdata/bash-completion.pc
@@ -1,0 +1,9 @@
+prefix=/usr
+compatdir=/etc/bash_completion.d
+completionsdir=${prefix}/share/bash-completion/completions
+helpersdir=${prefix}/share/bash-completion/helpers
+
+Name: bash-completion
+Description: programmable completion for the bash shell
+URL: https://github.com/scop/bash-completion
+Version: 2.8

--- a/scanner/pkgconfig/testdata/dracut.pc
+++ b/scanner/pkgconfig/testdata/dracut.pc
@@ -1,0 +1,6 @@
+Name: dracut
+Description: dracut
+Version: 64fefc221cf13e858d4921be7f0b1eea86c364d2
+dracutdir=/usr/lib/dracut
+dracutmodulesdir=/usr/lib/dracut/modules.d
+dracutconfdir=/usr/lib/dracut/dracut.conf.d

--- a/scanner/pkgconfig/testdata/libpng.pc
+++ b/scanner/pkgconfig/testdata/libpng.pc
@@ -1,0 +1,12 @@
+prefix=/usr/local
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include/libpng16
+
+Name: libpng
+Description: Loads and saves PNG files
+Version: 1.6.37
+Requires: zlib
+Libs: -L${libdir} -lpng16
+Libs.private: -lm -lz -lm 
+Cflags: -I${includedir}

--- a/scanner/pkgconfig/testdata/shared-mime-info.pc
+++ b/scanner/pkgconfig/testdata/shared-mime-info.pc
@@ -1,0 +1,8 @@
+prefix=/usr
+
+Name: shared-mime-info
+Description: Freedesktop common MIME database
+Version: 1.15
+Requires:
+Libs:
+Cflags:

--- a/scanner/pkgconfig/testdata/systemd.pc
+++ b/scanner/pkgconfig/testdata/systemd.pc
@@ -1,0 +1,44 @@
+#  SPDX-License-Identifier: LGPL-2.1+
+#
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+
+prefix=/usr
+rootprefix=/usr
+sysconfdir=/etc
+systemdutildir=${rootprefix}/lib/systemd
+systemdsystemunitdir=${rootprefix}/lib/systemd/system
+systemdsystempresetdir=${rootprefix}/lib/systemd/system-preset
+systemduserunitdir=${prefix}/lib/systemd/user
+systemduserpresetdir=${prefix}/lib/systemd/user-preset
+systemdsystemconfdir=${sysconfdir}/systemd/system
+systemduserconfdir=${sysconfdir}/systemd/user
+systemdsystemunitpath=${systemdsystemconfdir}:/etc/systemd/system:/run/systemd/system:/usr/local/lib/systemd/system:${systemdsystemunitdir}:/usr/lib/systemd/system:/lib/systemd/system
+systemduserunitpath=${systemduserconfdir}:/etc/systemd/user:/run/systemd/user:/usr/local/lib/systemd/user:/usr/local/share/systemd/user:${systemduserunitdir}:/usr/lib/systemd/user:/usr/share/systemd/user
+systemdsystemgeneratordir=${rootprefix}/lib/systemd/system-generators
+systemdusergeneratordir=${prefix}/lib/systemd/user-generators
+systemdsystemgeneratorpath=/run/systemd/system-generators:/etc/systemd/system-generators:/usr/local/lib/systemd/system-generators:${systemdsystemgeneratordir}
+systemdusergeneratorpath=/run/systemd/user-generators:/etc/systemd/user-generators:/usr/local/lib/systemd/user-generators:${systemdusergeneratordir}
+systemdsleepdir=${rootprefix}/lib/systemd/system-sleep
+systemdshutdowndir=${rootprefix}/lib/systemd/system-shutdown
+tmpfilesdir=${prefix}/lib/tmpfiles.d
+sysusersdir=${prefix}/lib/sysusers.d
+sysctldir=${prefix}/lib/sysctl.d
+binfmtdir=${prefix}/lib/binfmt.d
+modulesloaddir=${prefix}/lib/modules-load.d
+catalogdir=${prefix}/lib/systemd/catalog
+systemuidmax=999
+systemgidmax=999
+dynamicuidmin=61184
+dynamicuidmax=65519
+containeruidbasemin=524288
+containeruidbasemax=1878982656
+
+Name: systemd
+Description: systemd System and Service Manager
+URL: https://www.freedesktop.org/wiki/Software/systemd
+Version: 243

--- a/scanner/pkgconfig/testdata/udev.pc
+++ b/scanner/pkgconfig/testdata/udev.pc
@@ -1,0 +1,5 @@
+Name: udev
+Description: udev
+Version: 243
+
+udevdir=/usr/lib/udev


### PR DESCRIPTION
This change adds a scanner that looks for pkg-config
(https://www.freedesktop.org/wiki/Software/pkg-config/) files in layers.

This isn't wired up yet, because there's some planning to be done around
how this interacts with packages that will be picked up by a more
precise means, like a package manager.