### PR TITLE
vulnstore: limit diffs

### DIFF
--- a/internal/vulnstore/postgres/getupdateoperationdiff.go
+++ b/internal/vulnstore/postgres/getupdateoperationdiff.go
@@ -50,7 +50,8 @@ func getUpdateDiff(ctx context.Context, pool *pgxpool.Pool, prev, cur uuid.UUID)
 		vuln.id IN (
 			SELECT vuln AS id FROM uo_vuln JOIN lhs ON (uo_vuln.uo = lhs.id)
 			EXCEPT ALL
-			SELECT vuln AS id FROM uo_vuln JOIN rhs ON (uo_vuln.uo = rhs.id));`
+			SELECT vuln AS id FROM uo_vuln JOIN rhs ON (uo_vuln.uo = rhs.id))
+	LIMIT 500;`
 
 	if cur == uuid.Nil {
 		return nil, errors.New("nil uuid is invalid as \"current\" endpoint")


### PR DESCRIPTION
this commit puts a limit on the number of returned vulnerabilities when
diffing two update operations.

Signed-off-by: ldelossa <ldelossa@localhost.localdomain>