### PR TITLE
updater: use pointer receiver for errmap methods

### DIFF
--- a/internal/updater/controller.go
+++ b/internal/updater/controller.go
@@ -33,19 +33,19 @@ type errmap struct {
 	m map[string]error
 }
 
-func (e errmap) add(name string, err error) {
+func (e *errmap) add(name string, err error) {
 	e.Lock()
 	defer e.Unlock()
 	e.m[name] = err
 }
 
-func (e errmap) len() int {
+func (e *errmap) len() int {
 	e.Lock()
 	defer e.Unlock()
 	return len(e.m)
 }
 
-func (e errmap) error() error {
+func (e *errmap) error() error {
 	e.Lock()
 	defer e.Unlock()
 	var b strings.Builder


### PR DESCRIPTION
This would result in a subtle bug where the Mutex would get copied, but
because the map builtin has an internal pointer, as long as the map
didn't re-allocate the updates would show up and as long as the writes
weren't concurrent, the map race detector wouldn't trip.

Signed-off-by: Hank Donnay <hdonnay@redhat.com>