### PR TITLE
Add exception for rhel-7-alt OVAL stream

### DIFF
--- a/rhel/updaterset.go
+++ b/rhel/updaterset.go
@@ -150,6 +150,14 @@ func (f *Factory) UpdaterSet(ctx context.Context) (driver.UpdaterSet, error) {
 		case strings.Contains(p, "RHEL8"):
 			r = RHEL8
 		case strings.Contains(p, "RHEL7"):
+			// We need to disregard this OVAL stream because some advisories therein have
+			// been released with the CPEs identical to those used in classic RHEL stream.
+			// This in turn causes false CVEs to appear in scanned images. Red Hat Product
+			// Security is working on fixing this situation and the plan is to remove this
+			// exception in the future.
+			if name == "RHEL7-rhel-7-alt" {
+				continue
+			}
 			r = RHEL7
 		case strings.Contains(p, "RHEL6"):
 			r = RHEL6


### PR DESCRIPTION
See the comment above the exception for explanation of this PR.

There was also an alternate approach: Creating 
```go
var ignoredStreams = []string{
   "RHEL7-rhel-7-alt",
}
```
and then checking for each image whether it is ignored or not. Even though this would be better from maintainability point of view, I decided to go for this simple approach. It's mainly because:

- This will save a lot of iterations
- With high probability there'll be no other ignored stream