### PR TITLE
coalescer: refactor of the linux coalescer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,11 +63,11 @@ local-dev-logs:
 .PHONY: claircore-db-up
 claircore-db-up:
 	$(docker-compose) up -d claircore-db
-	$(docker) exec -it claircore_claircore-db_1 bash -c 'while ! pg_isready; do echo "waiting for postgres"; sleep 2; done'
+	$(docker) exec -it claircore-db bash -c 'while ! pg_isready; do echo "waiting for postgres"; sleep 2; done'
 
 .PHONY: claircore-db-restart
 claircore-db-restart:
-	$(docker) kill claircore-db && $(docker) rm claircore_claircore-db_1
+	$(docker) kill claircore-db && $(docker) rm claircore-db
 	make claircore-db-up
 
 .PHONY: libindexhttp-restart

--- a/internal/indexer/linux/coalescer.go
+++ b/internal/indexer/linux/coalescer.go
@@ -2,24 +2,12 @@ package linux
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/internal/indexer"
 )
 
-// layerArifact aggregates the any artifacts found within a layer
-type layerArtifacts struct {
-	hash  claircore.Digest
-	pkgs  []*claircore.Package
-	dist  []*claircore.Distribution // each layer can only have a single distribution
-	repos []*claircore.Repository
-}
-
-// Coalescer takes individual layer artifacts and coalesces them to form the final image's
-// package results
-//
-// It is expected to run a coalescer per "ecosystem". For example it would make sense to coalesce results
-// for dpkg, os-release, and apt scanners
 type Coalescer struct {
 	// the IndexReport this Coalescer is working on
 	ir *claircore.IndexReport
@@ -38,138 +26,69 @@ func NewCoalescer() *Coalescer {
 	}
 }
 
-// Coalesce coalesces artifacts found in layers and creates a final IndexReport with
+// Coalesce coalesces artifacts found in layers and creates an IndexReport with
 // the final package details found in the image. This method blocks and when its finished
 // the c.ir field will hold the final IndexReport
