### PR TITLE
Implement oval parsing for debian and ubuntu

### DIFF
--- a/debian/parser.go
+++ b/debian/parser.go
@@ -1,0 +1,46 @@
+package debian
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"io"
+
+	"github.com/quay/claircore"
+	"github.com/quay/claircore/pkg/ovalutil"
+	"github.com/quay/goval-parser/oval"
+	"github.com/rs/zerolog"
+)
+
+func (u *Updater) Parse(ctx context.Context, r io.ReadCloser) ([]*claircore.Vulnerability, error) {
+	log := zerolog.Ctx(ctx).With().
+		Str("component", "debian/Updater.Parse").
+		Logger()
+	ctx = log.WithContext(ctx)
+	log.Info().Msg("starting parse")
+	defer r.Close()
+	root := oval.Root{}
+	if err := xml.NewDecoder(r).Decode(&root); err != nil {
+		return nil, fmt.Errorf("debian: unable to decode OVAL document: %w", err)
+	}
+	log.Debug().Msg("xml decoded")
+	protoVulns := func(def oval.Definition) ([]*claircore.Vulnerability, error) {
+		vs := []*claircore.Vulnerability{}
+		v := &claircore.Vulnerability{
+			Updater:            u.Name(),
+			Name:               def.Title,
+			Description:        def.Description,
+			Issued:             def.Advisory.Issued.Date,
+			Links:              ovalutil.Links(def),
+			NormalizedSeverity: claircore.Unknown,
+			Dist:               releaseToDist(u.release),
+		}
+		vs = append(vs, v)
+		return vs, nil
+	}
+	vulns, err := ovalutil.DpkgDefsToVulns(ctx, &root, protoVulns)
+	if err != nil {
+		return nil, err
+	}
+	return vulns, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -18,12 +18,13 @@ require (
 	github.com/knqyf263/go-rpm-version v0.0.0-20170716094938-74609b86c936
 	github.com/lib/pq v1.3.0
 	github.com/quay/alas v1.0.1
-	github.com/quay/goval-parser v0.8.1
+	github.com/quay/goval-parser v0.8.2
 	github.com/remind101/migrate v0.0.0-20170729031349-52c1edff7319
 	github.com/rs/zerolog v1.15.0
 	github.com/stretchr/testify v1.5.1
 	github.com/tadasv/go-dpkg v0.0.0-20160704224136-c2cf9188b763
-	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
-	golang.org/x/tools v0.0.0-20191205215504-7b8c8591a921
+	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
+	golang.org/x/tools v0.0.0-20200811032001-fd80f4dbb3ea
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20191010095647-fc94e3f71652
 )

--- a/go.sum
+++ b/go.sum
@@ -330,8 +330,8 @@ github.com/prometheus/procfs v0.0.0-20180125133057-cb4147076ac7/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.5/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/quay/alas v1.0.1 h1:MuFpGGXyZlDD7+F/hrnMZmzhS8P2bjRzX9DyGmyLA+0=
 github.com/quay/alas v1.0.1/go.mod h1:pseepSrG9pwry1joG7RO/RNRFJaWqiqx9qeoomeYwEk=
-github.com/quay/goval-parser v0.8.1 h1:n5z8gtWHKEADljlnC6ySDZ+U+3cjAwYgVv9sMmIcGDM=
-github.com/quay/goval-parser v0.8.1/go.mod h1:Y0NTNfPYOC7yxsYKzJOrscTWUPq1+QbtHw4XpPXWPMc=
+github.com/quay/goval-parser v0.8.2 h1:6lZVroZhBw6okKBHvxS5a+/B2Q/b3cuKaSmRpz//9WA=
+github.com/quay/goval-parser v0.8.2/go.mod h1:Y0NTNfPYOC7yxsYKzJOrscTWUPq1+QbtHw4XpPXWPMc=
 github.com/remind101/migrate v0.0.0-20170729031349-52c1edff7319 h1:ukjThsA2ou7AmovpwtMVkNQSuoN/v5U16+JomTz3c7o=
 github.com/remind101/migrate v0.0.0-20170729031349-52c1edff7319/go.mod h1:rhSvwcijY9wfmrBYrfCvapX8/xOTV46NAUjBRgUyJqc=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
@@ -389,6 +389,7 @@ github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v0.0.0-20180618132009-1d523034197f/go.mod h1:5yf86TLmAcydyeJq5YvxkGPE2fm/u4myDekKRoLuqhs=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
+github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
@@ -409,6 +410,7 @@ golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7 h1:0hQKqeLdqlt5iIwVOBErRisrHJAN57yOiPRQItI20fU=
 golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975 h1:/Tl7pH94bvbAAHBdZJT947M/+gp0+CqQXDtMRC0fseo=
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -425,6 +427,8 @@ golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRuDixDT3tpyyb+LUpUlRWLxfhWrs=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
+golang.org/x/mod v0.3.0 h1:RM4zey1++hCTbCVQfnWeKs9/IEsaBLA8vTkd0WVtmH4=
+golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -448,6 +452,7 @@ golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200421231249-e086a090c8fd/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
+golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -459,6 +464,8 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a h1:WXEvlFVvvGxCJLG6REjsT03iWnKLEWinaScsxF2Vm2o=
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 h1:qwRHBd0NqMbJxfbotnDhm2ByMI1Shq4Y6oRJo21SGJA=
+golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -517,15 +524,21 @@ golang.org/x/tools v0.0.0-20190924052046-3ac2a5bbd98a h1:DJzZ1GRmbjp7ihxzAN6UTVp
 golang.org/x/tools v0.0.0-20190924052046-3ac2a5bbd98a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191205215504-7b8c8591a921 h1:a2kzKBu/PCzjVEtbXNEyM2K81W1PKoHxyNdm0lUiBiw=
 golang.org/x/tools v0.0.0-20191205215504-7b8c8591a921/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20200811032001-fd80f4dbb3ea h1:9ym67RBRK/wN50W0T3g8g1n8viM1D2ofgWufDlMfWe0=
+golang.org/x/tools v0.0.0-20200811032001-fd80f4dbb3ea/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gonum.org/v1/gonum v0.0.0-20190331200053-3d26580ed485/go.mod h1:2ltnJ7xHfj0zHS40VVPYEAAMTa3ZGguvHGBSJeRWqE0=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
 gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e/go.mod h1:kS+toOQn6AQKjmKJ7gzohV1XkqsFehRA2FbsbkopSuQ=

--- a/oracle/parser.go
+++ b/oracle/parser.go
@@ -71,7 +71,7 @@ func (u *Updater) Parse(ctx context.Context, r io.ReadCloser) ([]*claircore.Vuln
 		}
 		return vs, nil
 	}
