### PR TITLE
etc: update podman yaml

### DIFF
--- a/etc/podman.yaml.in
+++ b/etc/podman.yaml.in
@@ -69,7 +69,7 @@ spec:
         - mountPath: /src/claircore:z
           name: reporoot
       workingDir: /src/claircore/cmd/libindexhttp
-    - command: ['postgres']
+    - name: claircore-db
       env:
         - name: POSTGRES_INITDB_ARGS
           value: --no-sync
@@ -82,7 +82,6 @@ spec:
         - name: POSTGRES_DB
           value: claircore
       image: docker.io/library/postgres:11
-      name: claircore-db
       restartPolicy: OnFailure
       ports:
         - containerPort: 5434


### PR DESCRIPTION
Previous versions of the postgres container were happy to have the sever
run as root, but the new entrypoint drops permissions. The generated
yaml enshrined not using the container's entrypoint. This commit undoes
that.

Signed-off-by: Hank Donnay <hdonnay@redhat.com>