### PR TITLE
Add module property to Package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/crgimenes/goconfig v1.2.1
 	github.com/docker/docker v1.13.1 // indirect
 	github.com/doug-martin/goqu/v8 v8.6.0
-	github.com/gofrs/uuid v3.2.0+incompatible // indirect
 	github.com/golang/mock v1.3.1
 	github.com/google/go-cmp v0.4.0
 	github.com/google/go-containerregistry v0.0.0-20191206185556-eb7c14b719c6

--- a/internal/indexer/postgres/bootstrap.sql
+++ b/internal/indexer/postgres/bootstrap.sql
@@ -60,9 +60,10 @@ CREATE TABLE package (
     id SERIAL PRIMARY KEY,
     name text NOT NULL,
     kind text NOT NULL,
-    version text NOT NULL
+    version text NOT NULL,
+    module text NOT NULL
 );
-CREATE UNIQUE INDEX package_unique_idx ON package (name, version, kind);
+CREATE UNIQUE INDEX package_unique_idx ON package (name, version, kind, module);
 
 --- PackageScanArtifact
 --- A relation linking discovered packages with the 

--- a/internal/indexer/postgres/indexpackage.go
+++ b/internal/indexer/postgres/indexpackage.go
@@ -14,31 +14,31 @@ import (
 )
 
 const (
-	insertPackage = `INSERT INTO package (name, kind, version, norm_kind, norm_version)
-	VALUES ($1, $2, $3, $4, $5::int[])
-	ON CONFLICT (name, kind, version) DO NOTHING;`
+	insertPackage = `INSERT INTO package (name, kind, version, norm_kind, norm_version, module)
+	VALUES ($1, $2, $3, $4, $5::int[], $6)
+	ON CONFLICT (name, kind, version, module) DO NOTHING;`
 	selectDistID = `SELECT id FROM dist WHERE name = $1 AND version = $2 AND version_code_name = $3 AND version_id = $4 AND arch = $5;`
 	// we'll use a WITH statement here to gather all the id's necessary to create the
 	// scan artifact entry. see: https://www.postgresql.org/docs/current/queries-with.html#QUERIES-WITH-MODIFYING
 	insertPackageScanArtifactWith = `WITH source_package AS (
 	SELECT id AS source_id FROM package WHERE
-         name = $1 AND kind = $2 AND version = $3
+         name = $1 AND kind = $2 AND version = $3 AND module = $4
          ),
 
 	binary_package AS (
-        SELECT id AS package_id FROM package WHERE 
-	name = $4 AND kind = $5 AND version = $6
+        SELECT id AS package_id FROM package WHERE
+	name = $5 AND kind = $6 AND version = $7 AND module = $8
          ),
-        
+
 	scanner AS (
 	SELECT id AS scanner_id FROM scanner WHERE
-	name = $7 AND version = $8 AND kind = $9
+	name = $9 AND version = $10 AND kind = $11
 		)
-	      
-INSERT INTO package_scanartifact (layer_hash, package_db, repository_hint, package_id, source_id, scanner_id) VALUES 
-		  ($10, 
-           $11,
-           $12,
+
+INSERT INTO package_scanartifact (layer_hash, package_db, repository_hint, package_id, source_id, scanner_id) VALUES
+		  ($12,
+           $13,
+           $14,
           (SELECT package_id FROM binary_package),
           (SELECT source_id FROM source_package),
           (SELECT scanner_id FROM scanner))
@@ -116,9 +116,11 @@ func indexPackages(ctx context.Context, pool *pgxpool.Pool, pkgs []*claircore.Pa
 			pkg.Source.Name,
 			pkg.Source.Kind,
 			pkg.Source.Version,
+			pkg.Source.Module,
 			pkg.Name,
 			pkg.Kind,
 			pkg.Version,
+			pkg.Module,
 			scnr.Name(),
 			scnr.Version(),
 			scnr.Kind(),
@@ -153,7 +155,7 @@ func queueInsert(ctx context.Context, b *microbatch.Insert, stmt string, pkg *cl
 		vNorm = pkg.NormalizedVersion.V[:]
 	}
 	err := b.Queue(ctx, stmt,
-		pkg.Name, pkg.Kind, pkg.Version, vKind, vNorm,
+		pkg.Name, pkg.Kind, pkg.Version, vKind, vNorm, pkg.Module,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to queue insert for package %q: %w", pkg.Name, err)

--- a/internal/indexer/postgres/packagesbylayer.go
+++ b/internal/indexer/postgres/packagesbylayer.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	selectPackage                = `SELECT id, name, kind, source, version FROM package WHERE id = $1`
+	selectPackage                = `SELECT id, name, kind, source, version, module FROM package WHERE id = $1`
 	selectPackagesByArtifactJoin = `SELECT 
   package.id, 
   package.name, 
@@ -22,11 +22,13 @@ const (
   package.version, 
   package.norm_kind,
   package.norm_version,
+  package.module,
 
   source_package.id,
   source_package.name,
   source_package.kind,
   source_package.version,
+  source_package.module,
 
   package_scanartifact.package_db,
   package_scanartifact.repository_hint
@@ -88,11 +90,13 @@ func packagesByLayer(ctx context.Context, db *sqlx.DB, hash claircore.Digest, sc
 			&pkg.Version,
 			&nKind,
 			&nVer,
+			&pkg.Module,
 
 			&spkg.ID,
 			&spkg.Name,
 			&spkg.Kind,
 			&spkg.Version,
+			&spkg.Module,
 
 			&pkg.PackageDB,
 			&pkg.RepositoryHint,

--- a/libindex/migrations/migration1.go
+++ b/libindex/migrations/migration1.go
@@ -67,9 +67,10 @@ const (
 		kind text NOT NULL,
 		version text NOT NULL,
 		norm_kind text,
-		norm_version integer[10]
+		norm_version integer[10],
+		module text NOT NULL
 	);
-	CREATE UNIQUE INDEX IF NOT EXISTS package_unique_idx ON package (name, version, kind);
+	CREATE UNIQUE INDEX IF NOT EXISTS package_unique_idx ON package (name, version, kind, module);
 
 	--- PackageScanArtifact
 	--- A relation linking discovered packages with the 

--- a/package.go
+++ b/package.go
@@ -21,4 +21,6 @@ type Package struct {
 	// correctly ordered when compared with other representations from the same
 	// producer.
 	NormalizedVersion Version `json:"normalized_version,omitempty"`
+	// Module and stream which this package is part of
+	Module string `json:"module,omitempty"`
 }

--- a/rpm/packagescanner.go
+++ b/rpm/packagescanner.go
@@ -240,6 +240,7 @@ const queryFmt = `%{name}\n` +
 	`%{payloaddigestalgo}:%{payloaddigest}\n` +
 	`%{sigpgp:pgpsig}\n` +
 	`%{sourcerpm}\n` +
+	`%{RPMTAG_MODULARITYLABEL}\n` +
 	`.\n`
 const delim = "\n.\n"
 
@@ -309,6 +310,16 @@ func parsePackage(ctx context.Context, log zerolog.Logger, src map[string]*clair
 				Version: sp[len(sp)-2] + "-" + sp[len(sp)-1],
 			}
 			src[name] = p.Source
+		case 5:
+			moduleSplit := strings.Split(line, ":")
+			if len(moduleSplit) < 2 {
+				continue
+			}
+			moduleStream := fmt.Sprintf("%s:%s", moduleSplit[0], moduleSplit[1])
+			p.Module = moduleStream
+			if p.Source != nil {
+				p.Source.Module = moduleStream
+			}
 		}
 		switch err {
 		case nil:

--- a/test/package.go
+++ b/test/package.go
@@ -22,20 +22,7 @@ func GenDuplicatePackages(n int) ([]*claircore.Package, error) {
 	nn := n / 2
 	for i := 0; i < n; i++ {
 		ii := i % nn
-		pkgs = append(pkgs, &claircore.Package{
-			ID:             strconv.Itoa(ii),
-			Name:           fmt.Sprintf("package-%d", ii),
-			Version:        fmt.Sprintf("version-%d", ii),
-			Kind:           "binary",
-			PackageDB:      fmt.Sprintf("package-db-%d", i),
-			RepositoryHint: fmt.Sprintf("repository-hint-%d", i),
-			Source: &claircore.Package{
-				ID:      strconv.Itoa(n + i),
-				Name:    fmt.Sprintf("source-package-%d", ii),
-				Version: fmt.Sprintf("source-version-%d", ii),
-				Kind:    "source",
-			},
-		})
+		pkgs = append(pkgs, createPackage(i, ii, n))
 	}
 
 	return pkgs, nil
@@ -47,21 +34,27 @@ func GenDuplicatePackages(n int) ([]*claircore.Package, error) {
 func GenUniquePackages(n int) []*claircore.Package {
 	pkgs := []*claircore.Package{}
 	for i := 0; i < n; i++ {
-		pkgs = append(pkgs, &claircore.Package{
-			ID:             strconv.Itoa(i),
-			Name:           fmt.Sprintf("package-%d", i),
-			Version:        fmt.Sprintf("version-%d", i),
-			Kind:           "binary",
-			PackageDB:      fmt.Sprintf("package-db-%d", i),
-			RepositoryHint: fmt.Sprintf("repository-hint-%d", i),
-			Source: &claircore.Package{
-				ID:      strconv.Itoa(n + i),
-				Name:    fmt.Sprintf("source-package-%d", i),
-				Version: fmt.Sprintf("source-version-%d", i),
-				Kind:    "source",
-			},
-		})
+		pkgs = append(pkgs, createPackage(i, i, n))
 	}
 
 	return pkgs
+}
+
+func createPackage(i int, ii int, n int) *claircore.Package {
+	return &claircore.Package{
+		ID:             strconv.Itoa(ii),
+		Name:           fmt.Sprintf("package-%d", ii),
+		Version:        fmt.Sprintf("version-%d", ii),
+		Kind:           "binary",
+		PackageDB:      fmt.Sprintf("package-db-%d", i),
+		RepositoryHint: fmt.Sprintf("repository-hint-%d", i),
+		Module:         fmt.Sprintf("module:%d", ii),
+		Source: &claircore.Package{
+			ID:      strconv.Itoa(n + i),
+			Name:    fmt.Sprintf("source-package-%d", ii),
+			Version: fmt.Sprintf("source-version-%d", ii),
+			Kind:    "source",
+			Module:  fmt.Sprintf("source-module:%d", ii),
+		},
+	}
 }

--- a/test/postgres/package.go
+++ b/test/postgres/package.go
@@ -13,15 +13,15 @@ import (
 func InsertPackages(db *sqlx.DB, pkgs []*claircore.Package) error {
 	for _, pkg := range pkgs {
 		// index source packages
-		_, err := db.Exec(`INSERT INTO package (id, kind, name, version) VALUES ($1, $2, $3, $4)`,
-			&pkg.Source.ID, &pkg.Source.Kind, &pkg.Source.Name, &pkg.Source.Version)
+		_, err := db.Exec(`INSERT INTO package (id, kind, name, version, module) VALUES ($1, $2, $3, $4, $5)`,
+			&pkg.Source.ID, &pkg.Source.Kind, &pkg.Source.Name, &pkg.Source.Version, &pkg.Source.Module)
 		if err != nil {
 			return fmt.Errorf("failed to index test pacakge's source %v: %v", pkg.Source, err)
 		}
 
 		// index package
-		_, err = db.Exec(`INSERT INTO package (id, kind, name, version) VALUES ($1, $2, $3, $4)`,
-			&pkg.ID, &pkg.Kind, &pkg.Name, &pkg.Version)
+		_, err = db.Exec(`INSERT INTO package (id, kind, name, version, module) VALUES ($1, $2, $3, $4, $5)`,
+			&pkg.ID, &pkg.Kind, &pkg.Name, &pkg.Version, &pkg.Module)
 		if err != nil {
 			return fmt.Errorf("failed to insert test package %v: %v", pkg, err)
 		}


### PR DESCRIPTION
Module property stores information about package module and stream which
the package is part of.

This is mostly used for modular rpm content. Rpm parser gets module
info from RPMTAG_MODULARITYLABEL in rpm database.