### PR TITLE
libvulnhttp: add DisableBackgroundUpdates config option

### DIFF
--- a/cmd/libvulnhttp/main.go
+++ b/cmd/libvulnhttp/main.go
@@ -19,12 +19,13 @@ import (
 // Config this struct is using the goconfig library for simple flag and env var
 // parsing. See: https://github.com/crgimenes/goconfig
 type Config struct {
-	HTTPListenAddr string `cfgDefault:"0.0.0.0:8081" cfg:"HTTP_LISTEN_ADDR"`
-	MaxConnPool    int    `cfgDefault:"100" cfg:"MAX_CONN_POOL" cfgHelper:"the maximum size of the connection pool used for database connections"`
-	ConnString     string `cfgDefault:"host=localhost port=5434 user=claircore dbname=claircore sslmode=disable" cfg:"CONNECTION_STRING" cfgHelper:"Connection string for the provided DataStore"`
-	Run            string `cfg:"RUN" cfgDefault:"." cfgHelper:"Regexp of updaters to run."`
-	LogLevel       string `cfgDefault:"debug" cfg:"LOG_LEVEL" cfgHelper:"Log levels: debug, info, warning, error, fatal, panic" `
-	Migrations     bool   `cfgDefault:"true" cfg:"MIGRATIONS" cfgHelper:"Should server run migrations"`
+	HTTPListenAddr           string `cfgDefault:"0.0.0.0:8081" cfg:"HTTP_LISTEN_ADDR"`
+	MaxConnPool              int    `cfgDefault:"100" cfg:"MAX_CONN_POOL" cfgHelper:"the maximum size of the connection pool used for database connections"`
+	ConnString               string `cfgDefault:"host=localhost port=5434 user=claircore dbname=claircore sslmode=disable" cfg:"CONNECTION_STRING" cfgHelper:"Connection string for the provided DataStore"`
+	Run                      string `cfg:"RUN" cfgDefault:"." cfgHelper:"Regexp of updaters to run."`
+	LogLevel                 string `cfgDefault:"debug" cfg:"LOG_LEVEL" cfgHelper:"Log levels: debug, info, warning, error, fatal, panic" `
+	Migrations               bool   `cfgDefault:"true" cfg:"MIGRATIONS" cfgHelper:"Should server run migrations"`
+	DisableBackgroundUpdates bool   `cfgDefault:"false" cfg:"DISABLE_BACKGROUND_UPDATES" cfgHelper:"Should matcher regularly update vulnerability database"`
 }
 
 func main() {
@@ -88,10 +89,11 @@ func logLevel(conf Config) zerolog.Level {
 
 func confToLibvulnOpts(conf Config) *libvuln.Opts {
 	opts := &libvuln.Opts{
-		ConnString:  conf.ConnString,
-		MaxConnPool: int32(conf.MaxConnPool),
-		Migrations:  true,
-		UpdaterSets: nil,
+		ConnString:               conf.ConnString,
+		MaxConnPool:              int32(conf.MaxConnPool),
+		Migrations:               true,
+		UpdaterSets:              nil,
+		DisableBackgroundUpdates: conf.DisableBackgroundUpdates,
 	}
 	re, err := regexp.Compile(conf.Run)
 	if err == nil {


### PR DESCRIPTION
This option is useful when you develop `libvuln` library, want to keep it running but don't want regular updates to get in your way.

Signed-off-by: Jan Zmeskal <jzmeskal@redhat.com>