### PR TITLE
Add --delay-directory-restor option to tar command

### DIFF
--- a/cmd/cctool/unpack.go
+++ b/cmd/cctool/unpack.go
@@ -84,7 +84,7 @@ func Unpack(cmd context.Context, cfg *commonConfig, args []string) error {
 		if err != nil {
 			return err
 		}
-		tarcmd := exec.CommandContext(ctx, "tar", "-xC", dir)
+		tarcmd := exec.CommandContext(ctx, "tar", "-xC", dir, "--delay-directory-restore")
 		tarcmd.Stdin = rd
 		tarcmd.Stderr = &errbuf
 		if err := tarcmd.Run(); err != nil {

--- a/rpm/packagescanner.go
+++ b/rpm/packagescanner.go
@@ -168,7 +168,8 @@ func (ps *Scanner) Scan(ctx context.Context, layer *claircore.Layer) ([]*clairco
 	// hopefully there aren't any others strewn about.
 	tarcmd := exec.CommandContext(ctx, "tar", "-xC", root,
 		"--exclude", "dev",
-		"--exclude", ".wh*")
+		"--exclude", ".wh*",
+		"--delay-directory-restore")
 	tarcmd.Stdin = rd
 	tarcmd.Stderr = &errbuf
 	log.Debug().Str("dir", root).Strs("cmd", tarcmd.Args).Msg("tar invocation")
@@ -176,7 +177,8 @@ func (ps *Scanner) Scan(ctx context.Context, layer *claircore.Layer) ([]*clairco
 		log.Error().
 			Str("dir", root).
 			Strs("cmd", tarcmd.Args).
-			Str("err", errbuf.String()).
+			Str("stderr", errbuf.String()).
+			AnErr("err", err).
 			Msg("error extracting layer")
 		return nil, fmt.Errorf("rpm: failed to untar: %w", err)
 	}


### PR DESCRIPTION
In some cases tar command fails with permission error. This option
avoids those errors.

https://changilkim.wordpress.com/2013/12/30/tar-cannot-mkdir-permission-denied/