-	vulns, err := ovalutil.RPMDefsToVulns(ctx, root, protoVulns)
+	vulns, err := ovalutil.RPMDefsToVulns(ctx, &root, protoVulns)
 	if err != nil {
 		return nil, err
 	}

--- a/photon/parser.go
+++ b/photon/parser.go
@@ -44,7 +44,7 @@ func (u *Updater) Parse(ctx context.Context, r io.ReadCloser) ([]*claircore.Vuln
 				Dist: releaseToDist(u.release),
 			}}, nil
 	}
-	vulns, err := ovalutil.RPMDefsToVulns(ctx, root, protoVulns)
+	vulns, err := ovalutil.RPMDefsToVulns(ctx, &root, protoVulns)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ovalutil/dpkg.go
+++ b/pkg/ovalutil/dpkg.go
@@ -1,0 +1,136 @@
+package ovalutil
+
+import (
+	"context"
+
+	"github.com/quay/goval-parser/oval"
+	"github.com/rs/zerolog"
+
+	"github.com/quay/claircore"
+)
+
+// DpkgDefsToVulns iterates over the definitions in an oval root and assumes DpkgInfo objects and states.
+//
+// Each Criterion encountered with an EVR string will be translated into a claircore.Vulnerability
+func DpkgDefsToVulns(ctx context.Context, root *oval.Root, protoVulns ProtoVulnsFunc) ([]*claircore.Vulnerability, error) {
+	log := zerolog.Ctx(ctx).With().
+		Str("component", "ovalutil/DpkgDefsToVulns").
+		Logger()
+	ctx = log.WithContext(ctx)
+	vulns := make([]*claircore.Vulnerability, 0, 10000)
+	pkgcache := map[string]*claircore.Package{}
+	cris := []*oval.Criterion{}
+	for _, def := range root.Definitions.Definitions {
+		// create our prototype vulnerability
+		protoVulns, err := protoVulns(def)
+		if err != nil {
+			log.Debug().
+				Err(err).
+				Str("def_id", def.ID).
+				Msg("could not create prototype vulnerabilities")
+			continue
+		}
+		// recursively collect criterions for this definition
+		cris := cris[:0]
+		walkCriterion(ctx, &def.Criteria, &cris)
+		// unpack criterions into vulnerabilities
+		for _, criterion := range cris {
+			// lookup test
+			_, index, err := root.Tests.Lookup(criterion.TestRef)
+			if err != nil {
+				log.Debug().Str("test_ref", criterion.TestRef).Msg("test ref lookup failure. moving to next criterion")
+				continue
+			}
+			test := root.Tests.DpkgInfoTests[index]
+			if len(test.ObjectRefs) == 1 && len(test.StateRefs) == 0 {
+				// We always take an object reference to imply the existence of
+				// that object, so just skip tests with a single object reference
+				// and no associated state object.
+				continue
+			}
+			if len(test.ObjectRefs) != len(test.StateRefs) {
+				log.Debug().Str("test_ref", criterion.TestRef).Msg("object refs and state refs are not in pairs. moving to next criterion")
+				continue
+			}
+			// look at each object,state pair the test references
+			// and create a vuln if an evr tag is found
+			for i := 0; i < len(test.ObjectRefs); i++ {
+				objRef := test.ObjectRefs[i].ObjectRef
+				stateRef := test.StateRefs[i].StateRef
+				_, objIndex, err := root.Objects.Lookup(objRef)
+				if err != nil {
+					log.Error().Err(err).Str("object_ref", objRef).Msg("failed object lookup. moving to next object,state pair")
+					continue
+				}
+				_, stateIndex, err := root.States.Lookup(stateRef)
+				if err != nil {
+					log.Debug().Str("state_ref", stateRef).Msg("failed state lookup. moving to next object,state pair")
+					continue
+				}
+				object := root.Objects.DpkgInfoObjects[objIndex]
+				state := root.States.DpkgInfoStates[stateIndex]
+				// if EVR tag not present this is not a linux package
+				// see oval definitions for more details
+				if state.EVR == nil {
+					continue
+				}
+
+				for _, protoVuln := range protoVulns {
+					vuln := *protoVuln
+					vuln.FixedInVersion = state.EVR.Body
+					name := object.Name
+
+					// if the dpkginfo_object>name field has a var_ref it indicates
+					// a variable lookup for all packages affected by this vuln is necessary.
+					//
+					// if the name.Ref field is empty it indicates a single package is affected
+					// by the vuln and that package's name is in name.Body.
+					if len(name.Ref) > 0 {
+						_, i, err := root.Variables.Lookup(name.Ref)
+						if err != nil {
+							log.Error().Err(err).Msg("could not lookup variable id")
+							continue
+						}
+						consts := root.Variables.ConstantVariables[i]
+						for _, v := range consts.Values {
+							if pkg, ok := pkgcache[v.Body]; !ok {
+								p := &claircore.Package{
+									Name: v.Body,
+									Kind: claircore.BINARY,
+								}
+								pkgcache[v.Body] = p
+								vuln.Package = p
+							} else {
+								vuln.Package = pkg
+							}
+							if state.Arch != nil {
+								vuln.ArchOperation = mapArchOp(state.Arch.Operation)
+								vuln.Package.Arch = state.Arch.Body
+							}
+						}
+						vulns = append(vulns, &vuln)
+						// early continue
+						continue
+					}
+
+					if pkg, ok := pkgcache[name.Body]; !ok {
+						p := &claircore.Package{
+							Name: name.Body,
+							Kind: claircore.BINARY,
+						}
+						pkgcache[name.Body] = p
+						vuln.Package = p
+					} else {
+						vuln.Package = pkg
+					}
+					if state.Arch != nil {
+						vuln.ArchOperation = mapArchOp(state.Arch.Operation)
+						vuln.Package.Arch = state.Arch.Body
+					}
+					vulns = append(vulns, &vuln)
+				}
+			}
+		}
+	}
+	return vulns, nil
+}

