### PR TITLE
Louis/layer scanned fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 docker ?= docker
 docker-compose ?= docker-compose
 
+# clears any go code in various caches
+.PHONY: clear-cache
+clear-cache:
+	go clean -cache -testcache -modcache
+
 # generates mocks of interfaces for testing
 .PHONY: genmocks
 genmocks:

--- a/alpine/distributionscanner.go
+++ b/alpine/distributionscanner.go
@@ -90,7 +90,7 @@ func (*DistributionScanner) Kind() string { return scannerKind }
 // and perform a regex match for keywords indicating the associated alpine release
 //
 // If neither file is found a (nil,nil) is returned.
-// If the files are found but all regexp fail to match an empty distribution is returned.
+// If the files are found but all regexp fail to match an empty slice is returned.
 func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]*claircore.Distribution, error) {
 	defer trace.StartRegion(ctx, "Scanner.Scan").End()
 	log := zerolog.Ctx(ctx).With().
@@ -111,7 +111,7 @@ func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]
 			return []*claircore.Distribution{dist}, nil
 		}
 	}
-	return nil, nil
+	return []*claircore.Distribution{}, nil
 }
 
 // parse attempts to match all alpine release regexp and returns the associated

--- a/aws/distributionscanner.go
+++ b/aws/distributionscanner.go
@@ -60,7 +60,7 @@ func (*DistributionScanner) Kind() string { return scannerKind }
 // and perform a regex match for keywords indicating the associated AWS release
 //
 // If neither file is found a (nil,nil) is returned.
-// If the files are found but all regexp fail to match an empty distribution is returned.
+// If the files are found but all regexp fail to match an empty slice is returned.
 func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]*claircore.Distribution, error) {
 	defer trace.StartRegion(ctx, "Scanner.Scan").End()
 	log := zerolog.Ctx(ctx).With().
@@ -83,7 +83,7 @@ func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]
 			return []*claircore.Distribution{dist}, nil
 		}
 	}
-	return nil, nil
+	return []*claircore.Distribution{}, nil
 }
 
 // parse attempts to match all AWS release regexp and returns the associated

--- a/debian/distributionscanner.go
+++ b/debian/distributionscanner.go
@@ -65,7 +65,7 @@ func (*DistributionScanner) Kind() string { return scannerKind }
 // and perform a regex match for keywords indicating the associated Debian release
 //
 // If neither file is found a (nil,nil) is returned.
-// If the files are found but all regexp fail to match an empty distribution is returned.
+// If the files are found but all regexp fail to match an empty slice is returned.
 func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]*claircore.Distribution, error) {
 	defer trace.StartRegion(ctx, "Scanner.Scan").End()
 	log := zerolog.Ctx(ctx).With().
@@ -86,7 +86,7 @@ func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]
 			return []*claircore.Distribution{dist}, nil
 		}
 	}
-	return nil, nil
+	return []*claircore.Distribution{}, nil
 }
 
 // parse attempts to match all Debian release regexp and returns the associated

--- a/oracle/distributionscanner.go
+++ b/oracle/distributionscanner.go
@@ -74,7 +74,7 @@ func (*DistributionScanner) Kind() string { return scannerKind }
 // and perform a regex match for keywords indicating the associated Oracle release
 //
 // If neither file is found a (nil,nil) is returned.
-// If the files are found but all regexp fail to match an empty distribution is returned.
+// If the files are found but all regexp fail to match an empty slice is returned.
 func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]*claircore.Distribution, error) {
 	defer trace.StartRegion(ctx, "Scanner.Scan").End()
 	log := zerolog.Ctx(ctx).With().
@@ -95,7 +95,7 @@ func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]
 			return []*claircore.Distribution{dist}, nil
 		}
 	}
-	return nil, nil
+	return []*claircore.Distribution{}, nil
 }
 
 // parse attempts to match all Oracle release regexp and returns the associated

