### PR TITLE
cicd: github actions set-env fix

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -7,7 +7,7 @@ on:
       branch:
         description: 'the branch to prepare the release against'
         required: true
-        deault: 'master'
+        default: 'master'
       tag:
         description: 'the tag to be released'
         required: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,7 @@ jobs:
       - name: Setup
         run: |
           tag=`basename ${{ github.ref }}`
-          cat <<.
-          ::set-env name=TAG::${tag}
-          .
+          echo "VERSION=${tag}" >> $GITHUB_ENV
       - name: Checkout
         uses: actions/checkout@v2
         with:
@@ -36,9 +34,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: ${{env.TAG}} Release
+          release_name: ${{env.VERSION}} Release
           body_path: ${{github.workspace}}/changelog
-          prerelease: ${{ contains(env.TAG, 'alpha') || contains(env.TAG, 'beta') || contains(env.TAG, 'rc') }}
+          prerelease: ${{ contains(env.VERSION, 'alpha') || contains(env.VERSION, 'beta') || contains(env.VERSION, 'rc') }}
 
   deploy-documentation:
     runs-on: ubuntu-latest


### PR DESCRIPTION
commit removes deprecated set-env from github actions

Signed-off-by: ldelossa <ldelossa@redhat.com>