### PR TITLE
consistent conainter names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ unit-v:
 .PHONY: local-dev-up
 local-dev-up:
 	$(docker-compose) up -d claircore-db
-	$(docker) exec -it claircore_claircore-db_1 bash -c 'while ! pg_isready; do echo "waiting for postgres"; sleep 2; done'
+	$(docker) exec -it claircore-db bash -c 'while ! pg_isready; do echo "waiting for postgres"; sleep 2; done'
 	go mod vendor
 	$(docker-compose) up -d libindexhttp
 	$(docker-compose) up -d libvulnhttp
@@ -67,7 +67,7 @@ claircore-db-up:
 
 .PHONY: claircore-db-restart
 claircore-db-restart:
-	$(docker) kill claircore_claircore-db_1 && $(docker) rm claircore_claircore-db_1
+	$(docker) kill claircore-db && $(docker) rm claircore_claircore-db_1
 	make claircore-db-up
 
 .PHONY: libindexhttp-restart

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,6 +13,7 @@ services:
 
   claircore-db:
     image: postgres:11.5
+    container_name: claircore-db
     environment:
       POSTGRES_USER: "claircore"
       POSTGRES_DB: "claircore"
@@ -27,6 +28,7 @@ services:
 
   libindexhttp:
     image: quay.io/claircore/golang:1.13.3
+    container_name: libindexhttp
     ports:
       - "8080:8080"
     environment:
@@ -42,6 +44,7 @@ services:
 
   libvulnhttp:
     image: quay.io/claircore/golang:1.13.3
+    container_name: libvulnhttp
     ports:
       - "8081:8081"
     environment:

--- a/etc/podman.yaml.in
+++ b/etc/podman.yaml.in
@@ -82,7 +82,7 @@ spec:
         - name: POSTGRES_DB
           value: claircore
       image: docker.io/library/postgres:11
-      name: claircore-database
+      name: claircore-db
       restartPolicy: OnFailure
       ports:
         - containerPort: 5434


### PR DESCRIPTION
PR creates consistent container names so local dev does not break between git worktrees. 