### PR TITLE
fastesturl: deflake the test

### DIFF
--- a/pkg/fastesturl/fastesturl_test.go
+++ b/pkg/fastesturl/fastesturl_test.go
@@ -5,31 +5,63 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sync"
 	"testing"
-	"time"
 
 	"github.com/quay/claircore/pkg/fastesturl"
 )
 
+// Server sets up two testing servers, returning the two status codes in order.
+//
+// The returned RespCheck function must be used to ensure that both servers
+// return responses.
+func server(t *testing.T, a, b int) (*url.URL, *url.URL, fastesturl.RespCheck, func()) {
+	// TODO Use t.Cleanup instead of returning a function when our minimum go
+	// version is 1.14.
+	var closeSem sync.Once
+	sem := make(chan struct{})
+	srv1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Test-Server", "1")
+		w.WriteHeader(a)
+		return
+	}))
+	srv2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-sem
+		w.Header().Set("X-Test-Server", "2")
+		w.WriteHeader(b)
+		return
+	}))
+	urla, err := url.Parse(srv1.URL)
+	if err != nil {
+		t.Error(err)
+	}
+	urlb, err := url.Parse(srv2.URL)
+	if err != nil {
+		t.Error(err)
+	}
+	return urla, urlb,
+		func(resp *http.Response) bool {
+			defer closeSem.Do(func() { close(sem) })
+			return resp.StatusCode == http.StatusOK
+		},
+		func() {
+			srv1.CloseClientConnections()
+			srv1.Close()
+			srv2.CloseClientConnections()
+			srv2.Close()
+		}
+}
+
 // TestFastestURLFailure confirms we return nil
 // when all requests fail the default RespCheck
 func TestFastestURLAllFailure(t *testing.T) {
-	ts1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(10 * time.Millisecond)
-		w.Header().Set("X-Test-Server", "1")
-		w.WriteHeader(http.StatusBadRequest)
-		return
-	}))
-	ts2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(20 * time.Millisecond)
-		w.Header().Set("X-Test-Server", "2")
-		w.WriteHeader(http.StatusBadRequest)
-		return
-	}))
-	url1, _ := url.Parse(ts1.URL)
-	url2, _ := url.Parse(ts2.URL)
-	furl := fastesturl.New(nil, nil, nil, []*url.URL{url1, url2})
-	resp := furl.Do(context.TODO())
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
+	a, b, check, cleanup := server(t, http.StatusBadRequest, http.StatusBadRequest)
+	defer cleanup()
+
+	furl := fastesturl.New(nil, nil, check, []*url.URL{a, b})
+	resp := furl.Do(ctx)
 	if resp != nil {
 		t.Fatalf("resp should be nil")
 	}
@@ -39,47 +71,32 @@ func TestFastestURLAllFailure(t *testing.T) {
 // that passes the default RespCheck function despite it being
 // the slower server
 func TestFastestURLFailure(t *testing.T) {
-	ts1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(10 * time.Millisecond)
-		w.Header().Set("X-Test-Server", "1")
-		w.WriteHeader(http.StatusBadRequest)
-		return
-	}))
-	ts2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(20 * time.Millisecond)
-		w.Header().Set("X-Test-Server", "2")
-		return
-	}))
-	url1, _ := url.Parse(ts1.URL)
-	url2, _ := url.Parse(ts2.URL)
-	furl := fastesturl.New(nil, nil, nil, []*url.URL{url1, url2})
-	resp := furl.Do(context.TODO())
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
+	a, b, check, cleanup := server(t, http.StatusBadRequest, http.StatusOK)
+	defer cleanup()
+
+	furl := fastesturl.New(nil, nil, check, []*url.URL{a, b})
+	resp := furl.Do(ctx)
 	if resp == nil {
 		t.Fatalf("resp should not be nil")
 	}
 	respServer := resp.Header.Get("X-Test-Server")
 	if respServer != "2" {
-		t.Fatalf("test server 1 should be first")
+		t.Fatalf("test server 2 should be returned")
 	}
 }
 
 // TestFastestURLSuccess confirms the fastest server wins
 // when all servers respond successfully
 func TestFastestURLSuccess(t *testing.T) {
-	ts1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(10 * time.Millisecond)
-		w.Header().Set("X-Test-Server", "1")
-		return
-	}))
-	ts2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(20 * time.Millisecond)
-		w.Header().Set("X-Test-Server", "2")
-		return
-	}))
-	url1, _ := url.Parse(ts1.URL)
-	url2, _ := url.Parse(ts2.URL)
-	furl := fastesturl.New(nil, nil, nil, []*url.URL{url1, url2})
-	resp := furl.Do(context.TODO())
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
+	a, b, check, cleanup := server(t, http.StatusOK, http.StatusOK)
+	defer cleanup()
+
+	furl := fastesturl.New(nil, nil, check, []*url.URL{a, b})
+	resp := furl.Do(ctx)
 	if resp == nil {
 		t.Fatalf("resp should not be nil")
 	}


### PR DESCRIPTION
This commit changes the tests to sequence responses without using
sleeps.

Over the course of testing, using high counts caused the tests to hang.
I ended up restructuring the internals to fix that.

Signed-off-by: Hank Donnay <hdonnay@redhat.com>