### PR TITLE
cicd: sort changelog by semver

### DIFF
--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -4,6 +4,7 @@ info:
   title: CHANGELOG
   repository_url: https://github.com/quay/claircore
 options:
+  tag_sort_by: semver
   commits:
     sort_by: Scope
   commit_groups:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Changelog
         shell: bash
         run: |
-          curl -o /tmp/git-chglog -L https://github.com/git-chglog/git-chglog/releases/download/0.9.1/git-chglog_linux_amd64
+          curl -o /tmp/git-chglog -L https://github.com/ldelossa/git-chglog/releases/download/v0.11.2-sortbysemver/linux.amd64.git-chglog
           chmod u+x /tmp/git-chglog
           echo "creating change log for tag: ${{ github.event.inputs.tag }}"
           

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
       - name: ChangeLog
         run: |
-          curl -o git-chglog -L https://github.com/git-chglog/git-chglog/releases/download/0.9.1/git-chglog_linux_amd64
+          curl -o /tmp/git-chglog -L https://github.com/ldelossa/git-chglog/releases/download/v0.11.2-sortbysemver/linux.amd64.git-chglog
           chmod u+x git-chglog
           echo "creating change log for tag: $VERSION"
           ./git-chglog "${VERSION}" > "${{github.workspace}}/changelog"


### PR DESCRIPTION
since we interleave back-port releases with
mainline, we need to order our change log
by semver to ensure our changes merge correctly.

right now this uses a fork of git-chglog which
implements this semver-ordering.

if this PR merges: https://github.com/git-chglog/git-chglog/pull/124
we will no longer utilize the fork and pull git-chlog upstream latest

Signed-off-by: ldelossa <ldelossa@redhat.com>