### PR TITLE
Oval: check lookup type

### DIFF
--- a/pkg/ovalutil/dpkg.go
+++ b/pkg/ovalutil/dpkg.go
@@ -36,9 +36,12 @@ func DpkgDefsToVulns(ctx context.Context, root *oval.Root, protoVulns ProtoVulns
 		// unpack criterions into vulnerabilities
 		for _, criterion := range cris {
 			// lookup test
-			_, index, err := root.Tests.Lookup(criterion.TestRef)
+			testKind, index, err := root.Tests.Lookup(criterion.TestRef)
 			if err != nil {
 				log.Debug().Str("test_ref", criterion.TestRef).Msg("test ref lookup failure. moving to next criterion")
+				continue
+			}
+			if testKind != "dpkginfo_test" {
 				continue
 			}
 			test := root.Tests.DpkgInfoTests[index]
@@ -57,14 +60,20 @@ func DpkgDefsToVulns(ctx context.Context, root *oval.Root, protoVulns ProtoVulns
 			for i := 0; i < len(test.ObjectRefs); i++ {
 				objRef := test.ObjectRefs[i].ObjectRef
 				stateRef := test.StateRefs[i].StateRef
-				_, objIndex, err := root.Objects.Lookup(objRef)
+				objKind, objIndex, err := root.Objects.Lookup(objRef)
 				if err != nil {
 					log.Error().Err(err).Str("object_ref", objRef).Msg("failed object lookup. moving to next object,state pair")
 					continue
 				}
-				_, stateIndex, err := root.States.Lookup(stateRef)
+				if objKind != "dpkginfo_object" {
+					continue
+				}
+				stateKind, stateIndex, err := root.States.Lookup(stateRef)
 				if err != nil {
 					log.Debug().Str("state_ref", stateRef).Msg("failed state lookup. moving to next object,state pair")
+					continue
+				}
+				if stateKind != "dpkginfo_state" {
 					continue
 				}
 				object := root.Objects.DpkgInfoObjects[objIndex]

--- a/rhel/parse_test.go
+++ b/rhel/parse_test.go
@@ -32,8 +32,8 @@ func TestParse(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Logf("found %d vulnerabilities", len(vs))
-	// 16 packages, 2 cpes = 32 vulnerabilities
-	if got, want := len(vs), 32; got != want {
+	// 15 packages, 2 cpes = 30 vulnerabilities
+	if got, want := len(vs), 30; got != want {
 		t.Fatalf("got: %d vulnerabilities, want: %d vulnerabilities", got, want)
 	}
 	count := make(map[string]int)
@@ -45,8 +45,8 @@ func TestParse(t *testing.T) {
 		base      = "cpe:/a:redhat:enterprise_linux:8"
 		appstream = "cpe:/a:redhat:enterprise_linux:8::appstream"
 	)
-	if count[base] != 16 || count[appstream] != 16 {
-		t.Fatalf("got: %v vulnerabilities with, want 16 of each", count)
+	if count[base] != 15 || count[appstream] != 15 {
+		t.Fatalf("got: %v vulnerabilities with, want 15 of each", count)
 	}
 }
 


### PR DESCRIPTION
Lookup() function returns a object based on reference ID in all
sub-structures. This can cause that object that is returned can have a
different type than module requires.

This commit add checks to rpm and dpkg module to Lookup only properties
specific to the module.

Signed-off-by: Ales Raszka <araszka@redhat.com>