### PR TITLE
updater: do not float error

### DIFF
--- a/libvuln/libvuln.go
+++ b/libvuln/libvuln.go
@@ -66,7 +66,7 @@ func New(ctx context.Context, opts *Opts) (*Libvuln, error) {
 
 	// Run updaters synchronously, initially.
 	if err := l.RunUpdaters(ctx, setFuncs...); err != nil {
-		return nil, err
+		log.Error().Err(err).Msg("countered errors while initializing datastore")
 	}
 	if !opts.DisableBackgroundUpdates {
 		go l.loopUpdaters(ctx, opts.UpdateInterval, setFuncs...)


### PR DESCRIPTION
this commit stops an error returned by an updater from cascading to the
caller.

Signed-off-by: ldelossa <ldelossa@redhat.com>