### PR TITLE
CPE mapping in indexer + rhel matching changes

### DIFF
--- a/libvuln/opts.go
+++ b/libvuln/opts.go
@@ -124,7 +124,7 @@ func (o *Opts) parse(ctx context.Context) error {
 		&debian.Matcher{},
 		&python.Matcher{},
 		&ubuntu.Matcher{},
-		rhel.NewMatcher(ctx, nil),
+		&rhel.Matcher{},
 		&photon.Matcher{},
 	}
 

--- a/pkg/omnimatcher/omnimatcher.go
+++ b/pkg/omnimatcher/omnimatcher.go
@@ -20,7 +20,7 @@ var defaultOmniMatcher = []driver.Matcher{
 	&aws.Matcher{},
 	&debian.Matcher{},
 	&python.Matcher{},
-	rhel.NewMatcher(context.TODO(), nil),
+	&rhel.Matcher{},
 	&ubuntu.Matcher{},
 }
 

--- a/pkg/ovalutil/rpm.go
+++ b/pkg/ovalutil/rpm.go
@@ -104,6 +104,7 @@ func RPMDefsToVulns(ctx context.Context, root oval.Root, protoVulns ProtoVulnsFu
 							p := &claircore.Package{
 								Name:   object.Name,
 								Module: module,
+								Kind:   claircore.BINARY,
 							}
 							pkgcache[pkgCacheKey] = p
 							vuln.Package = p

--- a/rhel/containerapi/containerapi.go
+++ b/rhel/containerapi/containerapi.go
@@ -17,8 +17,8 @@ type ContainerImages struct {
 	Images []ContainerImage `json:"data"`
 }
 type ContainerImage struct {
-	ContentSets []string   `json:"content_sets"`
-	ParsedData  ParsedData `json:"parsed_data"`
+	CPEs       []string   `json:"cpe_ids"`
+	ParsedData ParsedData `json:"parsed_data"`
 }
 type ParsedData struct {
 	Architecture string  `json:"architecture"`
@@ -36,7 +36,7 @@ type ContainerAPI struct {
 }
 
 // GetCPEs fetches CPE information for given build from Red Hat Container API.
-func (c *ContainerAPI) GetContentSets(ctx context.Context, nvr, arch string) ([]string, error) {
+func (c *ContainerAPI) GetCPEs(ctx context.Context, nvr, arch string) ([]string, error) {
 	log := zerolog.Ctx(ctx).With().Logger()
 	uri, err := c.Root.Parse(path.Join("v1/images/nvr/", nvr))
 	if err != nil {
@@ -75,7 +75,7 @@ func (c *ContainerAPI) GetContentSets(ctx context.Context, nvr, arch string) ([]
 		for _, label := range image.ParsedData.Labels {
 			if label.Name == "architecture" {
 				if label.Value == arch {
-					return image.ContentSets, nil
+					return image.CPEs, nil
 				}
 			}
 		}

--- a/rhel/ecosystem.go
+++ b/rhel/ecosystem.go
@@ -21,7 +21,7 @@ func NewEcosystem(ctx context.Context) *indexer.Ecosystem {
 			}, nil
 		},
 		RepositoryScanners: func(ctx context.Context) ([]indexer.RepositoryScanner, error) {
-			return []indexer.RepositoryScanner{&RepositoryScanner{}}, nil
+			return []indexer.RepositoryScanner{NewRepositoryScanner(ctx, nil, "")}, nil
 		},
 		Coalescer: func(ctx context.Context) (indexer.Coalescer, error) {
 			return NewCoalescer(), nil

--- a/rhel/matcher.go
+++ b/rhel/matcher.go
@@ -2,55 +2,18 @@ package rhel
 
 import (
 	"context"
-	"net/http"
-	"os"
 
 	version "github.com/knqyf263/go-rpm-version"
-	"github.com/rs/zerolog"
 
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/libvuln/driver"
-	"github.com/quay/claircore/rhel/repo2cpe"
 )
-
-// DefaultRepo2CPEMappingURL is default URL with a mapping file provided by Red Hat
-const DefaultRepo2CPEMappingURL = "https://www.redhat.com/security/data/metrics/repository-to-cpe.json"
 
 // Matcher implements driver.Matcher.
 type Matcher struct {
-	mapping *repo2cpe.RepoCPEMapping
 }
 
 var _ driver.Matcher = (*Matcher)(nil)
-
-// TODO: we need to plumb a context thru here
-func NewMatcher(ctx context.Context, client *http.Client) *Matcher {
-	log := zerolog.Ctx(ctx).With().
-		Str("component", "rhel/matcher/NewMatcher").
-		Logger()
-
-	mappingURL := os.Getenv("REPO_TO_CPE_URL")
-	if mappingURL == "" {
-		mappingURL = DefaultRepo2CPEMappingURL
-	}
-	if client == nil {
-		client = http.DefaultClient
-	}
-
-	// launch local updater
-	log.Info().Msg("launching local updater job")
-	localUpdater := repo2cpe.NewLocalUpdaterJob(mappingURL, client)
-
-	// blocks until the first update try as an attempt to have a
-	// mapping file present before constructor returns.
-	localUpdater.Start(ctx)
-
-	return &Matcher{
-		&repo2cpe.RepoCPEMapping{
-			RepoCPEUpdater: localUpdater,
-		},
-	}
-}
 
 // Name implements driver.Matcher.
 func (*Matcher) Name() string {
@@ -66,6 +29,7 @@ func (*Matcher) Filter(record *claircore.IndexRecord) bool {
 func (*Matcher) Query() []driver.MatchConstraint {
 	return []driver.MatchConstraint{
 		driver.PackageModule,
+		driver.RepositoryName,
 	}
 }
 
@@ -75,32 +39,12 @@ func (m *Matcher) Vulnerable(ctx context.Context, record *claircore.IndexRecord,
 	// Assume the vulnerability record we have is for the last known vulnerable
 	// version, so greater versions aren't vulnerable.
 	cmp := func(i int) bool { return i != version.GREATER }
-	// But if it's explicitly marked as a fixed-in version, it't only vulnerable
+	// But if it's explicitly marked as a fixed-in version, it's only vulnerable
 	// if less than that version.
 	if vuln.FixedInVersion != "" {
 		vulnVer = version.NewVersion(vuln.FixedInVersion)
 		cmp = func(i int) bool { return i == version.LESS }
 	}
 	// compare version and architecture
-	match := cmp(pkgVer.Compare(vulnVer)) && vuln.ArchOperation.Cmp(record.Package.Arch, vuln.Package.Arch)
-	if !match {
-		return false, nil
-	}
-
-	// translate content-sets into CPEs and check whether given vulnerability has same CPE
-	repoCPEs, err := m.mapping.RepositoryToCPE(ctx, []string{record.Repository.Name})
-	if err != nil {
-		return false, err
-	}
-	_, found := find(repoCPEs, vuln.Repo.Name)
-	return found, nil
-}
-
-func find(slice []string, val string) (int, bool) {
-	for i, item := range slice {
-		if item == val {
-			return i, true
-		}
-	}
-	return -1, false
+	return cmp(pkgVer.Compare(vulnVer)) && vuln.ArchOperation.Cmp(record.Package.Arch, vuln.Package.Arch), nil
 }

--- a/rhel/parser.go
+++ b/rhel/parser.go
@@ -48,7 +48,11 @@ func (u *Updater) Parse(ctx context.Context, r io.ReadCloser) ([]*claircore.Vuln
 				Links:              ovalutil.Links(def),
 				Severity:           def.Advisory.Severity,
 				NormalizedSeverity: NormalizeSeverity(def.Advisory.Severity),
-				Repo:               &claircore.Repository{Name: affected, CPE: wfn},
+				Repo: &claircore.Repository{
+					Name: affected,
+					CPE:  wfn,
+					Key:  RedHatRepositoryKey,
+				},
 				// each updater is configured to parse a rhel release
 				// specific xml database. we'll use the updater's release
 				// to map the parsed vulnerabilities

--- a/rhel/repositoryscanner_test.go
+++ b/rhel/repositoryscanner_test.go
@@ -12,7 +12,9 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/quay/claircore"
+	"github.com/quay/claircore/pkg/cpe"
 	"github.com/quay/claircore/rhel/containerapi"
+	"github.com/quay/claircore/rhel/repo2cpe"
 	"github.com/quay/claircore/test/log"
 )
 
@@ -25,9 +27,9 @@ func TestRepositoryScanner(t *testing.T) {
 	apiData := map[string]*containerapi.ContainerImages{
 		"rh-pkg-1-1": &containerapi.ContainerImages{Images: []containerapi.ContainerImage{
 			{
-				ContentSets: []string{
-					"rhel-8-for-x86_64-baseos-rpms",
-					"rhel-8-for-x86_64-appstream-rpms",
+				CPEs: []string{
+					"cpe:/o:redhat:enterprise_linux:8::computenode",
+					"cpe:/o:redhat:enterprise_linux:8::baseos",
 				},
 				ParsedData: containerapi.ParsedData{
 					Architecture: "x86_64",
@@ -38,8 +40,22 @@ func TestRepositoryScanner(t *testing.T) {
 			},
 		}},
 	}
+	mappingData := repo2cpe.MappingFile{Data: map[string]repo2cpe.Repo{
+		"content-set-1": repo2cpe.Repo{
+			CPEs: []string{"cpe:/o:redhat:enterprise_linux:6::server", "cpe:/o:redhat:enterprise_linux:7::server"},
+		},
+		"content-set-2": repo2cpe.Repo{
+			CPEs: []string{"cpe:/o:redhat:enterprise_linux:7::server", "cpe:/o:redhat:enterprise_linux:8::server"},
+		},
+	}}
 
 	mux := http.NewServeMux()
+	mux.HandleFunc("/repository-2-cpe.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("last-modified", "Mon, 02 Jan 2006 15:04:05 MST")
+		if err := json.NewEncoder(w).Encode(mappingData); err != nil {
+			t.Fatal(err)
+		}
+	})
 	mux.HandleFunc("/v1/images/nvr/", func(w http.ResponseWriter, r *http.Request) {
 		path := path.Base(r.URL.Path)
 		if err := json.NewEncoder(w).Encode(apiData[path]); err != nil {
@@ -59,12 +75,14 @@ func TestRepositoryScanner(t *testing.T) {
 			name: "FromAPI",
 			want: []*claircore.Repository{
 				&claircore.Repository{
-					Name: "rhel-8-for-x86_64-baseos-rpms",
+					Name: "cpe:/o:redhat:enterprise_linux:8::computenode",
 					Key:  RedHatRepositoryKey,
+					CPE:  cpe.MustUnbind("cpe:/o:redhat:enterprise_linux:8::computenode"),
 				},
 				&claircore.Repository{
-					Name: "rhel-8-for-x86_64-appstream-rpms",
+					Name: "cpe:/o:redhat:enterprise_linux:8::baseos",
 					Key:  RedHatRepositoryKey,
+					CPE:  cpe.MustUnbind("cpe:/o:redhat:enterprise_linux:8::baseos"),
 				},
 			},
 			cfg:       &RepoScannerConfig{API: srv.URL},
@@ -74,26 +92,34 @@ func TestRepositoryScanner(t *testing.T) {
 			name: "From mapping file",
 			want: []*claircore.Repository{
 				&claircore.Repository{
-					Name: "content-set-1",
+					Name: "cpe:/o:redhat:enterprise_linux:6::server",
 					Key:  RedHatRepositoryKey,
+					CPE:  cpe.MustUnbind("cpe:/o:redhat:enterprise_linux:6::server"),
 				},
 				&claircore.Repository{
-					Name: "content-set-2",
+					Name: "cpe:/o:redhat:enterprise_linux:7::server",
 					Key:  RedHatRepositoryKey,
+					CPE:  cpe.MustUnbind("cpe:/o:redhat:enterprise_linux:7::server"),
+				},
+				&claircore.Repository{
+					Name: "cpe:/o:redhat:enterprise_linux:8::server",
+					Key:  RedHatRepositoryKey,
+					CPE:  cpe.MustUnbind("cpe:/o:redhat:enterprise_linux:8::server"),
 				},
 			},
-			cfg:       &RepoScannerConfig{API: srv.URL},
+			cfg:       &RepoScannerConfig{API: srv.URL, Repo2CPEMappingURL: srv.URL + "/repository-2-cpe.json"},
 			layerPath: "testdata/layer-with-embedded-cs.tar",
 		},
 		{
 			name:      "No-cpe-info",
 			want:      nil,
+			cfg:       &RepoScannerConfig{},
 			layerPath: "testdata/layer-with-no-cpe-info.tar",
 		},
 	}
 	for _, tt := range table {
 		t.Run(tt.name, func(t *testing.T) {
-			scanner := &RepositoryScanner{}
+			scanner := NewRepositoryScanner(ctx, nil, tt.cfg.Repo2CPEMappingURL)
 			l := &claircore.Layer{}
 			l.SetLocal(tt.layerPath)
 


### PR DESCRIPTION
The previous implementation of CPE mapping in the matcher has a lot of corner cases. So we decided to put a mapping code into indexer instead. Mapping is fetched in the background in regular intervals and it is used during repo scan.

This pull request also contains several changes that fixed rhel matching.