--- a/photon/distributionscanner.go
+++ b/photon/distributionscanner.go
@@ -67,7 +67,7 @@ func (*DistributionScanner) Kind() string { return scannerKind }
 // and perform a regex match for keywords indicating the associated photon release
 //
 // If neither file is found a (nil,nil) is returned.
-// If the files are found but all regexp fail to match an empty distribution is returned.
+// If the files are found but all regexp fail to match an empty slice is returned.
 func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]*claircore.Distribution, error) {
 	defer trace.StartRegion(ctx, "Scanner.Scan").End()
 	log := zerolog.Ctx(ctx).With().
@@ -88,7 +88,7 @@ func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]
 			return []*claircore.Distribution{dist}, nil
 		}
 	}
-	return []*claircore.Distribution{&claircore.Distribution{}}, nil
+	return []*claircore.Distribution{}, nil
 }
 
 // parse attempts to match all photon release regexp and returns the associated

--- a/rhel/distributionscanner.go
+++ b/rhel/distributionscanner.go
@@ -78,7 +78,7 @@ func (*DistributionScanner) Kind() string { return scannerKind }
 // and perform a regex match for keywords indicating the associated Oracle release
 //
 // If neither file is found a (nil,nil) is returned.
-// If the files are found but all regexp fail to match an empty distribution is returned.
+// If the files are found but all regexp fail to match an empty slice is returned.
 func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]*claircore.Distribution, error) {
 	defer trace.StartRegion(ctx, "Scanner.Scan").End()
 	log := zerolog.Ctx(ctx).With().
@@ -99,7 +99,7 @@ func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]
 			return []*claircore.Distribution{dist}, nil
 		}
 	}
-	return nil, nil
+	return []*claircore.Distribution{}, nil
 }
 
 // parse attempts to match all Oracle release regexp and returns the associated

--- a/suse/distributionscanner.go
+++ b/suse/distributionscanner.go
@@ -80,7 +80,7 @@ func (*DistributionScanner) Kind() string { return scannerKind }
 // and perform a regex match for keywords indicating the associated Suse release
 //
 // If neither file is found a (nil,nil) is returned.
-// If the files are found but all regexp fail to match an empty distribution is returned.
+// If the files are found but all regexp fail to match an empty slice is returned.
 func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]*claircore.Distribution, error) {
 	defer trace.StartRegion(ctx, "Scanner.Scan").End()
 	log := zerolog.Ctx(ctx).With().
@@ -101,7 +101,7 @@ func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]
 			return []*claircore.Distribution{dist}, nil
 		}
 	}
-	return nil, nil
+	return []*claircore.Distribution{}, nil
 }
 
 // parse attempts to match all Suse release regexp and returns the associated

--- a/ubuntu/distributionscanner.go
+++ b/ubuntu/distributionscanner.go
@@ -85,7 +85,7 @@ func (*DistributionScanner) Kind() string { return scannerKind }
 // and perform a regex match for keywords indicating the associated Ubuntu release
 //
 // If neither file is found a (nil,nil) is returned.
-// If the files are found but all regexp fail to match an empty distribution is returned.
+// If the files are found but all regexp fail to match an empty slice is returned.
 func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]*claircore.Distribution, error) {
 	defer trace.StartRegion(ctx, "Scanner.Scan").End()
 	log := zerolog.Ctx(ctx).With().
@@ -106,7 +106,7 @@ func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]
 			return []*claircore.Distribution{dist}, nil
 		}
 	}
-	return nil, nil
+	return []*claircore.Distribution{}, nil
 }
 
 // parse attempts to match all Ubuntu release regexp and returns the associated


### PR DESCRIPTION
This squashes two bugs which were causing libindex to misidentify a layer's distribution.

First the photon distribution scanner was returning an empty distribution even when no distribution could be identified. This caused an empty distribution to be returned and bound to the index report. 
Also we change all distribution scanners to do the right thing and return an empty array when the file they want to parse is present, but does not contain values that they identify with. 

Second the sql query used in LayerScanned were erroneously identifying layers as already scanned and this layer would never be processed. 

Boy scout tasks around layer scanning logging and adding makefile entry exist in this PR as well. 