### PR TITLE
cicd: fix release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,8 @@ jobs:
         run: |
           curl -o git-chglog -L https://github.com/git-chglog/git-chglog/releases/download/0.9.1/git-chglog_linux_amd64
           chmod u+x git-chglog
-          echo "creating change log for tag: $TAG"
-          ./git-chglog "${TAG}" > "${{github.workspace}}/changelog"
+          echo "creating change log for tag: $VERSION"
+          ./git-chglog "${VERSION}" > "${{github.workspace}}/changelog"
       - name: Create Release
         uses: actions/create-release@latest
         env:


### PR DESCRIPTION
previous to this commit the env var TAG was being used inplace of the
correct var VERSION when generating release change log.

Signed-off-by: ldelossa <ldelossa@redhat.com>