### PR TITLE
rhel: treat vulns without FixedInVersion as unfixed

### DIFF
--- a/rhel/matcher.go
+++ b/rhel/matcher.go
@@ -44,6 +44,9 @@ func (m *Matcher) Vulnerable(ctx context.Context, record *claircore.IndexRecord,
 	if vuln.FixedInVersion != "" {
 		vulnVer = version.NewVersion(vuln.FixedInVersion)
 		cmp = func(i int) bool { return i == version.LESS }
+	} else {
+		// If a vulnerability doesn't have FixedInVersion, assume it is unfixed.
+		vulnVer = version.NewVersion("65535:0")
 	}
 	// compare version and architecture
 	return cmp(pkgVer.Compare(vulnVer)) && vuln.ArchOperation.Cmp(record.Package.Arch, vuln.Package.Arch), nil


### PR DESCRIPTION
Red Hat Product Security will be enriching content of OVAL streams. Soon they'll also contain know vulnerabilities without published fix. This change enables us to treat vulnerabilities that don't have `FixedInVersion` field as unfixed.