### PR TITLE
cicd: fix release failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,9 @@ jobs:
       - name: ChangeLog
         run: |
           curl -o /tmp/git-chglog -L https://github.com/ldelossa/git-chglog/releases/download/v0.11.2-sortbysemver/linux.amd64.git-chglog
-          chmod u+x git-chglog
+          chmod u+x /tmp/git-chglog
           echo "creating change log for tag: $VERSION"
-          ./git-chglog "${VERSION}" > "${{github.workspace}}/changelog"
+          /tmp/git-chglog "${VERSION}" > "${{github.workspace}}/changelog"
       - name: Create Release
         uses: actions/create-release@latest
         env:


### PR DESCRIPTION
copy pasta of cicd jobs causes a bad
path lookup for the git-chglog tool.

Signed-off-by: ldelossa <ldelossa@redhat.com>