### PR TITLE
fetcher: relax allowable gzip types

### DIFF
--- a/internal/indexer/fetcher/fetcher.go
+++ b/internal/indexer/fetcher/fetcher.go
@@ -179,7 +179,9 @@ func (f *fetcher) fetch(ctx context.Context, layer *claircore.Layer) error {
 
 	var r io.Reader
 	switch {
-	case ct == "application/gzip":
+	case ct == "application/gzip" ||
+		ct == "application/vnd.docker.image.rootfs.diff.tar.gzip":
+		// Catch the old docker media type.
 		fallthrough
 	case strings.HasSuffix(ct, ".tar+gzip"):
 		g, err := gzip.NewReader(br)


### PR DESCRIPTION
Docker Manifest v2s2 defines
`application/vnd.docker.image.rootfs.diff.tar.gzip` as the media type for
layers, and apparently some registries use this when serving layer
blobs. This was failing the heuristic based on the OCI media types and
traditional MIME types.

Closes #303

Signed-off-by: Hank Donnay <hdonnay@redhat.com>