### PR TITLE
libindex: limit MaxConns in controller pool to 1

### DIFF
--- a/libindex/controllerfactory.go
+++ b/libindex/controllerfactory.go
@@ -3,6 +3,7 @@ package libindex
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/jackc/pgx/v4/pgxpool"
 
@@ -23,6 +24,8 @@ func controllerFactory(ctx context.Context, lib *Libindex, opts *Opts) (*control
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse ConnString: %v", err)
 	}
+	cfg.MaxConns = 1
+	cfg.MaxConnIdleTime = time.Minute * 5
 	pool, err := pgxpool.ConnectConfig(ctx, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create ConnPool: %v", err)


### PR DESCRIPTION
With the default number of connections controller pool can make set to 4, indexer tends to get quite greedy and might bully matcher and notifier. For in-depth discussion of this issue, see #308 