### PR TITLE
updaters: consolidate into manager

### DIFF
--- a/libvuln/jsonblob/jsonblob.go
+++ b/libvuln/jsonblob/jsonblob.go
@@ -1,0 +1,224 @@
+package jsonblob
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/quay/claircore"
+	"github.com/quay/claircore/libvuln/driver"
+)
+
+// New constructs an empty Store.
+func New() (*Store, error) {
+	s := Store{}
+	s.ops = make(map[string][]driver.UpdateOperation)
+	s.entry = make(map[uuid.UUID]*Entry)
+	return &s, nil
+}
+
+// A Store buffers update operations.
+type Store struct {
+	sync.RWMutex
+	entry  map[uuid.UUID]*Entry
+	ops    map[string][]driver.UpdateOperation
+	latest uuid.UUID
+}
+
+// Load reads in all the records serialized in the provided Reader.
+func Load(ctx context.Context, r io.Reader) (*Loader, error) {
+	l := Loader{
+		dec: json.NewDecoder(r),
+		cur: uuid.Nil,
+	}
+	return &l, nil
+}
+
+// Loader is an iterator struct that returns Entries.
+//
+// Users should call Next until it reports false, then check for errors via Err.
+type Loader struct {
+	err error
+	e   *Entry
+
+	dec  *json.Decoder
+	next *Entry
+	de   diskEntry
+	cur  uuid.UUID
+}
+
+// Next reports whether there's a Entry to be processed.
+func (l *Loader) Next() bool {
+	if l.err != nil {
+		return false
+	}
+
+	for l.err = l.dec.Decode(&l.de); l.err == nil; l.err = l.dec.Decode(&l.de) {
+		id := l.de.Ref
+		// If we just hit a new Entry, promote the current one.
+		if id != l.cur {
+			l.e = l.next
+			l.next = &Entry{}
+			l.next.Updater = l.de.Updater
+			l.next.Fingerprint = l.de.Fingerprint
+			l.next.Date = l.de.Date
+		}
+		l.next.Vuln = append(l.next.Vuln, l.de.Vuln)
+		l.de.Vuln = nil // Needed to ensure the Decoder allocates new backing memory.
+
+		// If this was an initial diskEntry, promote the ref.
+		if id != l.cur {
+			l.cur = id
+			// If we have an Entry ready, report that.
+			if l.e != nil {
+				return true
+			}
+		}
+	}
+	l.e = l.next
+	return true
+}
+
+// Entry returns the latest loaded Entry.
+func (l *Loader) Entry() *Entry {
+	return l.e
+}
+
+// Err is the latest encountered error.
+func (l *Loader) Err() error {
+	// Don't report EOF as an error.
+	if errors.Is(l.err, io.EOF) {
+		return nil
+	}
+	return l.err
+}
+
+// Store writes out the Store to the provided Writer. It's the inverse of Load.
+func (s *Store) Store(w io.Writer) error {
+	s.RLock()
+	defer s.RUnlock()
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	for id, e := range s.entry {
+		for _, v := range e.Vuln {
+			if err := enc.Encode(&diskEntry{
+				CommonEntry: e.CommonEntry,
+				Ref:         id,
+				Vuln:        v,
+			}); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// Entry is a record of all information needed to record a vulnerability at a
+// later date.
+type Entry struct {
+	CommonEntry
+	Vuln []*claircore.Vulnerability
+}
+
+// CommonEntry is an embedded type that's shared between the "normal" Entry type
+// and the on-disk json produced by a Store's Load method.
+type CommonEntry struct {
+	Updater     string
+	Fingerprint driver.Fingerprint
+	Date        time.Time
+}
+
+// DiskEntry is a single vulnerability. It's made from unpacking an Entry's
+// slice and adding a uuid for grouping back into an Entry upon read.
+type diskEntry struct {
+	CommonEntry
+	Ref  uuid.UUID
+	Vuln *claircore.Vulnerability
+}
+
+// Entries returns a map containing all the Entries stored by calls to
+// UpdateVulnerabilities.
+//
+// It is unsafe for modification because it does not return a copy of the map.
+func (s *Store) Entries() map[uuid.UUID]*Entry {
+	s.RLock()
+	defer s.RUnlock()
+	return s.entry
+}
+
+// UpdateVulnerabilities records all provided vulnerabilities.
+func (s *Store) UpdateVulnerabilities(_ context.Context, updater string, fingerprint driver.Fingerprint, vulns []*claircore.Vulnerability) (uuid.UUID, error) {
+	now := time.Now()
+	e := Entry{
+		Vuln: vulns,
+	}
+	e.Date = now
+	e.Updater = updater
+	e.Fingerprint = fingerprint
+	ref := uuid.New() // God help you if this wasn't unique.
+	s.Lock()
+	defer s.Unlock()
+	s.latest = ref
+	s.entry[ref] = &e
+	s.ops[updater] = append([]driver.UpdateOperation{{
+		Ref:         ref,
+		Date:        now,
+		Fingerprint: fingerprint,
+		Updater:     updater,
+	}}, s.ops[updater]...)
+	return ref, nil
+}
+
+// Copyops assumes all locks are taken care of.
+func (s *Store) copyops() map[string][]driver.UpdateOperation {
+	m := make(map[string][]driver.UpdateOperation, len(s.ops))
+	for k, v := range s.ops {
+		n := make([]driver.UpdateOperation, len(v))
+		copy(n, v)
+		m[k] = v
+	}
+	return m
+}
+
+// GetUpdateOperations returns a list of UpdateOperations in date descending
+// order for the given updaters.
+//
+// The returned map is keyed by Updater implementation's unique names.
+//
+// If no updaters are specified, all UpdateOperations are returned.
+func (s *Store) GetUpdateOperations(context.Context, ...string) (map[string][]driver.UpdateOperation, error) {
+	s.RLock()
+	defer s.RUnlock()
+	return s.copyops(), nil
+}
+
+// GetLatestUpdateRefs reports the latest update reference for every known
+// updater.
+func (s *Store) GetLatestUpdateRefs(context.Context) (map[string][]driver.UpdateOperation, error) {
+	s.RLock()
+	defer s.RUnlock()
+	return s.copyops(), nil
+}
+
+// GetLatestUpdateRef reports the latest update reference of any known
+// updater.
+func (s *Store) GetLatestUpdateRef(context.Context) (uuid.UUID, error) {
+	s.RLock()
+	defer s.RUnlock()
+	return s.latest, nil
+}
+
+// DeleteUpdateOperations is unimplemented.
+func (s *Store) DeleteUpdateOperations(context.Context, ...uuid.UUID) error {
+	return nil
+}
+
+// GetUpdateDiff is unimplemented.
+func (s *Store) GetUpdateDiff(ctx context.Context, prev, cur uuid.UUID) (*driver.UpdateDiff, error) {
+	return nil, nil
+}

--- a/libvuln/jsonblob/jsonblob_test.go
+++ b/libvuln/jsonblob/jsonblob_test.go
@@ -1,0 +1,73 @@
+package jsonblob
+
+import (
+	"context"
+	"io"
+	"io/ioutil"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/quay/claircore"
+	"github.com/quay/claircore/test"
+)
+
+func TestStore(t *testing.T) {
+	s, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	vs := test.GenUniqueVulnerabilities(10, "test")
+	ref, err := s.UpdateVulnerabilities(ctx, "test", "", vs)
+	if err != nil {
+		t.Error(err)
+	}
+	t.Logf("ref: %v", ref)
+
+	if err := s.Store(ioutil.Discard); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestRoundtrip(t *testing.T) {
+	ctx := context.Background()
+	a, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vs := test.GenUniqueVulnerabilities(10, "test")
+	ref, err := a.UpdateVulnerabilities(ctx, "test", "", vs)
+	if err != nil {
+		t.Error(err)
+	}
+	t.Logf("ref: %v", ref)
+
+	var got []*claircore.Vulnerability
+	r, w := io.Pipe()
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() error { defer w.Close(); return a.Store(w) })
+	eg.Go(func() error {
+		l, err := Load(ctx, r)
+		if err != nil {
+			return err
+		}
+		for l.Next() {
+			got = append(got, l.Entry().Vuln...)
+		}
+		if err := l.Err(); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err := eg.Wait(); err != nil {
+		t.Error(err)
+	}
+
+	if !cmp.Equal(got, vs) {
+		t.Error(cmp.Diff(got, vs))
+	}
+}

--- a/libvuln/updates/manager.go
+++ b/libvuln/updates/manager.go
@@ -1,0 +1,255 @@
+package updates
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"runtime"
+	"strings"
+	"time"
+
+	"golang.org/x/sync/semaphore"
+
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/quay/claircore/internal/vulnstore"
+	"github.com/quay/claircore/libvuln/driver"
+	"github.com/quay/claircore/pkg/distlock/postgres"
+	"github.com/quay/claircore/updater"
+	"github.com/rs/zerolog"
+)
+
+const (
+	DefaultInterval = time.Duration(30 * time.Minute)
+)
+
+var (
+	DefaultBatchSize = runtime.NumCPU()
+)
+
+type Configs map[string]driver.ConfigUnmarshaler
+
+// Manager oversees the configuration and invocation of vulstore updaters.
+//
+// The Manager may be used in a one-shot fashion, configured
+// to run background jobs, or both.
+type Manager struct {
+	// provides run-time updater construction.
+	factories map[string]driver.UpdaterSetFactory
+	// max in-flight updaters.
+	batchSize int
+	// update interval used once Manager.Start is invoked, otherwise
+	// this field is not used.
+	interval time.Duration
+	// configs provided to updaters once constructed.
+	configs Configs
+	// provided to construct distributed locks.
+	// TODO(louis): this will be replaced by newest distlock implementation.
+	pool   *pgxpool.Pool
+	client *http.Client
+	store  vulnstore.Updater
+}
+
+// NewManager will return a manager ready to have its Start or Run methods called.
+func NewManager(ctx context.Context, store vulnstore.Updater, pool *pgxpool.Pool, client *http.Client, opts ...ManagerOption) (*Manager, error) {
+	log := zerolog.Ctx(ctx).With().
+		Str("component", "libvuln/updates/NewManager").
+		Logger()
+	ctx = log.WithContext(ctx)
+
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	// the default Manager
+	m := &Manager{
+		store:     store,
+		pool:      pool,
+		factories: updater.Registered(),
+		batchSize: DefaultBatchSize,
+		interval:  DefaultInterval,
+		client:    client,
+	}
+
+	// these options can be ran order independent.
+	for _, opt := range opts {
+		opt(m)
+	}
+
+	err := updater.Configure(ctx, m.factories, m.configs, m.client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to configure updater set factory: %w", err)
+	}
+
+	return m, nil
+}
+
+// Start will run updaters at the given interval.
+//
+// Start is designed to be ran as a go routine.
+// Cancel the provided ctx to end the updater loop.
+func (m *Manager) Start(ctx context.Context) error {
+	log := zerolog.Ctx(ctx).With().
+		Str("component", "libvuln/updates/Manager.Start").
+		Logger()
+	ctx = log.WithContext(ctx)
+	if m.interval == 0 {
+		return fmt.Errorf("manager must be configured with an interval to start")
+	}
+	log.Info().Str("interval", m.interval.String()).Msg("starting background updates")
+
+	t := time.NewTicker(m.interval)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-t.C:
+			m.Run(ctx)
+		}
+	}
+}
+
+// Run constructs updaters from factories, configures them
+// and runs them in Manager.batchSize batches.
+//
+// Run is safe to call at anytime, regardless of whether
+// background updaters are running.
+func (m *Manager) Run(ctx context.Context) error {
+	log := zerolog.Ctx(ctx).With().
+		Str("component", "libvuln/updates/Manager.Run").
+		Logger()
+	ctx = log.WithContext(ctx)
+
+	updaters := []driver.Updater{}
+	// constructing updater sets may require network access,
+	// depending on the factory.
+	// if construction fails we will simply ignore those updater
+	// sets.
+	for _, factory := range m.factories {
+		set, err := factory.UpdaterSet(ctx)
+		if err != nil {
+			log.Error().Err(err).Msg("failed constructing factory, excluding from run")
+			continue
+		}
+		updaters = append(updaters, set.Updaters()...)
+	}
+
+	// reconfigure updaters
+	for _, u := range updaters {
+		f, fOK := u.(driver.Configurable)
+		cfg, cfgOK := m.configs[u.Name()]
+		if fOK && cfgOK {
+			if err := f.Configure(ctx, cfg, nil); err != nil {
+				log.Warn().Err(err).Str("updater", u.Name()).Msg("failed configuring updater, excluding from current run")
+				continue
+			}
+		}
+	}
+
+	log.Info().Int("total", len(updaters)).Int("batchSize", m.batchSize).Msg("running updaters")
+
+	sem := semaphore.NewWeighted(int64(m.batchSize))
+	errChan := make(chan error, len(updaters)+1) // +1 for a potential ctx error
+	for i := range updaters {
+
+		err := sem.Acquire(ctx, 1)
+		if err != nil {
+			log.Err(err).Msg("sem acquire failed, ending updater run.")
+			break
+		}
+
+		go func(u driver.Updater) {
+			defer sem.Release(1)
+
+			if err := ctx.Err(); err != nil {
+				return
+			}
+
+			if m.pool != nil {
+				lock := postgres.NewPool(m.pool, 0)
+				ok, err := lock.TryLock(ctx, u.Name())
+				if err != nil {
+					errChan <- err
+					return
+				}
+				if !ok {
+					log.Debug().Str("updater", u.Name()).Msg("another process running updater, excluding from run.")
+					return
+				}
+				defer lock.Unlock()
+			}
+
+			err = m.driveUpdater(ctx, u)
+			if err != nil {
+				errChan <- fmt.Errorf("%v: %w\n", u.Name(), err)
+			}
+		}(updaters[i])
+	}
+
+	// unconditionally wait for all in-flight go routines to return.
+	// the use of context.Background and lack of error checking is intentional.
+	// all in-flight go routines are gauranteed to release their sems.
+	sem.Acquire(context.Background(), int64(m.batchSize))
+
+	close(errChan)
+	if len(errChan) != 0 {
+		var b strings.Builder
+		b.WriteString("Updating errors:\n")
+		for err := range errChan {
+			fmt.Fprintf(&b, "%v\n", err)
+		}
+		return errors.New(b.String())
+	}
+	return nil
+}
+
+// driveUpdaters perform the business logic of fetching, parsing, and loading
+// vulnerabilities discovered by an updater into the database.
+func (m *Manager) driveUpdater(ctx context.Context, u driver.Updater) error {
+	name := u.Name()
+	log := zerolog.Ctx(ctx).With().
+		Str("component", "libvuln/updates/Manager.driveUpdater").
+		Str("updater", name).
+		Logger()
+	ctx = log.WithContext(ctx)
+
+	log.Info().Msg("starting update")
+
+	var prevFP driver.Fingerprint
+	opmap, err := m.store.GetUpdateOperations(ctx, name)
+	if err != nil {
+		return err
+	}
+
+	if s := opmap[name]; len(s) > 0 {
+		prevFP = s[0].Fingerprint
+	}
+
+	vulnDB, newFP, err := u.Fetch(ctx, prevFP)
+	if vulnDB != nil {
+		defer vulnDB.Close()
+	}
+	switch {
+	case err == nil:
+	case errors.Is(err, driver.Unchanged):
+		log.Info().Msg("vulnerability database unchanged")
+		return nil
+	default:
+		return err
+	}
+
+	vulns, err := u.Parse(ctx, vulnDB)
+	if err != nil {
+		return fmt.Errorf("database parse failed: %w", err)
+	}
+
+	_, err = m.store.UpdateVulnerabilities(ctx, name, newFP, vulns)
+	if err != nil {
+		return fmt.Errorf("vulnstore update failed: %w", err)
+	}
+
+	log.Info().Msg("finished update")
+	return nil
+}

--- a/libvuln/updates/options.go
+++ b/libvuln/updates/options.go
@@ -1,0 +1,73 @@
+package updates
+
+import (
+	"time"
+
+	"github.com/quay/claircore/libvuln/driver"
+)
+
+// ManagerOption specify optional configuration for a Manager.
+// Defaults will be used where options are not provided to the constructor.
+type ManagerOption func(m *Manager)
+
+// WithBatchSize sets the max number of parallel updaters that will run during an
+// update interval.
+func WithBatchSize(n int) ManagerOption {
+	return func(m *Manager) {
+		m.batchSize = n
+	}
+}
+
+// WithInterval configures the interval at which updaters will be ran.
+// The manager runs all configured updaters during an interval.
+// Setting this duration too low may cause missed update intervals.
+func WithInterval(interval time.Duration) ManagerOption {
+	return func(m *Manager) {
+		m.interval = interval
+	}
+}
+
+// WithEnabled configures the Manager to only run the specified
+// updaters.
+func WithEnabled(enabled []string) ManagerOption {
+	return func(m *Manager) {
+		for _, enable := range enabled {
+			for name := range m.factories {
+				if name == enable {
+					delete(m.factories, name)
+				}
+			}
+		}
+	}
+}
+
+// WithConfigs tells the Manager to configure each updater where
+// a configuration is provided.
+//
+// Configuration of individual updaters is delegated to updater/registry.go
+// Note: this option is optimal when ran after WithEnabled option. However,
+// this option has no strict depedency on others.
+func WithConfigs(cfgs Configs) ManagerOption {
+	return func(m *Manager) {
+		m.configs = cfgs
+	}
+}
+
+// WithOutOfTree allows callers to provide their own out-of-tree
+// updaters.
+//
+// note: currently we will never configure the outOfTree updater
+// factory. if this changes consider making this option a required
+// to avoid missing configuration
+func WithOutOfTree(outOfTree []driver.Updater) ManagerOption {
+	return func(m *Manager) {
+		us := driver.NewUpdaterSet()
+		for _, u := range outOfTree {
+			if err := us.Add(u); err != nil {
+				// duplicate updater, ignore.
+				continue
+			}
+		}
+		m.factories["outOfTree"] = driver.StaticSet(us)
+	}
+}


### PR DESCRIPTION
this commit consolidates updater filtering, getting defaults from the
registry, configuring factories, configuring updaters, and running
updaters in a loop into a single cohesive unit.

Signed-off-by: ldelossa <ldelossa@redhat.com>