### PR TITLE
updaters: do not kill loop on error

### DIFF
--- a/libvuln/libvuln.go
+++ b/libvuln/libvuln.go
@@ -131,7 +131,6 @@ func (l *Libvuln) loopUpdaters(ctx context.Context, p time.Duration, fs ...drive
 		case <-t.C:
 			if err := l.RunUpdaters(ctx, fs...); err != nil {
 				log.Error().Err(err).Msg("unable to run updaters")
-				return
 			}
 		}
 	}


### PR DESCRIPTION
this removes the case where a single updater error kills the long
running update loop

Signed-off-by: ldelossa <ldelossa@redhat.com>