### PR TITLE
Affected manifest: Update query and logic that determines afected manifests

### DIFF
--- a/internal/vulnstore/postgres/getupdateoperationdiff.go
+++ b/internal/vulnstore/postgres/getupdateoperationdiff.go
@@ -44,7 +44,8 @@ func getUpdateDiff(ctx context.Context, pool *pgxpool.Pool, prev, cur uuid.UUID)
 		arch_operation,
 		repo_name,
 		repo_key,
-		repo_uri
+		repo_uri,
+		fixed_in_version
 	FROM vuln
 	WHERE
 		vuln.id IN (

--- a/internal/vulnstore/postgres/scan_vulnerability.go
+++ b/internal/vulnstore/postgres/scan_vulnerability.go
@@ -38,6 +38,7 @@ func scanVulnerability(v *claircore.Vulnerability, row scanner) error {
 		&v.Repo.Name,
 		&v.Repo.Key,
 		&v.Repo.URI,
+		&v.FixedInVersion,
 	); err != nil {
 		return err
 	}

--- a/pkg/omnimatcher/omnimatcher.go
+++ b/pkg/omnimatcher/omnimatcher.go
@@ -46,6 +46,10 @@ func New(m []driver.Matcher) OmniMatcher {
 // Vulnerable will call each Matcher's Vulnerable method until one returns true.
 func (om OmniMatcher) Vulnerable(ctx context.Context, record *claircore.IndexRecord, vuln *claircore.Vulnerability) (bool, error) {
 	for _, m := range om {
+		applicable := m.Filter(record)
+		if !applicable {
+			continue
+		}
 		match, err := m.Vulnerable(ctx, record, vuln)
 		if err != nil {
 			return false, err


### PR DESCRIPTION
The pull request fixes 2 bugs in omnimatcher logic.

Add missing properties into affected manifest query
These properties were missing in queries that search for affected
manifest which caused incorrect API response.

-----
Use mather's Filter() in omnimatcher. 
The previous implementation used all matchers to find out whether
package is vulnerable. This approach didn't work because each matcher is
interested only in specific subset packages given by mather's filter.

This commit adds filer to omnimatcher to make sure only the right matchers
are used.