### PR TITLE
cicd: use CI golang image from quay.io

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
   tidy:
     name: Tidy
     runs-on: ubuntu-latest
-    container: docker.io/library/golang:latest
+    container: quay.io/app-sre/golang:latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -48,7 +48,7 @@ jobs:
   tests:
     name: Tests
     runs-on: ubuntu-latest
-    container: docker.io/library/golang:${{ matrix.go }}-buster
+    container: quay.io/app-sre/golang:${{ matrix.go }}-buster
     env:
       POSTGRES_CONNECTION_STRING: "host=claircore-db port=5432 user=claircore dbname=claircore sslmode=disable"
     services:


### PR DESCRIPTION
Get CI images from quay.io instead of DockerHub. This is related to https://github.com/quay/clair/pull/1138.