### PR TITLE
Add package_kind to vulnerability query

### DIFF
--- a/internal/vulnstore/postgres/querybuilder.go
+++ b/internal/vulnstore/postgres/querybuilder.go
@@ -24,13 +24,21 @@ func buildGetQuery(record *claircore.IndexRecord, opts *vulnstore.GetOpts) (stri
 	if record.Package.Name == "" {
 		return "", fmt.Errorf("IndexRecord must provide a Package.Name")
 	}
-	exps = append(exps, goqu.Ex{"package_name": record.Package.Name})
+	packageQuery := goqu.And(
+		goqu.Ex{"package_name": record.Package.Name},
+		goqu.Ex{"package_kind": record.Package.Kind},
+	)
+	exps = append(exps, packageQuery)
 
 	// If the package has a source, convert the first expression to an OR.
 	if record.Package.Source.Name != "" {
-		or := goqu.Or(
-			goqu.Ex{"package_name": record.Package.Name},
+		sourcePackageQuery := goqu.And(
 			goqu.Ex{"package_name": record.Package.Source.Name},
+			goqu.Ex{"package_kind": record.Package.Source.Kind},
+		)
+		or := goqu.Or(
+			packageQuery,
+			sourcePackageQuery,
 		)
 		exps[0] = or
 	}

--- a/internal/vulnstore/postgres/querybuilder_test.go
+++ b/internal/vulnstore/postgres/querybuilder_test.go
@@ -23,9 +23,8 @@ func Test_GetQueryBuilder_Deterministic_Args(t *testing.T) {
 		"repo_uri", "fixed_in_version", "updater"
 		FROM "vuln"
 		WHERE `
-		both       = `((("package_name" = 'package-0') OR ("package_name" = 'source-package-0')) AND `
-		noSource   = `(("package_name" = 'package-0') AND `
-		onlySource = `((("package_name" = 'package-0') OR ("package_name" = 'source-package-0')) AND `
+		both     = `(((("package_name" = 'package-0') AND ("package_kind" = 'binary')) OR (("package_name" = 'source-package-0') AND ("package_kind" = 'source'))) AND `
+		noSource = `((("package_name" = 'package-0') AND  ("package_kind" = 'binary')) AND `
 	)
 	var table = []struct {
 		// name of test


### PR DESCRIPTION
By adding package kind to database vulnerability query we query only
real affected packages. Without this code Clair produce false negatives
in case source package and binary package has same name.

When vulnerability is issued with source package all binary package that
have come from same source are marked as vulnerable.