### PR TITLE
vulnstore: fix gc live lock

### DIFF
--- a/cmd/libvulnhttp/main.go
+++ b/cmd/libvulnhttp/main.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/crgimenes/goconfig"
 	"github.com/quay/zlog"
@@ -81,6 +82,9 @@ func confToLibvulnOpts(conf Config) *libvuln.Opts {
 		Migrations:               true,
 		UpdaterSets:              nil,
 		DisableBackgroundUpdates: conf.DisableBackgroundUpdates,
+		UpdateInterval:           30 * time.Second,
+		UpdateWorkers:            10,
+		UpdateRetention:          10,
 	}
 
 	return opts

--- a/internal/vulnstore/postgres/store.go
+++ b/internal/vulnstore/postgres/store.go
@@ -105,7 +105,7 @@ WHERE array_length(ordered_ops.refs, 1) > $2;
 `
 
 		deleteVulns = `
-DELETE FROM vuln WHERE id NOT IN (SELECT vuln FROM uo_vuln);
+DELETE FROM vuln WHERE NOT EXISTS (SELECT * FROM uo_vuln WHERE vuln.id = uo_vuln.vuln);
 `
 	)
 


### PR DESCRIPTION
the previous query took an absurd amount of time to complete.
updated with a more performant query.

Signed-off-by: ldelossa <ldelossa@redhat.com>