### PR TITLE
indexer: database refactor

### DIFF
--- a/internal/indexer/postgres/affectedmanifest.go
+++ b/internal/indexer/postgres/affectedmanifest.go
@@ -37,8 +37,9 @@ func affectedManifests(ctx context.Context, pool *pgxpool.Pool, v claircore.Vuln
 		WHERE name = $1;
 		`
 		selectAffected = `
-		SELECT manifest_hash
+		SELECT manifest.hash
 		FROM manifest_index
+				 JOIN manifest ON manifest_index.manifest_hash = manifest.id
 		WHERE package_id = $1
 		  AND (
 			CASE

--- a/internal/indexer/postgres/distributionsbylayer.go
+++ b/internal/indexer/postgres/distributionsbylayer.go
@@ -33,7 +33,8 @@ func distributionsByLayer(ctx context.Context, db *sqlx.DB, hash claircore.Diges
 			   dist.pretty_name
 		FROM dist_scanartifact
 				 LEFT JOIN dist ON dist_scanartifact.dist_id = dist.id
-		WHERE dist_scanartifact.layer_hash = '%s'
+				 JOIN layer ON layer.hash = '%s'
+		WHERE dist_scanartifact.layer_hash = layer.id
 		  AND dist_scanartifact.scanner_id IN (?);
 		`
 	)

--- a/internal/indexer/postgres/indexmanifest.go
+++ b/internal/indexer/postgres/indexmanifest.go
@@ -16,8 +16,14 @@ import (
 func indexManifest(ctx context.Context, pool *pgxpool.Pool, ir *claircore.IndexReport) error {
 	const (
 		query = `
-		INSERT INTO manifest_index(package_id, dist_id, repo_id, manifest_hash)
-		VALUES ($1, $2, $3, $4)
+		WITH manifests AS (
+			SELECT id AS manifest_id
+			FROM manifest
+			WHERE hash = $4
+		)
+		INSERT
+		INTO manifest_index(package_id, dist_id, repo_id, manifest_hash)
+		VALUES ($1, $2, $3, (SELECT manifest_id FROM manifests))
 		ON CONFLICT DO NOTHING;
 		`
 	)

--- a/internal/indexer/postgres/indexpackage.go
+++ b/internal/indexer/postgres/indexpackage.go
@@ -39,7 +39,6 @@ func indexPackages(ctx context.Context, pool *pgxpool.Pool, pkgs []*claircore.Pa
 			  AND module = $4
 			  AND arch = $5
 		),
-
 			 binary_package AS (
 				 SELECT id AS package_id
 				 FROM package
@@ -49,18 +48,21 @@ func indexPackages(ctx context.Context, pool *pgxpool.Pool, pkgs []*claircore.Pa
 				   AND module = $9
 				   AND arch = $10
 			 ),
-
 			 scanner AS (
 				 SELECT id AS scanner_id
 				 FROM scanner
 				 WHERE name = $11
 				   AND version = $12
 				   AND kind = $13
+			 ),
+			 layer AS (
+				 SELECT id AS layer_id
+				 FROM layer
+				 WHERE layer.hash = $14
 			 )
-
 		INSERT
 		INTO package_scanartifact (layer_hash, package_db, repository_hint, package_id, source_id, scanner_id)
-		VALUES ($14,
+		VALUES ((SELECT layer_id FROM layer),
 				$15,
 				$16,
 				(SELECT package_id FROM binary_package),

--- a/internal/indexer/postgres/indexreport.go
+++ b/internal/indexer/postgres/indexreport.go
@@ -11,7 +11,12 @@ import (
 )
 
 const (
-	selectIndexReport = `SELECT scan_result FROM indexreport WHERE manifest_hash = $1`
+	selectIndexReport = `
+	SELECT scan_result
+	FROM indexreport
+			 JOIN manifest ON manifest.hash = $1
+	WHERE indexreport.manifest_hash = manifest.id;
+	`
 )
 
 func indexReport(ctx context.Context, db *sqlx.DB, hash claircore.Digest) (*claircore.IndexReport, bool, error) {

--- a/internal/indexer/postgres/indexrepository.go
+++ b/internal/indexer/postgres/indexrepository.go
@@ -30,17 +30,21 @@ func indexRepositories(ctx context.Context, db *sqlx.DB, pool *pgxpool.Pool, rep
 			  AND key = $2
 			  AND uri = $3
 		),
-
 			 scanner AS (
 				 SELECT id AS scanner_id
 				 FROM scanner
 				 WHERE name = $4
 				   AND version = $5
 				   AND kind = $6
+			 ),
+			 layer AS (
+				 SELECT id AS layer_id
+				 FROM layer
+				 WHERE layer.hash = $7
 			 )
 		INSERT
 		INTO repo_scanartifact (layer_hash, repo_id, scanner_id)
-		VALUES ($7,
+		VALUES ((SELECT layer_id FROM layer),
 				(SELECT repo_id FROM repositories),
 				(SELECT scanner_id FROM scanner))
 		ON CONFLICT DO NOTHING;

--- a/internal/indexer/postgres/layerscanned.go
+++ b/internal/indexer/postgres/layerscanned.go
@@ -13,18 +13,19 @@ import (
 func layerScanned(ctx context.Context, pool *pgxpool.Pool, hash claircore.Digest, scnr indexer.VersionedScanner) (bool, error) {
 	const (
 		selectScanner = `
-			SELECT id
-			FROM scanner
-			WHERE name = $1
-			  AND version = $2
-			  AND kind = $3;
-			`
+		SELECT id
+		FROM scanner
+		WHERE name = $1
+		  AND version = $2
+		  AND kind = $3;
+		`
 		selectScanned = `
-			SELECT layer_hash
-			FROM scanned_layer
-			WHERE layer_hash = $1
-			  AND scanner_id = $2
-			`
+		SELECT layer.hash
+		FROM layer
+                 JOIN scanned_layer ON scanned_layer.layer_hash = layer.id
+		WHERE layer.hash = $1
+		  AND scanned_layer.scanner_id = $2;
+		`
 	)
 
 	var scannerID int64

--- a/internal/indexer/postgres/manifestscanned.go
+++ b/internal/indexer/postgres/manifestscanned.go
@@ -21,7 +21,12 @@ func manifestScanned(ctx context.Context, db *sqlx.DB, hash claircore.Digest, sc
 		  AND version = $2
 		  AND kind = $3;
 		`
-		selectScanned = `SELECT scanner_id FROM scanned_manifest WHERE manifest_hash = $1;`
+		selectScanned = `
+		SELECT scanner_id
+		FROM scanned_manifest
+				 JOIN manifest ON scanned_manifest.manifest_hash = manifest.id
+		WHERE manifest.hash = $1;
+		`
 	)
 
 	// TODO Use passed-in Context.

--- a/internal/indexer/postgres/packagesbylayer.go
+++ b/internal/indexer/postgres/packagesbylayer.go
@@ -44,7 +44,8 @@ func packagesByLayer(ctx context.Context, db *sqlx.DB, hash claircore.Digest, sc
 		FROM package_scanartifact
 				 LEFT JOIN package ON package_scanartifact.package_id = package.id
 				 LEFT JOIN package source_package ON package_scanartifact.source_id = source_package.id
-		WHERE package_scanartifact.layer_hash = '%s'
+				 JOIN layer ON layer.hash = '%s'
+		WHERE package_scanartifact.layer_hash = layer.id
 		  AND package_scanartifact.scanner_id IN (?);
 		`
 	)

--- a/internal/indexer/postgres/persistmanifest.go
+++ b/internal/indexer/postgres/persistmanifest.go
@@ -21,8 +21,21 @@ func persistManifest(ctx context.Context, pool *pgxpool.Pool, manifest claircore
 		ON CONFLICT DO NOTHING;
 		`
 		insertManifestLayer = `
-		INSERT INTO manifest_layer (manifest_hash, layer_hash, i)
-		VALUES ($1, $2, $3)
+		WITH manifests AS (
+			SELECT id AS manifest_id
+			FROM manifest
+			WHERE hash = $1
+		),
+			 layers AS (
+				 SELECT id AS layer_id
+				 FROM layer
+				 WHERE hash = $2
+			 )
+		INSERT
+		INTO manifest_layer (manifest_hash, layer_hash, i)
+		VALUES ((SELECT manifest_id FROM manifests),
+				(SELECT layer_id FROM layers),
+				$3)
 		ON CONFLICT DO NOTHING;
 		`
 	)

--- a/internal/indexer/postgres/repositoriesbylayer.go
+++ b/internal/indexer/postgres/repositoriesbylayer.go
@@ -29,7 +29,8 @@ func repositoriesByLayer(ctx context.Context, db *sqlx.DB, hash claircore.Digest
 			   repo.cpe
 		FROM repo_scanartifact
 				 LEFT JOIN repo ON repo_scanartifact.repo_id = repo.id
-		WHERE repo_scanartifact.layer_hash = '%s'
+				 JOIN layer on layer.hash = '%s'
+		WHERE repo_scanartifact.layer_hash = layer.id
 		  AND repo_scanartifact.scanner_id IN (?);
 		`
 	)

--- a/internal/indexer/postgres/setindexreport.go
+++ b/internal/indexer/postgres/setindexreport.go
@@ -12,8 +12,15 @@ import (
 func setIndexReport(ctx context.Context, db *sqlx.DB, sr *claircore.IndexReport) error {
 	const (
 		upsertIndexReport = `
-		INSERT INTO indexreport (manifest_hash, scan_result)
-		VALUES ($1, $2)
+		WITH manifests AS (
+			SELECT id AS manifest_id
+			FROM manifest
+			WHERE hash = $1
+		)
+		INSERT
+		INTO indexreport (manifest_hash, scan_result)
+		VALUES ((select manifest_id from manifests),
+				$2)
 		ON CONFLICT (manifest_hash) DO UPDATE SET scan_result = excluded.scan_result
 		`
 	)

--- a/internal/indexer/postgres/setlayerscanned.go
+++ b/internal/indexer/postgres/setlayerscanned.go
@@ -20,8 +20,15 @@ func setLayerScanned(ctx context.Context, pool *pgxpool.Pool, hash claircore.Dig
 		  AND kind = $3;
 		`
 		query = `
-		INSERT INTO scanned_layer (layer_hash, scanner_id)
-		VALUES ($1, $2)
+		WITH layers AS (
+			SELECT id AS layer_id
+			FROM layer
+			WHERE hash = $1
+		)
+		INSERT
+		INTO scanned_layer (layer_hash, scanner_id)
+		VALUES ((SELECT layer_id FROM layers),
+				$2)
 		ON CONFLICT (layer_hash, scanner_id) DO NOTHING;
 		`
 	)

--- a/libindex/migrations/migration1.go
+++ b/libindex/migrations/migration1.go
@@ -6,21 +6,23 @@ const (
 	--- Layer
     --- an identity table consisting of a content addressable layer hash
     CREATE TABLE IF NOT EXISTS layer (
-        hash text PRIMARY KEY
+	    id bigserial PRIMARY KEY,
+        hash text UNIQUE
     );
 
     --- Manifest
     --- an identity table consisting of a content addressable manifest hash
     CREATE TABLE IF NOT EXISTS manifest (
-        hash text PRIMARY KEY
+	    id bigserial PRIMARY KEY,
+        hash text UNIQUE
     );
 
     --- ManifestLayer
     --- a many to many link table identifying the layers which comprise a manifest
     --- and the layer's ordering within a manifest
     CREATE TABLE IF NOT EXISTS manifest_layer (
-        manifest_hash text REFERENCES manifest(hash),
-        layer_hash text REFERENCES layer(hash),
+        manifest_hash bigint REFERENCES manifest(id),
+        layer_hash bigint REFERENCES layer(id),
         i bigint,
         PRIMARY KEY(manifest_hash, layer_hash, i)
     );
@@ -40,7 +42,7 @@ const (
     --- a relation to identify if a manifest was successfully scanned by a particular
     --- scanner
     CREATE TABLE IF NOT EXISTS scanned_manifest (
-        manifest_hash text REFERENCES manifest(hash),
+        manifest_hash bigint REFERENCES manifest(id),
         scanner_id bigint REFERENCES scanner(id),
         PRIMARY KEY(manifest_hash, scanner_id)
     );
@@ -48,7 +50,7 @@ const (
     --- ScannedLayer
     --- a relation to identify if a layer was successfully scanned by a particular scanner
     CREATE TABLE IF NOT EXISTS scanned_layer (
-        layer_hash text REFERENCES layer(hash),
+        layer_hash bigint REFERENCES layer(id),
         scanner_id bigint REFERENCES scanner(id),
         PRIMARY KEY(layer_hash, scanner_id)
     );
@@ -58,7 +60,7 @@ const (
 	--- been scanned by a particular scanner
 	CREATE TABLE IF NOT EXISTS scannerlist (
 		id BIGSERIAL PRIMARY KEY,
-		manifest_hash text,
+		manifest_hash bigint,
 		scanner_id bigint REFERENCES scanner(id)
 	);
 	CREATE INDEX IF NOT EXISTS scannerlist_manifest_hash_idx ON scannerlist (manifest_hash);
@@ -67,7 +69,7 @@ const (
 	--- the jsonb serialized result of a scan for a particular
 	--- manifest
 	CREATE TABLE IF NOT EXISTS indexreport (
-		manifest_hash text PRIMARY KEY REFERENCES manifest(hash),
+		manifest_hash bigint PRIMARY KEY REFERENCES manifest(id),
 		state text,
 		scan_result jsonb
 	);
@@ -92,7 +94,7 @@ const (
     CREATE TABLE IF NOT EXISTS dist_scanartifact (
           dist_id bigint REFERENCES dist(id),
           scanner_id bigint REFERENCES scanner(id),
-          layer_hash text REFERENCES layer(hash),
+          layer_hash bigint REFERENCES layer(id),
           PRIMARY KEY(dist_id, scanner_id, layer_hash)
     );
     CREATE INDEX IF NOT EXISTS dist_scanartifact_lookup_idx ON dist_scanartifact(layer_hash);
@@ -115,7 +117,7 @@ const (
     --- A relation linking discovered packages with the
     --- layer hash it was found
     CREATE TABLE IF NOT EXISTS package_scanartifact (
-           layer_hash text REFERENCES layer(hash),
+           layer_hash bigint REFERENCES layer(id),
            package_id bigint REFERENCES package(id),
            source_id bigint REFERENCES package(id),
            scanner_id bigint REFERENCES scanner(id),
@@ -141,7 +143,7 @@ const (
     CREATE TABLE IF NOT EXISTS repo_scanartifact (
         repo_id bigint REFERENCES repo(id),
         scanner_id bigint REFERENCES scanner(id),
-        layer_hash text REFERENCES layer(hash),
+        layer_hash bigint REFERENCES layer(id),
         PRIMARY KEY(repo_id, scanner_id, layer_hash)
     );
     CREATE INDEX IF NOT EXISTS repo_scanartifact_lookup_idx ON repo_scanartifact(layer_hash);
@@ -156,9 +158,9 @@ const (
         package_id    bigint NOT NULL REFERENCES package (id),
         dist_id       bigint REFERENCES dist (id),
         repo_id       bigint REFERENCES repo (id),
-        manifest_hash text REFERENCES manifest (hash)
+        manifest_hash bigint NOT NULL REFERENCES manifest (id)
     );
-    CREATE INDEX IF NOT EXISTS manifest_index_hash_lookup_idx ON manifest_index (manifest_hash);
+    CREATE INDEX IF NOT EXISTS manifest_index_hash_lookup_idx ON manifest_index (manifest_hash, package_id, dist_id, repo_id);
 	CREATE UNIQUE INDEX manifest_index_unique ON manifest_index (package_id, COALESCE(dist_id, 0), COALESCE(repo_id, 0), manifest_hash);
 	`
 )


### PR DESCRIPTION
this commit refactors the indexer's datamodel in an effort to store less
string data.

before this commit manifest and layer hashes were duplicated across many
tables. Now, all hashes are localized to their respective tables and
bigint ids are stored at each foreign key reference.

Signed-off-by: ldelossa <ldelossa@redhat.com>