### PR TITLE
CCTool Unpack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor
 *.swp
 book
 cctool
+!cctool/

--- a/cmd/cctool/main.go
+++ b/cmd/cctool/main.go
@@ -14,6 +14,7 @@ import (
 var cleanup sync.WaitGroup
 
 type commonConfig struct {
+	cleanup *sync.WaitGroup
 }
 
 type subcmd func(context.Context, *commonConfig, []string) error
@@ -33,7 +34,9 @@ func main() {
 		done()
 	}()
 
-	var cfg commonConfig
+	var cfg commonConfig = commonConfig{
+		cleanup: &cleanup,
+	}
 	fs := flag.NewFlagSet("main", flag.ExitOnError)
 	fs.Usage = func() {
 		out := fs.Output()
@@ -44,6 +47,8 @@ func main() {
 		fmt.Fprintln(out, "\tgenerate reports for containers provided as arguments or on stdin")
 		fmt.Fprintln(out, "manifest")
 		fmt.Fprintln(out, "\tgenerate manifests for containers provided as arguments or on stdin")
+		fmt.Fprintln(out, "unpack")
+		fmt.Fprintln(out, "\textracts each container's layers content for inspection")
 		fmt.Fprintln(out)
 	}
 
@@ -57,6 +62,8 @@ func main() {
 		cmd = Report
 	case "manifest":
 		cmd = Manifest
+	case "unpack":
+		cmd = Unpack
 	case "":
 		fs.Usage()
 		os.Exit(99)

--- a/cmd/cctool/unpack.go
+++ b/cmd/cctool/unpack.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/quay/claircore/internal/indexer/fetcher"
+)
+
+type unpackConfig struct {
+	timeout time.Duration
+}
+
+// Unpack will decompress and untar each layer of the provided image ref
+func Unpack(cmd context.Context, cfg *commonConfig, args []string) error {
+	cmdcfg := unpackConfig{}
+	fs := flag.NewFlagSet("cctool unpack", flag.ExitOnError)
+	fs.DurationVar(&cmdcfg.timeout, "timeout", 5*time.Minute, "timeout for successful http responses")
+	fs.Usage = func() {
+		out := fs.Output()
+		fmt.Fprintf(out, "Usage:\n")
+		fmt.Fprintf(out, "\tcctool unpack <image-ref>\n")
+		fmt.Fprintf(out, "Arguments:\n")
+		fmt.Fprintf(out, "\timage-ref: a reference to an image and it's repository\n\n")
+	}
+	fs.Parse(args)
+
+	// get the image reference from argument.
+	if len(fs.Args()) <= 0 || len(fs.Args()) >= 2 {
+		fs.Usage()
+		return nil
+	}
+
+	image := fs.Args()[0]
+	ctx, done := context.WithTimeout(cmd, cmdcfg.timeout)
+	defer done()
+
+	// inspect image reference and get manifest
+	m, err := Inspect(ctx, image)
+	if err != nil {
+		return err
+	}
+
+	// signal to main cli we need to wait on cleanup
+	// we are about to write to the file system
+	cfg.cleanup.Add(1)
+
+	// fetch layers
+	ctx, done = context.WithTimeout(cmd, cmdcfg.timeout)
+	defer done()
+
+	log.Printf("fetching layers")
+	f := fetcher.New(nil, "")
+	err = f.Fetch(ctx, m.Layers)
+	if err != nil {
+		return err
+	}
+	log.Printf("successfully fetched layers")
+
+	// create a tmp dir we will unpack layers to
+	td, err := ioutil.TempDir("", "cctool-unpack-")
+
+	log.Printf("exacting layers into tmp dir: %v.", td)
+	for i, layer := range m.Layers {
+		dirName := filepath.Base(layer.Local())
+		dir := filepath.Join(td, strconv.Itoa(i)+"-"+dirName)
+		err := os.Mkdir(dir, 0755)
+		if err != nil {
+			return err
+		}
+
+		errbuf := bytes.Buffer{}
+		rd, err := layer.Reader()
+		if err != nil {
+			return err
+		}
+		tarcmd := exec.CommandContext(ctx, "tar", "-xC", dir)
+		tarcmd.Stdin = rd
+		tarcmd.Stderr = &errbuf
+		if err := tarcmd.Run(); err != nil {
+			return fmt.Errorf("err: %v stderr: %v", err, errbuf.String())
+		}
+
+		// add u+w to all files so we do not error deleting files written
+		// without the w bit by tar
+		chmodcmd := exec.CommandContext(ctx, "chmod", "-R", "u+w", dir)
+		errbuf.Reset()
+		chmodcmd.Stderr = &errbuf
+		if err := chmodcmd.Run(); err != nil {
+			return fmt.Errorf("err: %v stderr: %v", err, errbuf.String())
+		}
+	}
+
+	// defer cleanup
+	defer func() {
+		log.Printf("recurively deleting tmp dir %v", td)
+		err := os.RemoveAll(td)
+		if err != nil {
+			log.Printf("failed to recursively remove %v: %v", td, err)
+		}
+		log.Printf("deleting downloaded layers in tmp dir")
+		err = f.Close()
+		if err != nil {
+			log.Printf("failed to clean layer files in tmp directory: %v", err)
+		}
+		// signal to main cli routine cleanup is done
+		cleanup.Done()
+	}()
+
+	// input loop waiting for exit
+	log.Printf(`you may now inspect layers. type "exit" or ctrl-c + enter to cleanup and quit`)
+	input := bufio.NewScanner(os.Stdin)
+	fmt.Print("> ")
+	for input.Scan() {
+		w := input.Text()
+		switch {
+		case w == "exit":
+			return nil
+		case ctx.Err() != nil:
+			return ctx.Err()
+		default:
+			log.Printf(`type "exit" or ctrl-c + enter to cleanup and quit`)
+			fmt.Print("> ")
+		}
+	}
+	panic("not reachable")
+}

--- a/cmd/cctool/unpack.go
+++ b/cmd/cctool/unpack.go
@@ -31,7 +31,7 @@ func Unpack(cmd context.Context, cfg *commonConfig, args []string) error {
 		fmt.Fprintf(out, "Usage:\n")
 		fmt.Fprintf(out, "\tcctool unpack <image-ref>\n")
 		fmt.Fprintf(out, "Arguments:\n")
-		fmt.Fprintf(out, "\timage-ref: a reference to an image and it's repository\n\n")
+		fmt.Fprintf(out, "\timage-ref: a reference to an image and its repository\n\n")
 	}
 	fs.Parse(args)
 
@@ -72,7 +72,7 @@ func Unpack(cmd context.Context, cfg *commonConfig, args []string) error {
 
 	log.Printf("exacting layers into tmp dir: %v.", td)
 	for i, layer := range m.Layers {
-		dirName := filepath.Base(layer.Local())
+		dirName := layer.Hash.String()
 		dir := filepath.Join(td, strconv.Itoa(i)+"-"+dirName)
 		err := os.Mkdir(dir, 0755)
 		if err != nil {

--- a/layer.go
+++ b/layer.go
@@ -28,6 +28,10 @@ func (l *Layer) SetLocal(f string) error {
 	return nil
 }
 
+func (l *Layer) Local() string {
+	return l.localPath
+}
+
 func (l *Layer) Fetched() bool {
 	_, err := os.Stat(l.localPath)
 	return err == nil

--- a/layer.go
+++ b/layer.go
@@ -28,10 +28,6 @@ func (l *Layer) SetLocal(f string) error {
 	return nil
 }
 
-func (l *Layer) Local() string {
-	return l.localPath
-}
-
 func (l *Layer) Fetched() bool {
 	_, err := os.Stat(l.localPath)
 	return err == nil


### PR DESCRIPTION
This PR implements a command to unpack a particular image reference to your temp directory.
I keep having to do this when detection fails for a particular image and this slipstreams that process

Signed-off-by: ldelossa <ldelossa@redhat.com>
