### PR TITLE
[v0.1 Backport] rhel: fix cpe mapping type assertion 

### DIFF
--- a/rhel/repo2cpe/updater.go
+++ b/rhel/repo2cpe/updater.go
@@ -31,10 +31,12 @@ func NewLocalUpdaterJob(url string, client *http.Client) *LocalUpdaterJob {
 	if client == nil {
 		client = http.DefaultClient
 	}
-	return &LocalUpdaterJob{
+	lu := &LocalUpdaterJob{
 		URL:    url,
 		Client: client,
 	}
+	lu.mapping.Store((*MappingFile)(nil))
+	return lu
 }
 
 // Get translates repositories into CPEs using a mapping file.
@@ -49,9 +51,10 @@ func (updater *LocalUpdaterJob) Get(ctx context.Context, repositories []string) 
 	}
 
 	cpes := []string{}
-	var mapping *MappingFile = updater.mapping.Load().(*MappingFile)
+	// interface conversion guaranteed to pass, see
+	// constructor.
+	mapping := updater.mapping.Load().(*MappingFile)
 	if mapping == nil {
-		// mapping not set yet. not an error
 		return cpes, nil
 	}
 


### PR DESCRIPTION
this commit makes sure a nil pointer of type *repo2cpe.MappingFile is
loaded into the atomic.Value.

type assertions of the atomic.Value should never fail after this.
Loads() of the atomic.Value before a mapping file is downloaded should
return a typed nil.

Signed-off-by: ldelossa <ldelossa@redhat.com>