### PR TITLE
indexer: filter scanners during manifest check

### DIFF
--- a/internal/indexer/controller/checkmanifest.go
+++ b/internal/indexer/controller/checkmanifest.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/quay/claircore/internal/indexer"
 	"github.com/rs/zerolog"
 )
 
@@ -12,6 +13,7 @@ func checkManifest(ctx context.Context, s *Controller) (State, error) {
 		Str("state", s.getState().String()).
 		Logger()
 	ctx = log.WithContext(ctx)
+
 	// determine if we've seen this manifest and if we've
 	// scanned it with the desired scanners
 	ok, err := s.Store.ManifestScanned(ctx, s.manifest.Hash, s.Vscnrs)
@@ -19,10 +21,26 @@ func checkManifest(ctx context.Context, s *Controller) (State, error) {
 		return Terminal, err
 	}
 
-	// if we haven't seen this manifest transition persist it
+	// if we haven't seen this manifest, determine which scanners to use, persist it
 	// and transition to FetchLayer state.
 	if !ok {
-		log.Info().Msg("manifest to be scanned... persisting manifest.")
+		log.Info().Msg("manifest to be scanned...")
+
+		// if a manifest was analyzed by a particular scanner we can
+		// omit it from this index, as all its comprising layers were analyzed
+		// by the particular scanner as well.
+		filtered := make(indexer.VersionedScanners, 0, len(s.Vscnrs))
+		for i := range s.Vscnrs {
+			ok, err := s.Store.ManifestScanned(ctx, s.manifest.Hash, s.Vscnrs[i:i+1]) // slice this to avoid allocations
+			if err != nil {
+				return Terminal, err
+			}
+			if !ok {
+				filtered = append(filtered, s.Vscnrs[i])
+			}
+		}
+		s.Vscnrs = filtered
+
 		err := s.Store.PersistManifest(ctx, *s.manifest)
 		if err != nil {
 			return Terminal, fmt.Errorf("failed to persist manifest: %v", err)

--- a/internal/indexer/postgres/manifestscanned.go
+++ b/internal/indexer/postgres/manifestscanned.go
@@ -42,7 +42,7 @@ func manifestScanned(ctx context.Context, db *sqlx.DB, hash claircore.Digest, sc
 		expectedIDs = append(expectedIDs, id)
 	}
 
-	// get a map of the found ids which have scanned this package
+	// get a map of the found ids which have scanned this manifest
 	var temp = []int64{}
 	var foundIDs = map[int64]struct{}{}
 	err := db.Select(&temp, selectScanned, hash)


### PR DESCRIPTION
This commit adds a filtering step in the CheckManifest state.
Now, if a manifest reports being analyzed by a particular scanner that
scanner will be omitted from all subsequent states.

This is safe to do, if a manifest was analyzed by a particular scanner,
this also means all it's layers were analyzed by the particular scanner.
Thus, the scanner need not be included in the rest of the indexing
process.

This fixes a unique constraint issue in the IndexFinished state.
Previous to this commit, an attempt to persist duplicate scanner ids was
made in the aforementioned state.

Signed-off-by: ldelossa <ldelossa@redhat.com>