-func (c *Coalescer) Coalesce(ctx context.Context, artifacts []*indexer.LayerArtifacts) (*claircore.IndexReport, error) {
-	if ctx.Err() != nil {
-		return nil, ctx.Err()
+func (c *Coalescer) Coalesce(ctx context.Context, layerArtifacts []*indexer.LayerArtifacts) (*claircore.IndexReport, error) {
+	distSearcher := NewDistSearcher(layerArtifacts)
+	packageSearcher := NewPackageSearcher(layerArtifacts)
+
+	// get all dists the seacher knows about
+	dists := distSearcher.Dists()
+	for _, dist := range dists {
+		c.ir.Distributions[dist.ID] = dist
 	}
 
-	for _, a := range artifacts {
-		for _, repo := range a.Repos {
-			c.ir.Repositories[repo.ID] = repo
-		}
-	}
-	// In our coalescing logic if a Distribution is found in layer (n) all packages found
-	// in layers 0-(n) will be associated with this layer. This is a heuristic.
-	// Let's do a search for the first Distribution we find and use a variable
-	// to keep reference of the current Distribution in scope
-	// As further Distributions are found we will inventory them and update our currDist pointer,
-	// thus tagging all subsequetly found packages with this Distribution.
-	// This is a requirement for handling dist upgrades where a layer may have it's operating system updated
-	var currDist *claircore.Distribution
-	for _, a := range artifacts {
-		if len(a.Dist) != 0 {
-			currDist = a.Dist[0]
-			c.ir.Distributions[currDist.ID] = currDist
-			break
-		}
-	}
-	// Next lets begin associating packages with their Environment. We must
-	// consider each package in a package database as a unique entity for
-	// the edge case where a unique package is located in more then one package database.
-	// we'll use a struct as a helper and a map to lookup these structs
-	type packageDatabase struct {
-		packages     map[string]*claircore.Package
-		environments map[string]*claircore.Environment
-	}
-	var dbs = map[string]*packageDatabase{}
-	// lets walk each layer forward looking for packages, new distributions, and
-	// creating the environments we discover packages in.
-	for _, layerArtifacts := range artifacts {
-		// check if we need to update our currDist
-		if len(layerArtifacts.Dist) != 0 {
-			currDist = layerArtifacts.Dist[0]
-			c.ir.Distributions[currDist.ID] = currDist
-		}
-		// associate packages with their environments
-		if len(layerArtifacts.Pkgs) != 0 {
-			for _, pkg := range layerArtifacts.Pkgs {
-				// if we encounter a package where we haven't recorded a package database,
-				// initialize the package database
-				var distID string
-				if currDist != nil {
-					distID = currDist.ID
-				}
-				if _, ok := dbs[pkg.PackageDB]; !ok {
-					packages := map[string]*claircore.Package{}
-					environments := map[string]*claircore.Environment{}
-					dbs[pkg.PackageDB] = &packageDatabase{packages, environments}
-				}
-				if _, ok := dbs[pkg.PackageDB].packages[pkg.ID]; !ok {
-					environment := &claircore.Environment{
-						PackageDB:      pkg.PackageDB,
-						IntroducedIn:   layerArtifacts.Hash,
-						DistributionID: distID,
-					}
-					for _, repo := range layerArtifacts.Repos {
-						environment.RepositoryIDs = append(environment.RepositoryIDs, repo.ID)
-					}
-					dbs[pkg.PackageDB].packages[pkg.ID] = pkg
-					dbs[pkg.PackageDB].environments[pkg.ID] = environment
-				}
-			}
-		}
-	}
-	if ctx.Err() != nil {
-		return nil, ctx.Err()
-	}
-	// we now have all the packages associated with their introduced in layers and environments.
-	// we must now prune any packages removed between layers. this coalescer works on the assumption
-	// that any changes to a package's database (dpkg, rpm, alpine, etc...) causes the entire database
-	// file to be written to the layer in which the change occurs. this assumption therefore
-	// allows for the following algorithm
-	// 1) walk layers backwards searching for newest modification of package database.
-	// 2) if we encounter a package existing in a particular database it means all packages within this package database are present.
-	//    record all packages found into a temporary map.
-	//    when we are finished searching the current layer add a key/value to the penultimate map indicating
-	//    we no longer care about this set of package databases.
-	// 3) continue for all layers, always checking to see if we've already encountered a package database.
-	//    as we only want to inventory packages from the newest package database
-	// 4) once all layers are scanned begin removing package ids not present in our penultimate packagesToKeep map
-	var packagesToKeep = map[string][]string{}
-	for i := len(artifacts) - 1; i >= 0; i-- {
-		layerArtifacts := artifacts[i]
-		if len(layerArtifacts.Pkgs) == 0 {
+	// walk layers backwards, grouping packages by package databases the first time we see them.
+	// at the end of this loop we have searched all layers for the newest occurence of a
+	// package database.
+	dbs := make(map[string][]*claircore.Package)
+	for i := len(layerArtifacts) - 1; i >= 0; i-- {
+		artifacts := layerArtifacts[i]
+		if len(artifacts.Pkgs) == 0 {
 			continue
 		}
-		// used as a temporary accumulator of package ids in this layer
-		var tmpPackagesToKeep = map[string][]string{}
-		for _, pkg := range layerArtifacts.Pkgs {
-			// have we already inventoried packages from this database ?
-			if _, ok := packagesToKeep[pkg.PackageDB]; !ok {
-				// ... we haven't so add to our temporary accumulator
-				tk := tmpPackagesToKeep[pkg.PackageDB]
-				tmpPackagesToKeep[pkg.PackageDB] = append(tk, pkg.ID)
+
+		tmp := make(map[string][]*claircore.Package)
+		for _, pkg := range artifacts.Pkgs {
+			if _, ok := dbs[pkg.PackageDB]; !ok {
+				tmp[pkg.PackageDB] = append(tmp[pkg.PackageDB], pkg)
 			}
 		}
-		for k, v := range tmpPackagesToKeep {
-			// finished inventorying the layer, add our inventoried packages to our
-			// penultimate map ensuring next iteration will ignore packages from these databases
-			packagesToKeep[k] = v
+		for db, pkgs := range tmp {
+			dbs[db] = pkgs
 		}
 	}
-	// now let's prune any packages not found in the newest version of the package databases
-	// we just inventoried
-	for name, db := range dbs {
-		for _, pkg := range db.packages {
-			if _, ok := packagesToKeep[name]; !ok {
-				delete(db.packages, pkg.ID)
-				delete(db.environments, pkg.ID)
+
+	for db, packages := range dbs {
+		for _, pkg := range packages {
+			// create our environment
+			env := &claircore.Environment{}
+
+			// get the digest and index of the layer this pkg was introduced in.
+			introDigest, introIndex, err := packageSearcher.Search(pkg)
+			if err != nil {
+				return nil, fmt.Errorf("search for package introduction info failed: %v", err)
 			}
-		}
-	}
-	// finally lets pack our results into an IndexReport
-	for _, db := range dbs {
-		for _, pkg := range db.packages {
+
+			// get the distribution associated with ths layer index
+			dist, err := distSearcher.Search(introIndex)
+			if err != nil {
+				return nil, fmt.Errorf("search for distribution to tag package failed: %v", err)
+			}
+
+			// pack env
+			if dist != nil {
+				env.DistributionID = dist.ID
+			}
+			env.IntroducedIn = *introDigest
+			env.PackageDB = db
+
+			// pack ir
 			c.ir.Packages[pkg.ID] = pkg
-			if _, ok := c.ir.Environments[pkg.ID]; !ok {
-				c.ir.Environments[pkg.ID] = []*claircore.Environment{db.environments[pkg.ID]}
-				continue
-			}
-			c.ir.Environments[pkg.ID] = append(c.ir.Environments[pkg.ID], db.environments[pkg.ID])
+			c.ir.Environments[pkg.ID] = append(c.ir.Environments[pkg.ID], env)
 		}
 	}
+
 	return c.ir, nil
 }

--- a/internal/indexer/linux/coalescer_test.go
+++ b/internal/indexer/linux/coalescer_test.go
@@ -11,10 +11,6 @@ import (
 	"github.com/quay/claircore/test/log"
 )
 
-// Test_Coalescer tests the private method coalesce on the linux.Coalescer.
-// it's simpler to test the core business logic of a linux.Coalescer after
-// database access would have occured. Thus we do not use a black box test
-// and instead test private methods.
 func Test_Coalescer(t *testing.T) {
 	ctx := context.Background()
 	ctx, done := log.TestLogger(ctx, t)

--- a/internal/indexer/linux/distsearcher.go
+++ b/internal/indexer/linux/distsearcher.go
@@ -1,0 +1,65 @@
+package linux
+
+import (
+	"fmt"
+
+	"github.com/quay/claircore"
+	"github.com/quay/claircore/internal/indexer"
+)
+
+// DistSearcher uses ClairCore's heuristic to determine a distribution for
+// a given layer.
+//
+// The searcher will first see if distribution information exists for the queried layer.
+// Next the searcher will look backwards in the layer history for distribution information.
+// Finally the searcher will look forward in the layer history as a final effort to find distribution info.
+type DistSearcher struct {
+	dists []*claircore.Distribution
+}
+
+func NewDistSearcher(artifacts []*indexer.LayerArtifacts) DistSearcher {
+	dists := make([]*claircore.Distribution, len(artifacts))
+
+	// record where dists show up in layers via slice
+	for i, artifact := range artifacts {
+		if len(artifact.Dist) > 0 {
+			dists[i] = artifact.Dist[0] // we dont support multiple dists found in a layer
+		}
+	}
+	return DistSearcher{dists}
+}
+
+func (ds DistSearcher) Search(n int) (*claircore.Distribution, error) {
+	if n >= len(ds.dists) || n < 0 {
+		return nil, fmt.Errorf("provided manifest contains %d layers. %d is out of bounds", len(ds.dists), n)
+	}
+
+	if found := ds.dists[n]; found != nil {
+		return found, nil
+	}
+
+	// first search backwards
+	for i := n - 1; i >= 0; i-- {
+		if ds.dists[i] != nil {
+			return ds.dists[i], nil
+		}
+	}
+
+	// now search forward
+	for i := n + 1; i < len(ds.dists); i++ {
+		if ds.dists[i] != nil {
+			return ds.dists[i], nil
+		}
+	}
+	return nil, nil
+}
+
+func (ds DistSearcher) Dists() []*claircore.Distribution {
+	out := make([]*claircore.Distribution, 0)
+	for _, dist := range ds.dists {
+		if dist != nil {
+			out = append(out, dist)
+		}
+	}
+	return out
+}

--- a/internal/indexer/linux/packagesearcher.go
+++ b/internal/indexer/linux/packagesearcher.go
@@ -1,0 +1,58 @@
+package linux
+
+import (
+	"github.com/quay/claircore"
+	"github.com/quay/claircore/internal/indexer"
+)
+
+// PackageSearcher tracks the layer's hash and index a package
+// was introduced in.
+type PackageSearcher struct {
+	m map[string]entry
+}
+
+// an entry mapped to a package's key.
+// tracks package hash and index pkg was introduced in.
+type entry struct {
+	digest *claircore.Digest
+	index  int
+}
+
+// creates a unique key in the package searcher's map
+func keyify(pkg *claircore.Package) string {
+	return pkg.Name + pkg.PackageDB + pkg.Version
+}
+
+// NewPackageSearcher contructs a PackageSearcher ready for its Search method
+// to be called
+func NewPackageSearcher(layerArtifacts []*indexer.LayerArtifacts) PackageSearcher {
+	m := make(map[string]entry, 0)
+	for i, artifacts := range layerArtifacts {
+		if len(artifacts.Pkgs) == 0 {
+			continue
+		}
+
+		for _, pkg := range artifacts.Pkgs {
+			key := keyify(pkg)
+			if _, ok := m[key]; !ok {
+				m[key] = entry{
+					&artifacts.Hash,
+					i,
+				}
+			}
+		}
+
+	}
+	return PackageSearcher{m}
+}
+
+// Search returns the layer hash and index a package was introduced in.
+func (pi *PackageSearcher) Search(pkg *claircore.Package) (*claircore.Digest, int, error) {
+	key := keyify(pkg)
+	entry, ok := pi.m[key]
+	if !ok {
+		return nil, 0, nil
+	}
+
+	return entry.digest, entry.index, nil
+}

--- a/internal/indexer/postgres/indexmanifest.go
+++ b/internal/indexer/postgres/indexmanifest.go
@@ -32,7 +32,7 @@ func indexManifest(ctx context.Context, pool *pgxpool.Pool, ir *claircore.IndexR
 
 	records := ir.IndexRecords()
 	if len(records) == 0 {
-		log.Warn().Msg("manifest being indexed has 0 scan records")
+		log.Warn().Msg("manifest being indexed has 0 index records")
 		return nil
 	}
 

--- a/libvuln/libvuln.go
+++ b/libvuln/libvuln.go
@@ -66,7 +66,7 @@ func New(ctx context.Context, opts *Opts) (*Libvuln, error) {
 
 	// Run updaters synchronously, initially.
 	if err := l.RunUpdaters(ctx, setFuncs...); err != nil {
-		return nil, err
+		log.Error().Err(err).Msg("encountered error while updating")
 	}
 	if !opts.DisableBackgroundUpdates {
 		go l.loopUpdaters(ctx, opts.UpdateInterval, setFuncs...)


### PR DESCRIPTION
This PR refactors the coalescer into a set of data structures working together. This as prompted by:

Jira:  PROJQUAY-995
Closes: #213

I am seeing analysis no longer includes older packages once upgraded. 

old-coalescer:
```
#### BEGINING REPORT FOR mitmproxy/mitmproxy:4.0.1 ####
mitmproxy:4.0.1 found musl    1.1.18-r2 CVE-2019-14697 (fixed: 1.1.18-r4)
mitmproxy:4.0.1 found expat   2.2.5-r0  CVE-2018-20843 (fixed: 2.2.7-r0)
mitmproxy:4.0.1 found expat   2.2.5-r0  CVE-2019-15903 (fixed: 2.2.7-r1)
mitmproxy:4.0.1 found openssl 1.0.2o-r0 CVE-2019-1563  (fixed: 1.0.2t-r0)
mitmproxy:4.0.1 found openssl 1.0.2o-r0 CVE-2019-1547  (fixed: 1.0.2t-r0)
mitmproxy:4.0.1 found openssl 1.0.2o-r0 CVE-2019-1559  (fixed: 1.0.2r-r0)
mitmproxy:4.0.1 found openssl 1.0.2o-r0 CVE-2018-0737  (fixed: 1.0.2o-r1)
mitmproxy:4.0.1 found openssl 1.0.2o-r0 CVE-2018-0732  (fixed: 1.0.2o-r1)
mitmproxy:4.0.1 found openssl 1.0.2o-r0 CVE-2018-5407  (fixed: 1.0.2q-r0)
mitmproxy:4.0.1 found openssl 1.0.2o-r0 CVE-2018-0734  (fixed: 1.0.2q-r0)
mitmproxy:4.0.1 found python3 3.6.3-r9  CVE-2018-1061  (fixed: 3.6.5-r0)
mitmproxy:4.0.1 found python3 3.6.3-r9  CVE-2018-1060  (fixed: 3.6.5-r0)
mitmproxy:4.0.1 found python3 3.6.3-r9  CVE-2019-9636  (fixed: 3.6.8-r0)
mitmproxy:4.0.1 found python3 3.6.3-r9  CVE-2018-20406 (fixed: 3.6.8-r0)
mitmproxy:4.0.1 found python3 3.6.3-r9  CVE-2018-14647 (fixed: 3.6.8-r0)
mitmproxy:4.0.1 found python3 3.6.3-r9  CVE-2019-16056 (fixed: 3.6.8-r1)
mitmproxy:4.0.1 found python3 3.6.3-r9  CVE-2019-16935 (fixed: 3.6.9-r1)
mitmproxy:4.0.1 found musl    1.1.18-r3 CVE-2019-14697 (fixed: 1.1.18-r4)
```

new coalescer
```
#### BEGINING REPORT FOR mitmproxy/mitmproxy:4.0.1 ####
mitmproxy:4.0.1 found expat   2.2.5-r0  CVE-2018-20843 (fixed: 2.2.7-r0)
mitmproxy:4.0.1 found expat   2.2.5-r0  CVE-2019-15903 (fixed: 2.2.7-r1)
mitmproxy:4.0.1 found openssl 1.0.2o-r0 CVE-2019-1559  (fixed: 1.0.2r-r0)
mitmproxy:4.0.1 found openssl 1.0.2o-r0 CVE-2018-5407  (fixed: 1.0.2q-r0)
mitmproxy:4.0.1 found openssl 1.0.2o-r0 CVE-2018-0734  (fixed: 1.0.2q-r0)
mitmproxy:4.0.1 found openssl 1.0.2o-r0 CVE-2019-1563  (fixed: 1.0.2t-r0)
mitmproxy:4.0.1 found openssl 1.0.2o-r0 CVE-2019-1547  (fixed: 1.0.2t-r0)
mitmproxy:4.0.1 found openssl 1.0.2o-r0 CVE-2018-0737  (fixed: 1.0.2o-r1)
mitmproxy:4.0.1 found openssl 1.0.2o-r0 CVE-2018-0732  (fixed: 1.0.2o-r1)
mitmproxy:4.0.1 found python3 3.6.3-r9  CVE-2019-16935 (fixed: 3.6.9-r1)
mitmproxy:4.0.1 found python3 3.6.3-r9  CVE-2018-1061  (fixed: 3.6.5-r0)
mitmproxy:4.0.1 found python3 3.6.3-r9  CVE-2018-1060  (fixed: 3.6.5-r0)
mitmproxy:4.0.1 found python3 3.6.3-r9  CVE-2019-9636  (fixed: 3.6.8-r0)
mitmproxy:4.0.1 found python3 3.6.3-r9  CVE-2018-20406 (fixed: 3.6.8-r0)
mitmproxy:4.0.1 found python3 3.6.3-r9  CVE-2018-14647 (fixed: 3.6.8-r0)
mitmproxy:4.0.1 found python3 3.6.3-r9  CVE-2019-16056 (fixed: 3.6.8-r1)
mitmproxy:4.0.1 found musl    1.1.18-r3 CVE-2019-14697 (fixed: 1.1.18-r4)
```

apk info
```
❯ docker run --rm -it mitmproxy/mitmproxy:4.0.1 /bin/sh
/ # apk info musl
WARNING: Ignoring APKINDEX.70c88391.tar.gz: No such file or directory
WARNING: Ignoring APKINDEX.5022a8a2.tar.gz: No such file or directory
musl-1.1.18-r3 description:
the musl c library (libc) implementation

musl-1.1.18-r3 webpage:
http://www.musl-libc.org/

musl-1.1.18-r3 installed size:
581632
```

Signed-off-by: ldelossa <ldelossa@redhat.com>