--- a/pkg/ovalutil/rpm.go
+++ b/pkg/ovalutil/rpm.go
@@ -26,7 +26,7 @@ type ProtoVulnsFunc func(def oval.Definition) ([]*claircore.Vulnerability, error
 // RPMDefsToVulns iterates over the definitions in an oval root and assumes RPMInfo objects and states.
 //
 // Each Criterion encountered with an EVR string will be translated into a claircore.Vulnerability
-func RPMDefsToVulns(ctx context.Context, root oval.Root, protoVulns ProtoVulnsFunc) ([]*claircore.Vulnerability, error) {
+func RPMDefsToVulns(ctx context.Context, root *oval.Root, protoVulns ProtoVulnsFunc) ([]*claircore.Vulnerability, error) {
 	log := zerolog.Ctx(ctx).With().
 		Str("component", "ovalutil/RPMDefsToVulns").
 		Logger()
@@ -72,7 +72,7 @@ func RPMDefsToVulns(ctx context.Context, root oval.Root, protoVulns ProtoVulnsFu
 				continue
 			}
 			// look at each object,state pair the test references
-			// and create a vuln if an evr tag if found
+			// and create a vuln if an evr tag is found
 			for i := 0; i < len(test.ObjectRefs); i++ {
 				objRef := test.ObjectRefs[i].ObjectRef
 				stateRef := test.StateRefs[i].StateRef

--- a/rhel/parser.go
+++ b/rhel/parser.go
@@ -62,7 +62,7 @@ func (u *Updater) Parse(ctx context.Context, r io.ReadCloser) ([]*claircore.Vuln
 		}
 		return vs, nil
 	}
-	vulns, err := ovalutil.RPMDefsToVulns(ctx, root, protoVulns)
+	vulns, err := ovalutil.RPMDefsToVulns(ctx, &root, protoVulns)
 	if err != nil {
 		return nil, err
 	}

--- a/suse/parser.go
+++ b/suse/parser.go
@@ -43,7 +43,7 @@ func (u *Updater) Parse(ctx context.Context, r io.ReadCloser) ([]*claircore.Vuln
 				Dist: releaseToDist(u.release),
 			}}, nil
 	}
-	vulns, err := ovalutil.RPMDefsToVulns(ctx, root, protoVulns)
+	vulns, err := ovalutil.RPMDefsToVulns(ctx, &root, protoVulns)
 	if err != nil {
 		return nil, err
 	}

--- a/ubuntu/parser.go
+++ b/ubuntu/parser.go
@@ -1,0 +1,46 @@
+package ubuntu
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"io"
+
+	"github.com/quay/claircore"
+	"github.com/quay/claircore/pkg/ovalutil"
+	"github.com/quay/goval-parser/oval"
+	"github.com/rs/zerolog"
+)
+
+func (u *Updater) Parse(ctx context.Context, r io.ReadCloser) ([]*claircore.Vulnerability, error) {
+	log := zerolog.Ctx(ctx).With().
+		Str("component", "ubuntu/Updater.Parse").
+		Logger()
+	ctx = log.WithContext(ctx)
+	log.Info().Msg("starting parse")
+	defer r.Close()
+	root := oval.Root{}
+	if err := xml.NewDecoder(r).Decode(&root); err != nil {
+		return nil, fmt.Errorf("ubuntu: unable to decode OVAL document: %w", err)
+	}
+	log.Debug().Msg("xml decoded")
+	protoVulns := func(def oval.Definition) ([]*claircore.Vulnerability, error) {
+		vs := []*claircore.Vulnerability{}
+		v := &claircore.Vulnerability{
+			Updater:            u.Name(),
+			Name:               def.Title,
+			Description:        def.Description,
+			Issued:             def.Advisory.Issued.Date,
+			Links:              ovalutil.Links(def),
+			NormalizedSeverity: claircore.Unknown,
+			Dist:               releaseToDist(u.release),
+		}
+		vs = append(vs, v)
+		return vs, nil
+	}
+	vulns, err := ovalutil.DpkgDefsToVulns(ctx, &root, protoVulns)
+	if err != nil {
+		return nil, err
+	}
+	return vulns, nil
+}

