### PR TITLE
updatediffs: fix broken query, add cctool subcommand

### DIFF
--- a/internal/vulnstore/postgres/getupdateoperationdiff.go
+++ b/internal/vulnstore/postgres/getupdateoperationdiff.go
@@ -114,11 +114,11 @@ func populateRefs(ctx context.Context, diff *driver.UpdateDiff, pool *pgxpool.Po
 	const query = `SELECT updater, fingerprint, date FROM update_operation WHERE ref = $1;`
 	var err error
 
-	diff.B.Ref = cur
+	diff.Cur.Ref = cur
 	err = pool.QueryRow(ctx, query, cur).Scan(
-		&diff.B.Updater,
-		&diff.B.Fingerprint,
-		&diff.B.Date,
+		&diff.Cur.Updater,
+		&diff.Cur.Fingerprint,
+		&diff.Cur.Date,
 	)
 	switch {
 	case err == nil:
@@ -131,11 +131,11 @@ func populateRefs(ctx context.Context, diff *driver.UpdateDiff, pool *pgxpool.Po
 	if prev == uuid.Nil {
 		return nil
 	}
-	diff.A.Ref = prev
+	diff.Prev.Ref = prev
 	err = pool.QueryRow(ctx, query, prev).Scan(
-		&diff.A.Updater,
-		&diff.A.Fingerprint,
-		&diff.A.Date,
+		&diff.Prev.Updater,
+		&diff.Prev.Fingerprint,
+		&diff.Prev.Date,
 	)
 	switch {
 	case err == nil:

--- a/internal/vulnstore/postgres/getupdateoperations.go
+++ b/internal/vulnstore/postgres/getupdateoperations.go
@@ -29,7 +29,7 @@ func (s *Store) GetLatestUpdateRef(ctx context.Context) (uuid.UUID, error) {
 }
 
 func getLatestRefs(ctx context.Context, pool *pgxpool.Pool) (map[string]uuid.UUID, error) {
-	const query = `SELECT updater, ref FROM update_operation GROUP BY updater ORDER BY updater, id USING > LIMIT 1;`
+	const query = `SELECT DISTINCT ON (updater) updater, ref FROM update_operation ORDER BY updater, id USING >;`
 	log := zerolog.Ctx(ctx).With().
 		Str("component", "internal/vulnstore/postgres/getLatestRefs").
 		Logger()

--- a/internal/vulnstore/postgres/update_e2e_test.go
+++ b/internal/vulnstore/postgres/update_e2e_test.go
@@ -204,11 +204,11 @@ func (e *e2e) Diff(ctx context.Context) func(t *testing.T) {
 			}
 
 			// make sure update operations match generated test values
-			if prev != diff.A.Ref {
-				t.Errorf("want: %v, got: %v", diff.A.Ref, prev)
+			if prev != diff.Prev.Ref {
+				t.Errorf("want: %v, got: %v", diff.Prev.Ref, prev)
 			}
-			if cur != diff.B.Ref {
-				t.Errorf("want: %v, got: %v", diff.B.Ref, cur)
+			if cur != diff.Cur.Ref {
+				t.Errorf("want: %v, got: %v", diff.Cur.Ref, cur)
 			}
 
 			// confirm removed and add vulnerabilities are the ones we expect

--- a/libvuln/driver/updatediff.go
+++ b/libvuln/driver/updatediff.go
@@ -13,16 +13,16 @@ import (
 
 // UpdateOperation is a unique update to the vulnstore by an Updater.
 type UpdateOperation struct {
-	Ref         uuid.UUID
-	Updater     string
-	Fingerprint Fingerprint
-	Date        time.Time
+	Ref         uuid.UUID   `json:"ref"`
+	Updater     string      `json:"updater"`
+	Fingerprint Fingerprint `json:"fingerprint"`
+	Date        time.Time   `json:"date"`
 }
 
 // UpdateDiff represents added or removed vulnerabilities between update operations
 type UpdateDiff struct {
-	A       UpdateOperation
-	B       UpdateOperation
-	Added   []claircore.Vulnerability
-	Removed []claircore.Vulnerability
+	Prev    UpdateOperation           `json:"prev"`
+	Cur     UpdateOperation           `json:"cur"`
+	Added   []claircore.Vulnerability `json:"added"`
+	Removed []claircore.Vulnerability `json:"removed"`
 }


### PR DESCRIPTION
This also normalizes the json names of the update structures.

Signed-off-by: Hank Donnay <hdonnay@redhat.com>