### PR TITLE
RHEL: Use last-modified to cache data

### DIFF
--- a/pkg/ovalutil/fetcher.go
+++ b/pkg/ovalutil/fetcher.go
@@ -167,7 +167,6 @@ func (f fingerprint) Set(h http.Header) {
 func (f *fingerprint) From(h http.Header) {
 	if tag := h.Get("etag"); tag != "" {
 		f.Etag = tag
-		return
 	}
 	f.Date = h.Get("last-modified")
 }

--- a/rhel/updaterset.go
+++ b/rhel/updaterset.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 
 	"github.com/rs/zerolog"
@@ -140,7 +139,7 @@ func (f *Factory) UpdaterSet(ctx context.Context) (driver.UpdaterSet, error) {
 	}
 
 	for _, e := range m {
-		name := strings.TrimSuffix(path.Base(e.Path), ".oval.xml.bz2")
+		name := strings.TrimSuffix(strings.Replace(e.Path, "/", "-", -1), ".oval.xml.bz2")
 		uri, err := f.url.Parse(e.Path)
 		if err != nil {
 			return s, err


### PR DESCRIPTION
Sometime E-tag doesn't work as expected so adding last-modified makes
sure we don't update same file multiple times if it hasn't changed.

Signed-off-by: Ales Raszka <araszka@redhat.com>