### PR TITLE
Make python package name case insensitive 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor
 *.swp
 book
+cctool

--- a/python/matcher.go
+++ b/python/matcher.go
@@ -1,9 +1,6 @@
 package python
 
 import (
-	"log"
-	"strings"
-
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/libvuln/driver"
 	"github.com/quay/claircore/pkg/pep440"
@@ -24,8 +21,6 @@ func (*Matcher) Name() string { return "python" }
 // Filter implements driver.Matcher.
 func (*Matcher) Filter(record *claircore.IndexRecord) bool {
 	return record.Package.NormalizedVersion.Kind == "pep440"
-	log.Printf("%+#v", record.Package)
-	return strings.HasPrefix(record.Package.PackageDB, "python:")
 }
 
 // Query implements driver.Matcher.

--- a/python/packagescanner.go
+++ b/python/packagescanner.go
@@ -109,7 +109,7 @@ func (ps *Scanner) Scan(ctx context.Context, layer *claircore.Layer) ([]*clairco
 			return nil, err
 		}
 		ret = append(ret, &claircore.Package{
-			Name:              hdr.Get("Name"),
+			Name:              strings.ToLower(hdr.Get("Name")),
 			Version:           v.String(),
 			PackageDB:         "python:" + filepath.Join(n, "..", ".."),
 			Kind:              "source",

--- a/python/packagescanner_test.go
+++ b/python/packagescanner_test.go
@@ -340,7 +340,7 @@ var scanTable = []test.ScannerTestcase{
 		Hash:   "sha256:109a55eba749c02eb6a4533eba12d8aa02a68417ff96886d049798ed5653a156",
 		Want: []*claircore.Package{
 			&claircore.Package{
-				Name:           "Pillow",
+				Name:           "pillow",
 				Version:        "6.2.1",
 				Kind:           "source",
 				PackageDB:      "python:usr/local/lib/python3.7/site-packages",

--- a/pyupio/updater.go
+++ b/pyupio/updater.go
@@ -269,7 +269,7 @@ func (db db) Vulnerabilites(ctx context.Context, repo *claircore.Repository) ([]
 				v := &claircore.Vulnerability{
 					Name:        e.ID,
 					Description: e.Advisory,
-					Package:     &claircore.Package{Name: k},
+					Package:     &claircore.Package{Name: strings.ToLower(k)},
 					Repo:        repo,
 					Range:       &claircore.Range{},
 				}


### PR DESCRIPTION
The image `ararunprasad/flask-0.12` has vulnerable Flask version 0.12 , but it is not flagged by Claircore due to case-sensitive name comparison.

```
./cctool report ararunprasad/flask-0.12
```

Actually I couldn't write a test for this fix because the package name equality has been done through SQL query. Correct me If I'm wrong.