### PR TITLE
updater: remove updater diff limit

### DIFF
--- a/internal/vulnstore/postgres/getupdateoperationdiff.go
+++ b/internal/vulnstore/postgres/getupdateoperationdiff.go
@@ -51,8 +51,7 @@ func getUpdateDiff(ctx context.Context, pool *pgxpool.Pool, prev, cur uuid.UUID)
 		vuln.id IN (
 			SELECT vuln AS id FROM uo_vuln JOIN lhs ON (uo_vuln.uo = lhs.id)
 			EXCEPT ALL
-			SELECT vuln AS id FROM uo_vuln JOIN rhs ON (uo_vuln.uo = rhs.id))
-	LIMIT 500;`
+			SELECT vuln AS id FROM uo_vuln JOIN rhs ON (uo_vuln.uo = rhs.id));`
 
 	if cur == uuid.Nil {
 		return nil, errors.New("nil uuid is invalid as \"current\" endpoint")


### PR DESCRIPTION
The limit can be removed because it is no longer needed and not having a
limit didn't cause issues as we thought at a beginning.

Signed-off-by: Ales Raszka <araszka@redhat.com>