### PR TITLE
log: one more attempt at race squashing

### DIFF
--- a/alpine/fetcher_test.go
+++ b/alpine/fetcher_test.go
@@ -11,9 +11,9 @@ import (
 )
 
 func TestFetcher(t *testing.T) {
-	ctx, done := context.WithCancel(context.Background())
+	ctx := context.Background()
+	ctx, done := log.TestLogger(ctx, t)
 	defer done()
-	ctx = log.TestLogger(ctx, t)
 
 	var table = []struct {
 		release   Release

--- a/alpine/packagescanner_test.go
+++ b/alpine/packagescanner_test.go
@@ -147,9 +147,9 @@ func TestScan(t *testing.T) {
 		},
 	}
 
-	ctx, done := context.WithCancel(context.Background())
+	ctx := context.Background()
+	ctx, done := log.TestLogger(ctx, t)
 	defer done()
-	ctx = log.TestLogger(ctx, t)
 	l := &claircore.Layer{
 		Hash: hash,
 	}

--- a/alpine/parser_test.go
+++ b/alpine/parser_test.go
@@ -126,9 +126,8 @@ func TestParser(t *testing.T) {
 
 	for _, test := range table {
 		t.Run(test.testFile, func(t *testing.T) {
-			ctx, done := context.WithCancel(ctx)
+			ctx, done := log.TestLogger(ctx, t)
 			defer done()
-			ctx = log.TestLogger(ctx, t)
 
 			path := fmt.Sprintf("testdata/%s", test.testFile)
 			f, err := os.Open(path)

--- a/aws/updater_integration_test.go
+++ b/aws/updater_integration_test.go
@@ -30,9 +30,8 @@ func Test_Updater(t *testing.T) {
 
 	for _, table := range tt {
 		t.Run(table.name, func(t *testing.T) {
-			ctx, done := context.WithCancel(ctx)
+			ctx, done := log.TestLogger(ctx, t)
 			defer done()
-			ctx = log.TestLogger(ctx, t)
 
 			updater, err := NewUpdater(table.release)
 			assert.NoError(t, err)

--- a/debian/matcher_integration_test.go
+++ b/debian/matcher_integration_test.go
@@ -24,9 +24,9 @@ import (
 // CVE data
 func Test_Matcher_Integration(t *testing.T) {
 	integration.Skip(t)
-	ctx, done := context.WithCancel(context.Background())
+	ctx := context.Background()
+	ctx, done := log.TestLogger(ctx, t)
 	defer done()
-	ctx = log.TestLogger(ctx, t)
 	db, store, teardown := vulnstore.TestStore(ctx, t)
 	defer teardown()
 
@@ -56,7 +56,7 @@ func Test_Matcher_Integration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to decode IndexReport: %v", err)
 	}
-	vr, err := matcher.Match(context.Background(), &ir, []driver.Matcher{m}, store)
+	vr, err := matcher.Match(ctx, &ir, []driver.Matcher{m}, store)
 	if err != nil {
 		t.Fatalf("expected nil error but got %v", err)
 	}

--- a/debian/updater_integration_test.go
+++ b/debian/updater_integration_test.go
@@ -38,9 +38,8 @@ func Test_Updater(t *testing.T) {
 
 	for _, table := range tt {
 		t.Run(table.name, func(t *testing.T) {
-			ctx, done := context.WithCancel(ctx)
+			ctx, done := log.TestLogger(ctx, t)
 			defer done()
-			ctx = log.TestLogger(ctx, t)
 			updater := NewUpdater(table.release)
 			t.Log(updater.url)
 

--- a/dpkg/scanner_test.go
+++ b/dpkg/scanner_test.go
@@ -794,9 +794,9 @@ func TestScanner(t *testing.T) {
 			RepositoryHint: "daafc6eba6eae603327bf8fc49645999",
 		},
 	}
-	ctx, done := context.WithCancel(context.Background())
+	ctx := context.Background()
+	ctx, done := log.TestLogger(ctx, t)
 	defer done()
-	ctx = log.TestLogger(ctx, t)
 	l := &claircore.Layer{
 		Hash: hash,
 	}

--- a/internal/indexer/controller/controller_test.go
+++ b/internal/indexer/controller/controller_test.go
@@ -52,9 +52,8 @@ func Test_Controller_IndexerError(t *testing.T) {
 
 	for _, table := range tt {
 		t.Run(table.name, func(t *testing.T) {
-			ctx, done := context.WithCancel(ctx)
+			ctx, done := log.TestLogger(ctx, t)
 			defer done()
-			ctx = log.TestLogger(ctx, t)
 			store, fetcher := table.mock(t)
 			c := New(&indexer.Opts{
 				Store:   store,
@@ -112,9 +111,8 @@ func Test_Controller_IndexFinished(t *testing.T) {
 
 	for _, table := range tt {
 		t.Run(table.name, func(t *testing.T) {
-			ctx, done := context.WithCancel(ctx)
+			ctx, done := log.TestLogger(ctx, t)
 			defer done()
-			ctx = log.TestLogger(ctx, t)
 			store, fetcher := table.mock(t)
 			// set global startState for purpose of this test
 			startState = IndexFinished

--- a/internal/indexer/fetcher/fetcher_test.go
+++ b/internal/indexer/fetcher/fetcher_test.go
@@ -35,10 +35,9 @@ type testcase struct {
 }
 
 func (tc testcase) Run(ctx context.Context) func(*testing.T) {
-	ctx, done := context.WithCancel(ctx)
 	return func(t *testing.T) {
+		ctx, done := log.TestLogger(ctx, t)
 		defer done()
-		ctx = log.TestLogger(ctx, t)
 		layers := test.ServeLayers(ctx, t, tc.N)
 		for _, l := range layers {
 			t.Logf("%+v", l)
@@ -98,9 +97,8 @@ func TestInvalid(t *testing.T) {
 
 	for _, table := range tt {
 		t.Run(table.name, func(t *testing.T) {
-			ctx, done := context.WithCancel(ctx)
+			ctx, done := log.TestLogger(ctx, t)
 			defer done()
-			ctx = log.TestLogger(ctx, t)
 			fetcher := New(&testClient, indexer.InMem)
 			if err := fetcher.Fetch(ctx, table.layer); err == nil {
 				t.Fatal("expected error, got nil")

--- a/internal/indexer/linux/coalescer_test.go
+++ b/internal/indexer/linux/coalescer_test.go
@@ -16,9 +16,9 @@ import (
 // database access would have occured. Thus we do not use a black box test
 // and instead test private methods.
 func Test_Coalescer(t *testing.T) {
-	ctx, done := context.WithCancel(context.Background())
+	ctx := context.Background()
+	ctx, done := log.TestLogger(ctx, t)
 	defer done()
-	ctx = log.TestLogger(ctx, t)
 	coalescer := &Coalescer{
 		ir: &claircore.IndexReport{
 			Environments:  map[string][]*claircore.Environment{},

--- a/internal/indexer/postgres/affected_manifests_e2e_test.go
+++ b/internal/indexer/postgres/affected_manifests_e2e_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/jmoiron/sqlx"
 	"github.com/lib/pq"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/internal/indexer"
 	"github.com/quay/claircore/test/integration"
@@ -26,9 +27,9 @@ type affectedE2E struct {
 
 func TestAffectedE2E(t *testing.T) {
 	integration.Skip(t)
-	ctx, done := context.WithCancel(context.Background())
+	ctx := context.Background()
+	ctx, done := log.TestLogger(ctx, t)
 	defer done()
-	ctx = log.TestLogger(ctx, t)
 	db, store, teardown := TestStore(ctx, t)
 	defer teardown()
 

--- a/internal/indexer/postgres/indexpackage_benchmark_test.go
+++ b/internal/indexer/postgres/indexpackage_benchmark_test.go
@@ -179,9 +179,8 @@ func Benchmark_IndexPackages(b *testing.B) {
 
 	for _, bench := range benchmarks {
 		b.Run(bench.name, func(b *testing.B) {
-			ctx, done := context.WithCancel(ctx)
+			ctx, done := log.TestLogger(ctx, b)
 			defer done()
-			ctx = log.TestLogger(ctx, b)
 			db, store, teardown := TestStore(ctx, b)
 			defer teardown()
 

--- a/internal/indexer/postgres/packagesbylayer_benchmark_test.go
+++ b/internal/indexer/postgres/packagesbylayer_benchmark_test.go
@@ -91,9 +91,8 @@ func Benchmark_PackagesByLayer(b *testing.B) {
 
 	for _, bench := range benchmarks {
 		b.Run(bench.name, func(b *testing.B) {
-			ctx, done := context.WithCancel(ctx)
+			ctx, done := log.TestLogger(ctx, b)
 			defer done()
-			ctx = log.TestLogger(ctx, b)
 			db, store, teardown := TestStore(ctx, b)
 			defer teardown()
 

--- a/internal/vulnstore/postgres/update_e2e_test.go
+++ b/internal/vulnstore/postgres/update_e2e_test.go
@@ -24,9 +24,9 @@ import (
 // TestE2E performs an end to end test of update operations and diffing
 func TestE2E(t *testing.T) {
 	integration.Skip(t)
-	ctx, done := context.WithCancel(context.Background())
+	ctx := context.Background()
+	ctx, done := log.TestLogger(ctx, t)
 	defer done()
-	ctx = log.TestLogger(ctx, t)
 
 	cases := []e2e{
 		{

--- a/libindex/libindex_integration_test.go
+++ b/libindex/libindex_integration_test.go
@@ -124,9 +124,8 @@ func (tc testcase) RunInner(ctx context.Context, t *testing.T, dsn string, next 
 func (tc testcase) Run(ctx context.Context, check checkFunc) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Parallel()
-		ctx, done := context.WithCancel(ctx)
+		ctx, done := log.TestLogger(ctx, t)
 		defer done()
-		ctx = log.TestLogger(ctx, t)
 		db, err := integration.NewDB(ctx, t)
 		if err != nil {
 			t.Fatal(err)

--- a/oracle/parser_test.go
+++ b/oracle/parser_test.go
@@ -14,9 +14,9 @@ import (
 
 func TestParse(t *testing.T) {
 	t.Parallel()
-	ctx, done := context.WithCancel(context.Background())
+	ctx := context.Background()
+	ctx, done := log.TestLogger(ctx, t)
 	defer done()
-	ctx = log.TestLogger(ctx, t)
 	u, err := NewUpdater(-1)
 	if err != nil {
 		t.Fatal(err)

--- a/oracle/updater_test.go
+++ b/oracle/updater_test.go
@@ -11,9 +11,9 @@ import (
 )
 
 func TestFetch(t *testing.T) {
-	ctx, done := context.WithCancel(context.Background())
+	ctx := context.Background()
+	ctx, done := log.TestLogger(ctx, t)
 	defer done()
-	ctx = log.TestLogger(ctx, t)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.ServeFile(w, r, "testdata/com.oracle.elsa-2018.xml")
 	}))

--- a/osrelease/scanner_test.go
+++ b/osrelease/scanner_test.go
@@ -22,9 +22,9 @@ type parsecase struct {
 
 func (c parsecase) Test(t *testing.T) {
 	t.Parallel()
-	ctx, done := context.WithCancel(context.Background())
+	ctx := context.Background()
+	ctx, done := log.TestLogger(ctx, t)
 	defer done()
-	ctx = log.TestLogger(ctx, t)
 	ctx, task := trace.NewTask(ctx, "parse test")
 	defer task.End()
 	trace.Log(ctx, "parse test:file", c.File)
@@ -142,9 +142,9 @@ type layerspec struct {
 
 func (lc layercase) Test(t *testing.T) {
 	t.Parallel()
-	ctx, done := context.WithCancel(context.Background())
+	ctx := context.Background()
+	ctx, done := log.TestLogger(ctx, t)
 	defer done()
-	ctx = log.TestLogger(ctx, t)
 	s := Scanner{}
 	l := &claircore.Layer{}
 	f, err := fetch.Layer(ctx, t, nil, lc.Layer.From, lc.Layer.Repo, lc.Layer.Blob)

--- a/photon/integration_test.go
+++ b/photon/integration_test.go
@@ -11,9 +11,9 @@ import (
 )
 
 func check_release(t *testing.T, photon_release Release) {
-	ctx, done := context.WithCancel(context.Background())
+	ctx := context.Background()
+	ctx, done := log.TestLogger(ctx, t)
 	defer done()
-	ctx = log.TestLogger(ctx, t)
 
 	u, err := NewUpdater(photon_release)
 	if err != nil {

--- a/pyupio/updater_test.go
+++ b/pyupio/updater_test.go
@@ -154,9 +154,9 @@ func (tc dbTestcase) filename() string {
 }
 
 func (tc dbTestcase) Run(t *testing.T) {
-	ctx, done := context.WithCancel(context.Background())
+	ctx := context.Background()
+	ctx, done := log.TestLogger(ctx, t)
 	defer done()
-	ctx = log.TestLogger(ctx, t)
 
 	f, err := os.Open(tc.filename())
 	if err != nil {

--- a/rhel/coalescer_test.go
+++ b/rhel/coalescer_test.go
@@ -16,9 +16,9 @@ import (
 // database access would have occurred. Thus we do not use a black box test
 // and instead test private methods.
 func Test_Coalescer(t *testing.T) {
-	ctx, done := context.WithCancel(context.Background())
+	ctx := context.Background()
+	ctx, done := log.TestLogger(ctx, t)
 	defer done()
-	ctx = log.TestLogger(ctx, t)
 	coalescer := NewCoalescer()
 	// we will test
 	// 1) packages before a distribution was discovered are tagged with
@@ -86,9 +86,9 @@ func Test_Coalescer(t *testing.T) {
 }
 
 func Test_Coalescer_cpe_repos(t *testing.T) {
-	ctx, done := context.WithCancel(context.Background())
+	ctx := context.Background()
+	ctx, done := log.TestLogger(ctx, t)
 	defer done()
-	ctx = log.TestLogger(ctx, t)
 	coalescer := NewCoalescer()
 	repo1 := &claircore.Repository{
 		ID:   "1",
@@ -161,9 +161,9 @@ func Test_Coalescer_cpe_repos(t *testing.T) {
 }
 
 func Test_Coalescer_updated_package(t *testing.T) {
-	ctx, done := context.WithCancel(context.Background())
+	ctx := context.Background()
+	ctx, done := log.TestLogger(ctx, t)
 	defer done()
-	ctx = log.TestLogger(ctx, t)
 	coalescer := NewCoalescer()
 	repo1 := &claircore.Repository{
 		ID:   "1",
@@ -226,9 +226,9 @@ func Test_Coalescer_updated_package(t *testing.T) {
 }
 
 func Test_Coalescer_downgraded_package(t *testing.T) {
-	ctx, done := context.WithCancel(context.Background())
+	ctx := context.Background()
+	ctx, done := log.TestLogger(ctx, t)
 	defer done()
-	ctx = log.TestLogger(ctx, t)
 	coalescer := NewCoalescer()
 	repo1 := &claircore.Repository{
 		ID:   "1",
@@ -291,9 +291,9 @@ func Test_Coalescer_downgraded_package(t *testing.T) {
 }
 
 func Test_Coalescer_removed_package(t *testing.T) {
-	ctx, done := context.WithCancel(context.Background())
+	ctx := context.Background()
+	ctx, done := log.TestLogger(ctx, t)
 	defer done()
-	ctx = log.TestLogger(ctx, t)
 	coalescer := NewCoalescer()
 	repo1 := &claircore.Repository{
 		ID:   "1",

--- a/rhel/fetch_test.go
+++ b/rhel/fetch_test.go
@@ -22,9 +22,8 @@ func TestFetch(t *testing.T) {
 	defer srv.Close()
 
 	t.Run("FetchContext", func(t *testing.T) {
-		ctx, done := context.WithCancel(ctx)
+		ctx, done := log.TestLogger(ctx, t)
 		defer done()
-		ctx = log.TestLogger(ctx, t)
 		u, err := NewUpdater(3, WithClient(srv.Client()), WithURL(srv.URL, ""))
 		if err != nil {
 			t.Fatal(err)
@@ -54,9 +53,8 @@ func TestFetch(t *testing.T) {
 	})
 
 	t.Run("Fetch", func(t *testing.T) {
-		ctx, done := context.WithCancel(ctx)
+		ctx, done := log.TestLogger(ctx, t)
 		defer done()
-		ctx = log.TestLogger(ctx, t)
 		u, err := NewUpdater(3, WithClient(srv.Client()), WithURL(srv.URL, ""))
 		if err != nil {
 			t.Fatal(err)

--- a/rhel/matcher_test.go
+++ b/rhel/matcher_test.go
@@ -24,9 +24,9 @@ import (
 
 func TestMatcherIntegration(t *testing.T) {
 	integration.Skip(t)
-	ctx, done := context.WithCancel(context.Background())
+	ctx := context.Background()
+	ctx, done := log.TestLogger(ctx, t)
 	defer done()
-	ctx = log.TestLogger(ctx, t)
 	db, store, teardown := vulnstore.TestStore(ctx, t)
 	defer teardown()
 	m := &Matcher{}

--- a/rhel/parse_test.go
+++ b/rhel/parse_test.go
@@ -14,9 +14,9 @@ import (
 
 func TestParse(t *testing.T) {
 	t.Parallel()
-	ctx, done := context.WithCancel(context.Background())
+	ctx := context.Background()
+	ctx, done := log.TestLogger(ctx, t)
 	defer done()
-	ctx = log.TestLogger(ctx, t)
 
 	u, err := NewUpdater(3)
 	if err != nil {

--- a/rhel/repositoryscanner_test.go
+++ b/rhel/repositoryscanner_test.go
@@ -17,9 +17,9 @@ import (
 )
 
 func TestRepositoryScanner(t *testing.T) {
-	ctx, done := context.WithCancel(context.Background())
+	ctx := context.Background()
+	ctx, done := log.TestLogger(ctx, t)
 	defer done()
-	ctx = log.TestLogger(ctx, t)
 
 	// Set up a response map and test server to mock the Container API.
 	resp := map[string]*containerImages{

--- a/rpm/packagescanner_test.go
+++ b/rpm/packagescanner_test.go
@@ -1596,9 +1596,9 @@ func TestScan(t *testing.T) {
 			t.Skipf("skipping test: missing needed utility %q (%v)", exe, err)
 		}
 	}
-	ctx, done := context.WithCancel(context.Background())
+	ctx := context.Background()
+	ctx, done := log.TestLogger(ctx, t)
 	defer done()
-	ctx = log.TestLogger(ctx, t)
 	l := &claircore.Layer{
 		Hash: hash,
 	}

--- a/suse/integration_test.go
+++ b/suse/integration_test.go
@@ -12,9 +12,9 @@ import (
 
 func TestLiveDatabase(t *testing.T) {
 	integration.Skip(t)
-	ctx, done := context.WithCancel(context.Background())
+	ctx := context.Background()
+	ctx, done := log.TestLogger(ctx, t)
 	defer done()
-	ctx = log.TestLogger(ctx, t)
 
 	u, err := NewUpdater(EnterpriseServer15)
 	if err != nil {

--- a/test/packagescanner.go
+++ b/test/packagescanner.go
@@ -40,7 +40,8 @@ func (tc ScannerTestcase) Digest() claircore.Digest {
 // Run returns a function suitable for using with (*testing.T).Run.
 func (tc ScannerTestcase) Run(ctx context.Context) func(*testing.T) {
 	return func(t *testing.T) {
-		ctx = log.TestLogger(ctx, t)
+		ctx, done := log.TestLogger(ctx, t)
+		defer done()
 		d := tc.Digest()
 		n, err := fetch.Layer(ctx, t, http.DefaultClient, tc.Domain, tc.Name, d)
 		if err != nil {


### PR DESCRIPTION
This change introduces a child context and explicitly closing the write
end of the pipe. It should catch the situation where a line could be
being written after the Context was cancelled and the test returned.

Signed-off-by: Hank Donnay <hdonnay@redhat.com>