### PR TITLE
Makefile: handle SELinux permissions for volume in docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -38,7 +38,7 @@ services:
       LAYER_SCAN_CONCURRENCY: 10
       LOG_LEVEL: "debug"
     volumes:
-      - "./:/src/claircore/"
+      - "./:/src/claircore/:z"
     command:
       [ "bash", "-c", "cd /src/claircore/cmd/libindexhttp; go run -mod vendor ." ]
 
@@ -52,6 +52,6 @@ services:
       CONNECTION_STRING: "host=claircore-db port=5432 user=claircore dbname=claircore sslmode=disable"
       LOG_LEVEL: "debug"
     volumes:
-      - "./:/src/claircore/"
+      - "./:/src/claircore/:z"
     command:
       [ "bash", "-c", "cd /src/claircore/cmd/libvulnhttp; go run -mod vendor ." ]


### PR DESCRIPTION
When setting up local dev environment on SELinux-enabled system, `libindexhttp` and `libvulnhttp` containers exit with error code and "Permission denied" in log. This is because by default a repository cloned into your home does not have the SELinux type required by docker. This can be solved by adding `z` suffix to the volume mount. Docker then takes care about applying the proper SELinux type to the mounted volume. More info [here](https://prefetch.net/blog/2017/09/30/using-docker-volumes-on-selinux-enabled-servers/).

It seems that this does not negatively affect non-SELinux systems. Adam tested it on Arch Linux and no problems were encountered. However, if someone else can also verify on non-SELinux OS, it would be great.