### PR TITLE
postgres: fix update_operation response

### DIFF
--- a/internal/indexer/controller/controller.go
+++ b/internal/indexer/controller/controller.go
@@ -11,7 +11,7 @@ import (
 )
 
 // StartState is a global variable which is normally set to the starting state
-// of the controller. this global maybe overwriten to aide in testing. for example
+// of the controller. this global maybe overwritten to aide in testing. for example
 // confirming that the controller does the correct thing in terminal states.
 // see controller_test.go
 var startState State = CheckManifest

--- a/internal/indexer/controller/indexfinished.go
+++ b/internal/indexer/controller/indexfinished.go
@@ -9,7 +9,7 @@ import (
 
 // indexFinished is the terminal stateFunc. once it transitions the
 // indexer to the IndexFinished state the indexer will no longer transition
-// and return a IndexReport to the caller
+// and return an IndexReport to the caller
 func indexFinished(ctx context.Context, s *Controller) (State, error) {
 	log := zerolog.Ctx(ctx).With().
 		Str("state", s.getState().String()).
@@ -20,7 +20,7 @@ func indexFinished(ctx context.Context, s *Controller) (State, error) {
 
 	err := s.Store.SetIndexFinished(ctx, s.report, s.Vscnrs)
 	if err != nil {
-		return Terminal, fmt.Errorf("failed finish scann. attempt a rescan of the manifest: %v", err)
+		return Terminal, fmt.Errorf("failed finish scan. attempt a rescan of the manifest: %v", err)
 	}
 
 	log.Info().Msg("manifest successfully scanned")

--- a/internal/indexer/controller/state.go
+++ b/internal/indexer/controller/state.go
@@ -24,14 +24,14 @@ const (
 	// ScanLayers scans each image including the image layer and indexes the contents
 	// Transitions: BuildLayerResult
 	ScanLayers
-	// Coalesce runs each provided ecosystem's coalescer and mergs their scan results
+	// Coalesce runs each provided ecosystem's coalescer and merges their scan results
 	// Transitions: IndexManifest
 	Coalesce
 	// IndexManifest evaluates a coalesced IndexReport and writes it's contents
 	// to the the persistence layer where it maybe searched.
 	// Transitions: IndexFinished
 	IndexManifest
-	// IndexError state indicates a impassable error has occured.
+	// IndexError state indicates a impassable error has occurred.
 	// returns a ScanResult with the error field
 	// Transitions: Terminal
 	IndexError

--- a/internal/vulnstore/postgres/store.go
+++ b/internal/vulnstore/postgres/store.go
@@ -59,7 +59,7 @@ func (s *Store) GetLatestUpdateRefs(ctx context.Context) (map[string][]driver.Up
 func (s *Store) Get(ctx context.Context, records []*claircore.IndexRecord, opts vulnstore.GetOpts) (map[string][]*claircore.Vulnerability, error) {
 	vulns, err := get(ctx, s.pool, records, opts)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get vulnerabilites: %v", err)
+		return nil, fmt.Errorf("failed to get vulnerabilities: %v", err)
 	}
 	return vulns, nil
 }

--- a/libindex/opts.go
+++ b/libindex/opts.go
@@ -19,7 +19,7 @@ const (
 	DefaultLayerFetchOpt        = indexer.OnDisk
 )
 
-// Opts are depedencies and options for constructing an instance of libindex
+// Opts are dependencies and options for constructing an instance of libindex
 type Opts struct {
 	// the connection string for the datastore specified above
 	ConnString string

--- a/libvuln/handler.go
+++ b/libvuln/handler.go
@@ -147,7 +147,7 @@ func (h *HTTP) UpdateOperations(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			resp := &je.Response{
 				Code:    "internal server error",
-				Message: fmt.Sprintf("could not get update operations: %v", err),
+				Message: fmt.Sprintf("could not delete update operations: %v", err),
 			}
 			je.Error(w, resp, http.StatusInternalServerError)
 			return
@@ -156,7 +156,7 @@ func (h *HTTP) UpdateOperations(w http.ResponseWriter, r *http.Request) {
 	default:
 		resp := &je.Response{
 			Code:    "method-not-allowed",
-			Message: "endpoint only allows POST",
+			Message: "endpoint only allows GET and DELETE",
 		}
 		je.Error(w, resp, http.StatusMethodNotAllowed)
 		return


### PR DESCRIPTION
Fix error responses of `UpdateOperations` handler. The only real change in this PR is in `libvuln/handler.go`. The rest are just typos I encountered when studying the code.