### PR TITLE
Revert "cicd: use CI golang image from quay.io"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
   tidy:
     name: Tidy
     runs-on: ubuntu-latest
-    container: quay.io/app-sre/golang:latest
+    container: docker.io/library/golang:latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -48,7 +48,7 @@ jobs:
   tests:
     name: Tests
     runs-on: ubuntu-latest
-    container: quay.io/app-sre/golang:${{ matrix.go }}-buster
+    container: docker.io/library/golang:${{ matrix.go }}-buster
     env:
       POSTGRES_CONNECTION_STRING: "host=claircore-db port=5432 user=claircore dbname=claircore sslmode=disable"
     services:


### PR DESCRIPTION
Unfortunately it seems we need to go back to DockerHub image as app-sre image has become private. 

This reverts commit 97fa28bcb92a7b0db1b15cfb6cc45bd678d3f268.

Signed-off-by: Jan Zmeskal <jzmeskal@redhat.com>