### PR TITLE
update photon security url to new location

### DIFF
--- a/photon/photon.go
+++ b/photon/photon.go
@@ -12,7 +12,7 @@ import (
 var upstreamBase *url.URL
 
 func init() {
-	const base = `https://packages.vmware.com/photon/security/oval/`
+	const base = `https://packages.vmware.com/photon/photon_oval_definitions/`
 	var err error
 	upstreamBase, err = url.Parse(base)
 	if err != nil {


### PR DESCRIPTION
photon artifacts publish had a change. this change is final. 
updating url change.