### PR TITLE
add consistent linux bridge name

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,14 @@
 version: "3.7"
+
+# if you are using firewalld add this consistent bridge name
+# to your trusted zone
+# sudo firewall-cmd --zone=trusted --add-interface=claircore --permanent
+# sudo firewall-cmd --reload
+networks:
+  default:
+    driver_opts:
+      com.docker.network.bridge.name: claircore
+
 services:
 
   claircore-db:


### PR DESCRIPTION
I like to keep firewalld enabled on my fedora machine.
Docker compose creates a user defined network and usually the linux bridge interface it creates has a random name and this makes it difficult to place into firewalld zone rules.
This PR makes the local-dev linux bridge interface hosting the local dev network a consistent name. 

Signed-off-by: ldelossa <ldelossa@redhat.com>