--- a/ubuntu/updater.go
+++ b/ubuntu/updater.go
@@ -3,17 +3,14 @@ package ubuntu
 import (
 	"compress/bzip2"
 	"context"
-	"encoding/xml"
 	"fmt"
 	"io"
 	"net/http"
 
-	"github.com/quay/goval-parser/oval"
 	"github.com/rs/zerolog"
 
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/libvuln/driver"
-	"github.com/quay/claircore/pkg/ovalutil"
 	"github.com/quay/claircore/pkg/tmp"
 )
 
@@ -66,6 +63,10 @@ func NewUpdater(release Release) *Updater {
 		release: release,
 		c:       http.DefaultClient,
 	}
+}
+
+func (u *Updater) Name() string {
+	return fmt.Sprintf("ubuntu-%s-updater", u.release)
 }
 
 func (u *Updater) Fetch(ctx context.Context, fingerprint driver.Fingerprint) (io.ReadCloser, driver.Fingerprint, error) {
@@ -121,128 +122,4 @@ func (u *Updater) Fetch(ctx context.Context, fingerprint driver.Fingerprint) (io
 
 	log.Info().Msg("fetched latest oval database successfully")
 	return f, driver.Fingerprint(fp), err
-}
-
-func (u *Updater) Parse(ctx context.Context, contents io.ReadCloser) ([]*claircore.Vulnerability, error) {
-	log := zerolog.Ctx(ctx).With().
-		Str("component", "ubuntu/Updater.Parse").
-		Str("database", u.url).
-		Logger()
-	ctx = log.WithContext(ctx)
-	log.Info().Msg("parsing oval database")
-	defer contents.Close()
-
-	log.Debug().Msg("decoding xml database")
-	ovalRoot := oval.Root{}
-	err := xml.NewDecoder(contents).Decode(&ovalRoot)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode OVAL xml contents: %v", err)
-	}
-	log.Debug().
-		Int("count", len(ovalRoot.Definitions.Definitions)).
-		Msg("finished decoding xml database")
-
-	result := []*claircore.Vulnerability{}
-	for _, def := range ovalRoot.Definitions.Definitions {
-		// resets static curVuln values to empty strings
-		u.reset()
-
-		// not a vulnerability
-		if def.Class != "vulnerability" {
-			continue
-		}
-		// does not contain a CVE ID
-		if len(def.References) == 0 {
-			continue
-		}
-
-		// each ubuntu CVE contains multiple affected packages. we
-		// want to "flatten" these into unique claircore.Vulnerability data structs.
-		// lets store the data that remains static for each "flattened" or in other words "unpacked"
-		// vulnerability in the current CVE in u.curVuln. we can then copy this struct
-		// as we unpack the CVE definition and add the copy with the pkg and dist into to the result array
-		u.curVuln.Issued = def.Advisory.PublicDate.Date
-		u.curVuln.Name = def.References[0].RefID
-		u.curVuln.Description = def.Description
-		u.curVuln.Links = ovalutil.Links(def)
-		u.curVuln.Severity = def.Advisory.Severity
-		u.curVuln.NormalizedSeverity = NormalizeSeverity(def.Advisory.Severity)
-
-		// now that we have our curVuln setup, unpack each nested package
-		// into it's own claircore.Vulnerability struct
-		vulns := u.unpack(def.Criteria, []*claircore.Vulnerability{})
-		result = append(result, vulns...)
-	}
-	log.Info().
-		Int("count", len(result)).
-		Msg("parsed oval database")
-	return result, nil
-}
-
-func (u *Updater) reset() {
-	u.curVuln.Name = ""
-	u.curVuln.Description = ""
-	u.curVuln.Links = ""
-	u.curVuln.Severity = ""
-}
-
-// unpack walks the recursive criteria structure and finds all packages. we copy u.curVuln and add the
-// unpacked CVE to the result array
-func (u *Updater) unpack(cri oval.Criteria, vulns []*claircore.Vulnerability) []*claircore.Vulnerability {
-	for _, c := range cri.Criterions {
-		if c.Negate {
-			continue
-		}
-
-		if name, fixVersion, ok := parseNotFixedYet(c.Comment); ok {
-			vuln := u.classifyVuln(name, fixVersion)
-			vulns = append(vulns, vuln)
-		}
-		if name, fixVersion, ok := parseNotDecided(c.Comment); ok {
-			vuln := u.classifyVuln(name, fixVersion)
-			vulns = append(vulns, vuln)
-		}
-		if name, fixVersion, ok := parseFixed(c.Comment); ok {
-			vuln := u.classifyVuln(name, fixVersion)
-			vulns = append(vulns, vuln)
-		}
-
-		// nop for now
-		// <criterion test_ref="oval:com.ubuntu.xenial:tst:10" comment="The vulnerability of the 'brotli' package in xenial is not known (status: 'needs-triage'). It is pending evaluation." />
-		// <criterion test_ref="oval:com.ubuntu.bionic:tst:201211480000000" comment="apache2: while related to the CVE in some way, a decision has been made to ignore this issue (note: 'code-not-compiled')." />
-
-	}
-
-	if len(cri.Criterias) == 0 {
-		return vulns
-	}
-	// recurse
-	for _, c := range cri.Criterias {
-		vulns = u.unpack(c, vulns)
-	}
-
-	return vulns
-}
-
-// classifyVuln defines the vulnerability's package and distribution data and adds it to the result.
-// pay attention here in order to use the same fields as the dpkg package scanner uses when classifying packages
-// and distribution information.
-func (u *Updater) classifyVuln(name string, fixVersion string) *claircore.Vulnerability {
-	pkg := &claircore.Package{
-		Name: name,
-		Kind: claircore.BINARY,
-	}
-
-	// make a copy of u.curVuln. it has the fields representing the curent
-	// vulnerability being parsed populated.
-	vuln := u.curVuln
-	vuln.FixedInVersion = fixVersion
-	vuln.Package = pkg
-	vuln.Dist = releaseToDist(u.release)
-	vuln.Updater = u.Name()
-	return &vuln
-}
-
-func (u *Updater) Name() string {
-	return fmt.Sprintf("ubuntu-%s-updater", u.release)
 }


### PR DESCRIPTION
This PR implements correct OVAL parsing for debian and ubuntu moving
away from incorrect regex parsing of the oval data.

goval-parser is bumped to obtain the necessary datastructures.

Signed-off-by: ldelossa <ldelossa@redhat.com>