### PR TITLE
cicd: use quay.io/claircore/golang in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
   tidy:
     name: Tidy
     runs-on: ubuntu-latest
-    container: docker.io/library/golang:latest
+    container: quay.io/claircore/golang:1.15
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -48,7 +48,7 @@ jobs:
   tests:
     name: Tests
     runs-on: ubuntu-latest
-    container: docker.io/library/golang:${{ matrix.go }}-buster
+    container: quay.io/claircore/golang:${{ matrix.go }}
     env:
       POSTGRES_CONNECTION_STRING: "host=claircore-db port=5432 user=claircore dbname=claircore sslmode=disable"
     services:
@@ -69,8 +69,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: OS Dependencies
-        run: apt-get update && apt-get install -y tar make gcc
       - name: Go Dependencies
         run: go mod vendor
       - name: Tests

--- a/etc/Dockerfile
+++ b/etc/Dockerfile
@@ -3,6 +3,7 @@ FROM registry.access.redhat.com/ubi8/ubi:8.1 AS install
 RUN dnf install -q -y \
 	gcc \
 	make \
+	git \
 	&&\
 	dnf clean all
 ARG GO_VERSION


### PR DESCRIPTION
This is my latest attempt to remove dependency on DockerHub golang image. Here's the basic idea behind this:
- I noticed that there's already existing quay.io/claircore/golang image
- That image is already used by docker-compose files both in this repo and in quay/clair
- In this repo, we have a very easy-to-use make target to build that image
Given all of this, I though to myself: Why not just use this image at other places beyond docker-compose as well?

Here's what I did to make it work:
- I added `git` package to the Dockerfile we use to build the quay image. As far as I can tell, that was the only thing missing there
- I rebuild and pushed all the tags we require (1.13, 1.14, 1.15, 1.15.2)
- I changed container in 'tidy' job to quay.io/claircore/golang:1.15. We used to point at `latest` tag, but I don't think that's really necessary. We could of course have `latest` tag in quay as well, but that seems like unnecessary maintenance
- I changed the container in `tests` job. We used to rely on Debian-based container, but I don't really see any benefit in that. On the contrary, with the switch to UBI-based image, there's no need for installation of additional OS dependencies
- I created https://github.com/quay/clair/pull/1147 to accompany this