### PR TITLE
matchers: provide a way to pass config

### DIFF
--- a/crda/matcherfactory.go
+++ b/crda/matcherfactory.go
@@ -12,7 +12,7 @@ import (
 	"github.com/quay/claircore/libvuln/driver"
 )
 
-// Factory contains the configuration for fetching and parsing a pulp manifest.
+// Factory contains the configuration to connect with CRDA remote matcher.
 type Factory struct {
 	url    *url.URL
 	client *http.Client

--- a/crda/matcherfactory.go
+++ b/crda/matcherfactory.go
@@ -1,0 +1,64 @@
+package crda
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+
+	"github.com/quay/zlog"
+	"go.opentelemetry.io/otel/baggage"
+	"go.opentelemetry.io/otel/label"
+
+	"github.com/quay/claircore/libvuln/driver"
+)
+
+// Factory contains the configuration for fetching and parsing a pulp manifest.
+type Factory struct {
+	url    *url.URL
+	client *http.Client
+}
+
+// MatcherFactory implements driver.MatcherFactory.
+func (f *Factory) Matcher(ctx context.Context) (driver.Matcher, error) {
+	m, err := NewMatcher(WithClient(f.client), WithURL(f.url))
+	if err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+// To decode the config.
+type FactoryConfig struct {
+	URL string `json:"url" yaml:"url"`
+}
+
+// MatcherFactory implements driver.MatcherConfigurable.
+func (f *Factory) Configure(ctx context.Context, cfg driver.MatcherConfigUnmarshaler, c *http.Client) error {
+	ctx = baggage.ContextWithValues(ctx,
+		label.String("component", "crda/MatcherFactory.Configure"))
+	var fc FactoryConfig
+
+	if err := cfg(&fc); err != nil {
+		return err
+	}
+	zlog.Debug(ctx).Msg("loaded incoming config")
+
+	if fc.URL != "" {
+		u, err := url.Parse(fc.URL)
+		if err != nil {
+			return err
+		}
+		zlog.Info(ctx).
+			Str("url", u.String()).
+			Msg("configured manifest URL")
+		f.url = u
+	}
+
+	if c != nil {
+		zlog.Info(ctx).
+			Msg("configured HTTP client")
+		f.client = c
+	}
+
+	return nil
+}

--- a/crda/remotematcher.go
+++ b/crda/remotematcher.go
@@ -104,13 +104,9 @@ func WithClient(c *http.Client) Option {
 // WithHost sets the server host name that the matcher should use for requests.
 //
 // If not passed to NewMatcher, defaultHost will be used.
-func WithURL(uri string) Option {
-	u, err := url.Parse(uri)
+func WithURL(url *url.URL) Option {
 	return func(m *Matcher) error {
-		if err != nil {
-			return err
-		}
-		m.url = u
+		m.url = url
 		return nil
 	}
 }

--- a/crda/remotematcher_test.go
+++ b/crda/remotematcher_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -47,7 +48,8 @@ type matcherTestcase struct {
 }
 
 func newMatcher(t *testing.T, srv *httptest.Server) *Matcher {
-	m, err := NewMatcher(WithClient(srv.Client()), WithURL(srv.URL))
+	url, _ := url.Parse(srv.URL)
+	m, err := NewMatcher(WithClient(srv.Client()), WithURL(url))
 	if err != nil {
 		t.Errorf("there should be no err %v", err)
 	}

--- a/libvuln/driver/matcherfactory.go
+++ b/libvuln/driver/matcherfactory.go
@@ -23,3 +23,18 @@ type MatcherConfigUnmarshaler func(interface{}) error
 type MatcherConfigurable interface {
 	Configure(context.Context, MatcherConfigUnmarshaler, *http.Client) error
 }
+
+// MatcherFactoryFunc would ease the registration of Matchers which doesn't
+// need Configurability.
+type MatcherFactoryFunc func(context.Context) (Matcher, error)
+
+func (u MatcherFactoryFunc) Matcher(ctx context.Context) (Matcher, error) {
+	return u(ctx)
+}
+
+// MatcherStatic creates an MatcherFactoryFunc returning the provided matcher.
+func MatcherStatic(s Matcher) MatcherFactory {
+	return MatcherFactoryFunc(func(_ context.Context) (Matcher, error) {
+		return s, nil
+	})
+}

--- a/libvuln/driver/matcherfactory.go
+++ b/libvuln/driver/matcherfactory.go
@@ -24,7 +24,7 @@ type MatcherConfigurable interface {
 	Configure(context.Context, MatcherConfigUnmarshaler, *http.Client) error
 }
 
-// MatcherFactoryFunc would ease the registration of Matchers which doesn't
+// MatcherFactoryFunc would ease the registration of Matchers which don't
 // need Configurability.
 type MatcherFactoryFunc func(context.Context) (Matcher, error)
 

--- a/libvuln/driver/matcherfactory.go
+++ b/libvuln/driver/matcherfactory.go
@@ -1,0 +1,25 @@
+package driver
+
+import (
+	"context"
+
+	"net/http"
+)
+
+// MatcherFactory is used to construct matchers at run-time.
+type MatcherFactory interface {
+	Matcher(context.Context) (Matcher, error)
+}
+
+// MatcherConfigUnmarshaler can be thought of as an Unmarshal function with the byte
+// slice provided, or a Decode function.
+//
+// The function should populate a passed struct with any configuration
+// information.
+type MatcherConfigUnmarshaler func(interface{}) error
+
+// MatcherConfigurable is an interface that MatcherFactory can implement to opt-in to having
+// their configuration provided dynamically.
+type MatcherConfigurable interface {
+	Configure(context.Context, MatcherConfigUnmarshaler, *http.Client) error
+}

--- a/libvuln/libvuln.go
+++ b/libvuln/libvuln.go
@@ -64,7 +64,7 @@ func New(ctx context.Context, opts *Opts) (*Libvuln, error) {
 		opts.Client,
 		matchers.WithEnabled(opts.MatcherNames),
 		matchers.WithConfigs(opts.MatcherConfigs),
-		// matchers.WithOutOfTree(opts.Matchers),
+		matchers.WithOutOfTree(opts.Matchers),
 	)
 	zlog.Info(ctx).Int("len", len(l.matchers)).Msg("matchers created")
 	if err != nil {

--- a/libvuln/opts.go
+++ b/libvuln/opts.go
@@ -82,6 +82,10 @@ type Opts struct {
 	// keyed by name.
 	MatcherConfigs map[string]driver.MatcherConfigUnmarshaler
 
+	// A list of out-of-tree matchers you'd like libvuln to
+	// use.
+	//
+	// This list will me merged with the default matchers.
 	Matchers []driver.Matcher
 
 	// UpdateWorkers controls the number of update workers running concurrently.

--- a/libvuln/opts.go
+++ b/libvuln/opts.go
@@ -13,17 +13,8 @@ import (
 	"github.com/jackc/pgx/v4/stdlib"
 	"github.com/remind101/migrate"
 
-	"github.com/quay/claircore/alpine"
-	"github.com/quay/claircore/aws"
-	"github.com/quay/claircore/debian"
 	"github.com/quay/claircore/libvuln/driver"
 	"github.com/quay/claircore/libvuln/migrations"
-	"github.com/quay/claircore/oracle"
-	"github.com/quay/claircore/photon"
-	"github.com/quay/claircore/python"
-	"github.com/quay/claircore/rhel"
-	"github.com/quay/claircore/suse"
-	"github.com/quay/claircore/ubuntu"
 )
 
 const (
@@ -116,21 +107,6 @@ type Opts struct {
 	Client *http.Client
 }
 
-// defaultMatchers is a variable containing
-// all the matchers libvuln will use to match
-// index records to vulnerabilities.
-var defaultMatchers = []driver.Matcher{
-	&alpine.Matcher{},
-	&aws.Matcher{},
-	&debian.Matcher{},
-	&oracle.Matcher{},
-	&photon.Matcher{},
-	&python.Matcher{},
-	&rhel.Matcher{},
-	&suse.Matcher{},
-	&ubuntu.Matcher{},
-}
-
 // parse is an internal method for constructing
 // the necessary Updaters and Matchers for Libvuln
 // usage
@@ -159,9 +135,6 @@ func (o *Opts) parse(ctx context.Context) error {
 	if o.UpdateWorkers <= 0 {
 		o.UpdateWorkers = DefaultUpdateWorkers
 	}
-
-	// merge default matchers with any out-of-tree specified
-	o.Matchers = append(o.Matchers, defaultMatchers...)
 
 	if o.Client == nil {
 		o.Client = http.DefaultClient

--- a/libvuln/opts.go
+++ b/libvuln/opts.go
@@ -69,10 +69,28 @@ type Opts struct {
 	// If you desire no updaters to run do not add an updater
 	// into this slice.
 	Updaters []driver.Updater
-	// A list of out-of-tree matchers you'd like libvuln to
-	// use.
+	// A slice of strings representing which
+	// matchers will be used.
 	//
-	// This list will me merged with the default matchers.
+	// If nil all default Matchers will be used
+	//
+	// The following names are supported by default:
+	// "alpine"
+	// "aws"
+	// "debian"
+	// "oracle"
+	// "photon"
+	// "python"
+	// "rhel"
+	// "suse"
+	// "ubuntu"
+	// "crda" - remotematcher calls hosted api via RPC.
+	MatcherNames []string
+
+	// Config holds configuration blocks for MatcherFactories and Matchers,
+	// keyed by name.
+	MatcherConfigs map[string]driver.MatcherConfigUnmarshaler
+
 	Matchers []driver.Matcher
 
 	// UpdateWorkers controls the number of update workers running concurrently.

--- a/matchers/defaults/defaults.go
+++ b/matchers/defaults/defaults.go
@@ -1,5 +1,4 @@
-//
-// Importing this package registers default updaters via its init function.
+// Importing this package registers default matchers via its init function.
 package defaults
 
 import (
@@ -33,7 +32,7 @@ func init() {
 }
 
 // Error reports if an error was encountered when initializing the default
-// updaters.
+// matchers.
 func Error() error {
 	return regerr
 }

--- a/matchers/defaults/defaults.go
+++ b/matchers/defaults/defaults.go
@@ -7,8 +7,18 @@ import (
 	"sync"
 	"time"
 
+	"github.com/quay/claircore/alpine"
+	"github.com/quay/claircore/aws"
 	"github.com/quay/claircore/crda"
+	"github.com/quay/claircore/debian"
+	"github.com/quay/claircore/libvuln/driver"
 	"github.com/quay/claircore/matchers/registry"
+	"github.com/quay/claircore/oracle"
+	"github.com/quay/claircore/photon"
+	"github.com/quay/claircore/python"
+	"github.com/quay/claircore/rhel"
+	"github.com/quay/claircore/suse"
+	"github.com/quay/claircore/ubuntu"
 )
 
 var (
@@ -28,8 +38,28 @@ func Error() error {
 	return regerr
 }
 
+// defaultMatchers is a variable containing
+// all the matchers libvuln will use to match
+// index records to vulnerabilities.
+var defaultMatchers = []driver.Matcher{
+	&alpine.Matcher{},
+	&aws.Matcher{},
+	&debian.Matcher{},
+	&oracle.Matcher{},
+	&photon.Matcher{},
+	&python.Matcher{},
+	&rhel.Matcher{},
+	&suse.Matcher{},
+	&ubuntu.Matcher{},
+}
+
 func inner(ctx context.Context) error {
 	registry.Register("crda", &crda.Factory{})
+
+	for _, m := range defaultMatchers {
+		mf := driver.MatcherStatic(m)
+		registry.Register(m.Name(), mf)
+	}
 
 	return nil
 }

--- a/matchers/defaults/defaults.go
+++ b/matchers/defaults/defaults.go
@@ -1,0 +1,35 @@
+//
+// Importing this package registers default updaters via its init function.
+package defaults
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/quay/claircore/crda"
+	"github.com/quay/claircore/matchers/registry"
+)
+
+var (
+	once   sync.Once
+	regerr error
+)
+
+func init() {
+	ctx, done := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer done()
+	once.Do(func() { regerr = inner(ctx) })
+}
+
+// Error reports if an error was encountered when initializing the default
+// updaters.
+func Error() error {
+	return regerr
+}
+
+func inner(ctx context.Context) error {
+	registry.Register("crda", &crda.Factory{})
+
+	return nil
+}

--- a/matchers/matchers.go
+++ b/matchers/matchers.go
@@ -22,13 +22,14 @@ type Matchers struct {
 	// configs provided to matchers once constructed.
 	configs Configs
 	client  *http.Client
-	// out-of-tree matchers
+	// out-of-tree matchers.
 	matchers []driver.Matcher
 }
 
 type MatchersOption func(m *Matchers)
 
-// NewManager will return a manager ready to have its Start or Run methods called.
+// NewMatchers will return a slice of Matcher created based on the provided
+// MatchersOption.
 func NewMatchers(ctx context.Context, client *http.Client, opts ...MatchersOption) ([]driver.Matcher, error) {
 	ctx = baggage.ContextWithValues(ctx,
 		label.String("component", "libvuln/matchers/NewMatchers"))
@@ -37,7 +38,6 @@ func NewMatchers(ctx context.Context, client *http.Client, opts ...MatchersOptio
 		client = http.DefaultClient
 	}
 
-	// the default Manager
 	m := &Matchers{
 		factories: registry.Registered(),
 		client:    client,
@@ -54,7 +54,7 @@ func NewMatchers(ctx context.Context, client *http.Client, opts ...MatchersOptio
 	}
 
 	matchers := []driver.Matcher{}
-	// constructing matchers may require network access,
+	// constructing matchers may return error,
 	// depending on the factory.
 	// if construction fails we will simply ignore those matcher.
 	for _, factory := range m.factories {

--- a/matchers/matchers.go
+++ b/matchers/matchers.go
@@ -1,0 +1,68 @@
+package matchers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/quay/zlog"
+	"go.opentelemetry.io/otel/baggage"
+	"go.opentelemetry.io/otel/label"
+
+	"github.com/quay/claircore/libvuln/driver"
+	_ "github.com/quay/claircore/matchers/defaults"
+	"github.com/quay/claircore/matchers/registry"
+)
+
+type Configs map[string]driver.MatcherConfigUnmarshaler
+
+type Matchers struct {
+	// provides run-time matcher construction.
+	factories map[string]driver.MatcherFactory
+	// configs provided to matchers once constructed.
+	configs Configs
+	client  *http.Client
+}
+
+type MatchersOption func(m *Matchers)
+
+// NewManager will return a manager ready to have its Start or Run methods called.
+func NewMatchers(ctx context.Context, client *http.Client, opts ...MatchersOption) ([]driver.Matcher, error) {
+	ctx = baggage.ContextWithValues(ctx,
+		label.String("component", "libvuln/matchers/NewMatchers"))
+
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	// the default Manager
+	m := &Matchers{
+		factories: registry.Registered(),
+		client:    client,
+	}
+
+	// these options can be ran order independent.
+	for _, opt := range opts {
+		opt(m)
+	}
+
+	err := registry.Configure(ctx, m.factories, m.configs, m.client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to configure updater set factory: %w", err)
+	}
+
+	matchers := []driver.Matcher{}
+	// constructing updater sets may require network access,
+	// depending on the factory.
+	// if construction fails we will simply ignore those updater
+	// sets.
+	for _, factory := range m.factories {
+		matcher, err := factory.Matcher(ctx)
+		if err != nil {
+			zlog.Error(ctx).Err(err).Msg("failed constructing factory, excluding from run")
+			continue
+		}
+		matchers = append(matchers, matcher)
+	}
+	return matchers, nil
+}

--- a/matchers/options.go
+++ b/matchers/options.go
@@ -43,18 +43,11 @@ func WithConfigs(cfgs Configs) MatchersOption {
 // WithOutOfTree allows callers to provide their own out-of-tree
 // updaters.
 //
-// note: currently we will never configure the outOfTree updater
+// note: currently we will never configure the outOfTree matcher
 // factory. if this changes consider making this option a required
 // to avoid missing configuration
-// func WithOutOfTree(outOfTree []driver.Updater) MatchersOption {
-// 	return func(m *Matchers) {
-// 		us := driver.NewUpdaterSet()
-// 		for _, u := range outOfTree {
-// 			if err := us.Add(u); err != nil {
-// 				// duplicate updater, ignore.
-// 				continue
-// 			}
-// 		}
-// 		m.factories["outOfTree"] = driver.StaticSet(us)
-// 	}
-// }
+func WithOutOfTree(outOfTree []driver.Matcher) MatchersOption {
+	return func(m *Matchers) {
+		m.matchers = outOfTree
+	}
+}

--- a/matchers/options.go
+++ b/matchers/options.go
@@ -5,11 +5,11 @@ import (
 )
 
 // WithEnabled configures the Matchers to only run the specified
-// updater sets.
+// matchers.
 //
-// If enabled == nil all default updater sets will run (same as not providing this option to the constructor at all).
-// If len(enabled) == 0 no default updater sets will run.
-// If len(enabled) > 0 only provided updater sets will be ran.
+// If enabled == nil all default matchers will run (same as not providing this option to the constructor at all).
+// If len(enabled) == 0 no default matchers will run.
+// If len(enabled) > 0 only provided matchers will be ran.
 func WithEnabled(enabled []string) MatchersOption {
 	return func(m *Matchers) {
 		if enabled == nil {
@@ -28,10 +28,10 @@ func WithEnabled(enabled []string) MatchersOption {
 	}
 }
 
-// WithConfigs tells the Matchers to configure each updater where
+// WithConfigs tells the Matchers to configure each matcher where
 // a configuration is provided.
 //
-// Configuration of individual updaters is delegated to updater/registry.go
+// Configuration of individual matchers is delegated to matchers/registry/registry.go
 // Note: this option is optimal when ran after WithEnabled option. However,
 // this option has no strict depedency on others.
 func WithConfigs(cfgs Configs) MatchersOption {
@@ -41,11 +41,7 @@ func WithConfigs(cfgs Configs) MatchersOption {
 }
 
 // WithOutOfTree allows callers to provide their own out-of-tree
-// updaters.
-//
-// note: currently we will never configure the outOfTree matcher
-// factory. if this changes consider making this option a required
-// to avoid missing configuration
+// matchers.
 func WithOutOfTree(outOfTree []driver.Matcher) MatchersOption {
 	return func(m *Matchers) {
 		m.matchers = outOfTree

--- a/matchers/options.go
+++ b/matchers/options.go
@@ -1,0 +1,60 @@
+package matchers
+
+import (
+	"github.com/quay/claircore/libvuln/driver"
+)
+
+// WithEnabled configures the Matchers to only run the specified
+// updater sets.
+//
+// If enabled == nil all default updater sets will run (same as not providing this option to the constructor at all).
+// If len(enabled) == 0 no default updater sets will run.
+// If len(enabled) > 0 only provided updater sets will be ran.
+func WithEnabled(enabled []string) MatchersOption {
+	return func(m *Matchers) {
+		if enabled == nil {
+			return
+		}
+
+		factories := map[string]driver.MatcherFactory{}
+		for _, enable := range enabled {
+			for name, factory := range m.factories {
+				if name == enable {
+					factories[name] = factory
+				}
+			}
+		}
+		m.factories = factories
+	}
+}
+
+// WithConfigs tells the Matchers to configure each updater where
+// a configuration is provided.
+//
+// Configuration of individual updaters is delegated to updater/registry.go
+// Note: this option is optimal when ran after WithEnabled option. However,
+// this option has no strict depedency on others.
+func WithConfigs(cfgs Configs) MatchersOption {
+	return func(m *Matchers) {
+		m.configs = cfgs
+	}
+}
+
+// WithOutOfTree allows callers to provide their own out-of-tree
+// updaters.
+//
+// note: currently we will never configure the outOfTree updater
+// factory. if this changes consider making this option a required
+// to avoid missing configuration
+// func WithOutOfTree(outOfTree []driver.Updater) MatchersOption {
+// 	return func(m *Matchers) {
+// 		us := driver.NewUpdaterSet()
+// 		for _, u := range outOfTree {
+// 			if err := us.Add(u); err != nil {
+// 				// duplicate updater, ignore.
+// 				continue
+// 			}
+// 		}
+// 		m.factories["outOfTree"] = driver.StaticSet(us)
+// 	}
+// }

--- a/matchers/registry/registry.go
+++ b/matchers/registry/registry.go
@@ -1,7 +1,4 @@
 // Package matchers holds a registry of default matchers.
-//
-// A set of in-tree matchers can be added by using the defaults package's Set
-// function.
 package registry
 
 import (
@@ -49,7 +46,7 @@ func Registered() map[string]driver.MatcherFactory {
 func Configure(ctx context.Context, fs map[string]driver.MatcherFactory, cfg map[string]driver.MatcherConfigUnmarshaler, c *http.Client) error {
 	errd := false
 	var b strings.Builder
-	b.WriteString("updater: errors configuring factories:")
+	b.WriteString("matchers: errors configuring factories:")
 	if c == nil {
 		c = http.DefaultClient
 	}

--- a/matchers/registry/registry.go
+++ b/matchers/registry/registry.go
@@ -1,0 +1,73 @@
+// Package matchers holds a registry of default matchers.
+//
+// A set of in-tree matchers can be added by using the defaults package's Set
+// function.
+package registry
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/quay/claircore/libvuln/driver"
+)
+
+var pkg = struct {
+	sync.Mutex
+	fs map[string]driver.MatcherFactory
+}{
+	fs: make(map[string]driver.MatcherFactory),
+}
+
+// Register registers an MatcherFactory.
+//
+// Register will panic if the same name is used twice.
+func Register(name string, f driver.MatcherFactory) {
+	pkg.Lock()
+	defer pkg.Unlock()
+	if _, ok := pkg.fs[name]; ok {
+		panic("")
+	}
+	pkg.fs[name] = f
+}
+
+// Registered returns a new map populated with the registered UpdaterSetFactories.
+func Registered() map[string]driver.MatcherFactory {
+	pkg.Lock()
+	defer pkg.Unlock()
+	r := make(map[string]driver.MatcherFactory, len(pkg.fs))
+	for k, v := range pkg.fs {
+		r[k] = v
+	}
+	return r
+}
+
+// Configure calls the Configure method on all the passed-in
+// UpdaterSetFactories.
+func Configure(ctx context.Context, fs map[string]driver.MatcherFactory, cfg map[string]driver.MatcherConfigUnmarshaler, c *http.Client) error {
+	errd := false
+	var b strings.Builder
+	b.WriteString("updater: errors configuring factories:")
+	if c == nil {
+		c = http.DefaultClient
+	}
+
+	for name, fac := range fs {
+		f, fOK := fac.(driver.MatcherConfigurable)
+		cf, cfOK := cfg[name]
+		if fOK && cfOK {
+			if err := f.Configure(ctx, cf, c); err != nil {
+				errd = true
+				b.WriteString("\n\t")
+				b.WriteString(err.Error())
+			}
+		}
+	}
+
+	if errd {
+		return errors.New(b.String())
+	}
+	return nil
+}

--- a/matchers/registry/registry.go
+++ b/matchers/registry/registry.go
@@ -33,7 +33,7 @@ func Register(name string, f driver.MatcherFactory) {
 	pkg.fs[name] = f
 }
 
-// Registered returns a new map populated with the registered UpdaterSetFactories.
+// Registered returns a new map populated with the registered MatcherFactories.
 func Registered() map[string]driver.MatcherFactory {
 	pkg.Lock()
 	defer pkg.Unlock()
@@ -45,7 +45,7 @@ func Registered() map[string]driver.MatcherFactory {
 }
 
 // Configure calls the Configure method on all the passed-in
-// UpdaterSetFactories.
+// MatcherFactories.
 func Configure(ctx context.Context, fs map[string]driver.MatcherFactory, cfg map[string]driver.MatcherConfigUnmarshaler, c *http.Client) error {
 	errd := false
 	var b strings.Builder


### PR DESCRIPTION
This PR implements factory with registry pattern for matchers to facilitate passing configurable parameters to matchers.