### PR TITLE
rhel: discard unaffected vulnerabilities

### DIFF
--- a/pkg/ovalutil/rpm_test.go
+++ b/pkg/ovalutil/rpm_test.go
@@ -1,0 +1,73 @@
+package ovalutil
+
+import (
+	"testing"
+
+	"github.com/quay/goval-parser/oval"
+)
+
+type definitionTypeTestCase struct {
+	def        oval.Definition
+	want, name string
+	err        bool
+}
+
+func TestGetDefinitionType(t *testing.T) {
+	testCases := []definitionTypeTestCase{
+		{
+			def:  oval.Definition{ID: "oval:com.redhat.cve:def:20162166"},
+			want: CVEDefinition,
+			err:  false,
+			name: "CVE",
+		},
+		{
+			def:  oval.Definition{ID: "oval:com.redhat.unaffected:def:202014340"},
+			want: UnaffectedDefinition,
+			err:  false,
+			name: "unaffected",
+		},
+		{
+			def:  oval.Definition{ID: "oval:com.redhat.rhsa:def:20190966"},
+			want: RHSADefinition,
+			err:  false,
+			name: "RHSA",
+		},
+		{
+			def:  oval.Definition{ID: "oval:com.redhat.rhba:def:20193384"},
+			want: RHBADefinition,
+			err:  false,
+			name: "RHBA",
+		},
+		{
+			def:  oval.Definition{ID: "oval:com.redhat.rhea:def:20193845"},
+			want: RHEADefinition,
+			err:  false,
+			name: "RHEA",
+		},
+		{
+			def:  oval.Definition{ID: "oval:com.redhat.rhea::20193845"},
+			want: "",
+			err:  true,
+			name: "malformed definition",
+		},
+		{
+			def:  oval.Definition{ID: ""},
+			want: "",
+			err:  true,
+			name: "empty ID",
+		},
+	}
+
+	for _, tc := range testCases {
+		got, err := GetDefinitionType(tc.def)
+		if !tc.err && err != nil {
+			t.Errorf("%q returned error while it shouldn't", tc.name)
+		}
+		if tc.err && err == nil {
+			t.Errorf("%q didn't return error while it should", tc.name)
+		}
+		if tc.want != got {
+			t.Errorf("%q failed: want %q, got %q", tc.name, tc.want, got)
+		}
+	}
+}


### PR DESCRIPTION
This PR comlements #338 and since this one isn't as straightforward, I think it's a good time to dive in and explain broader context of these two changes. 

Red Hat Product Security is planning to release new version of OVAL data. The main difference will be addition of `<affected_cpe_list>` to definitions of class "vulnerability". There are two types of such definitions in OVAL files, distinguished by the format of their ID.

### Unfixed vulnerability
Example (Example are only from testing data. Their content might have been edited for testing purposes, what matters here is the format):
```xml
  <definition class="vulnerability" id="oval:com.redhat.cve:def:20162166" version="634">
   <metadata>
    <title>CVE-2016-2166 qpid-proton: reactor sends  messages in clear if ssl is requested but not available (moderate)</title>
    <reference ref_id="CVE-2016-2166" ref_url="https://access.redhat.com/security/cve/CVE-2016-2166" source="CVE"/>
    <description>STATEMENT: This issue affects the versions of qpid-proton as shipped with Red Hat Satellite version 6. Red Hat Product Security has rated this issue as having Moderate security impact. A future update may address this issue. For additional information, refer to the Issue Severity Classification: https://access.redhat.com/security/updates/classification/.</description>
    <advisory from="secalert@redhat.com">
     <severity>Important</severity>
     <updated date="2020-08-04"/>
     <cve cvss2="4.3/AV:N/AC:M/Au:N/C:P/I:N/A:N" cwe="CWE-223" href="https://access.redhat.com/security/cve/CVE-2016-2166" impact="moderate" public="20160309">CVE-2016-2166</cve>
     <affected_cpe_list>
      <cpe>cpe:/a:redhat:enterprise_linux:8::appstream</cpe>
     </affected_cpe_list>
    </advisory>
   </metadata>
   <criteria operator="OR">
    <criterion comment="Red Hat Enterprise Linux must be installed" test_ref="oval:com.redhat.cve:tst:20162166006"/>
    <criteria operator="AND">
     <criterion comment="Red Hat Enterprise Linux 8 is installed" test_ref="oval:com.redhat.cve:tst:20162166005"/>
     <criteria operator="OR">
      <criteria operator="AND">
       <criterion comment="qpid-proton-c is installed" test_ref="oval:com.redhat.cve:tst:20162166001"/>
       <criterion comment="qpid-proton-c is signed with Red Hat redhatrelease2 key" test_ref="oval:com.redhat.cve:tst:20162166002"/>
      </criteria>
      <criteria operator="AND">
       <criterion comment="python3-qpid-proton is installed" test_ref="oval:com.redhat.cve:tst:20162166003"/>
       <criterion comment="python3-qpid-proton is signed with Red Hat redhatrelease2 key" test_ref="oval:com.redhat.cve:tst:20162166004"/>
      </criteria>
     </criteria>
    </criteria>
   </criteria>
  </definition>
  ``` 
This represents known vulnerability without existing fix released in an advisory. Definitions like these have been in OVAL files for some time. However, they didn't have any CPEs associated with them, therefore their further processing has been always discarded [here](https://github.com/quay/claircore/blob/ddd2621e8c3eb91b91b4b912b1b93bbbc2c7d785/rhel/parser.go#L31) by iterating through an empty loop. Now they will be processed and therefore we must decide whether they affect packages or not. This was done in #338.

### Vulnerability not affecting package
Example:
```xml
  <definition class="vulnerability" id="oval:com.redhat.unaffected:def:202014340" version="633">
   <metadata>
    <title>Unaffected components for: CVE-2020-14340 xnio: file descriptor leak caused by growing amounts of NIO Selector file handles may lead to DoS (moderate)</title>
    <reference ref_id="CVE-2020-14340" ref_url="https://access.redhat.com/security/cve/CVE-2020-14340" source="CVE"/>
    <description>Red Hat's versions of the associated software have been determined to NOT be affected by CVE-2020-14340.</description>
    <advisory from="secalert@redhat.com">
     <severity>Moderate</severity>
     <updated date="2021-02-16"/>
     <cve cvss3="5.9/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H" cwe="CWE-400" href="https://access.redhat.com/security/cve/CVE-2020-14340" impact="moderate" public="20200724">CVE-2020-14340</cve>
     <affected_cpe_list>
      <cpe>cpe:/a:redhat:enterprise_linux:8::appstream</cpe>
     </affected_cpe_list>
    </advisory>
   </metadata>
   <criteria operator="OR">
    <criterion comment="Red Hat Enterprise Linux must be installed" test_ref="oval:com.redhat.cve:tst:20190223026"/>
    <criteria operator="AND">
     <criterion comment="Red Hat Enterprise Linux 8 is installed" test_ref="oval:com.redhat.cve:tst:20190223025"/>
     <criterion comment="xnio is installed" test_ref="oval:com.redhat.unaffected:tst:202014340001"/>
     <criterion comment="xnio is not installed" test_ref="oval:com.redhat.unaffected:tst:202014340002"/>
    </criteria>
   </criteria>
  </definition>
```
This represent a vulnerability that DOES NOT affect the package in question. Why those are even published in OVAL, I have no idea. The fact is thought that they've also been around for some time already. Again, they haven't had any CPEs associated with that, so we didn't care about them. Now that they'll have CPEs, there's a couple of ways to deal with them. Let's consider two.

We could simply not to anything. In that case I assume we'd still correctly treat them as not affecting a package. The reason for that is that the criteria are set up in such a way that can never be true. For example, package `xnio` is both installed and not installed. 
Pros:
* No need for additional code

Cons:
* Clair takes time to process vulnerabilities that we really don't care about
* They get stored in DB and increase the amount records there which
* Slows down other queries

The second option is what is presented in this PR. As you can see, I did not need to do anything super complicated and I think discarding unaffected vulnerabilities as soon as we identify their type is a good response to the cons outlined about. 

### Discussion
**Q:** Okay, so we're discarding unaffected vulnerbilities. Makes sense. But why the condition also catches unfixed CVEs? Haven't you said that they've been dealt with in #338?
**A:** Yup, that's true. However, before all of this is done, there's still one major thing that must be implemented. We need to provide logic required in scenario when an unfixed CVE is actaully fixed and an advisory is released. In such case we need to make sure that a package is affected by the RHSA vulnerability and no longer affected by the CVE vulnerability. Until that happens, I'm blocking Product Security. So my idea was:
* We merge this and release a new version of CC
* Product Security can release new OVAL data as we'll simply discard all definitions where class is "vulnerability"
* In the meanwhile, I can work on the logic of CVE -> RHSA transition
* We merge the last part of this effort while also removing the condition that makes us discard `ovalutil.CVEDefinition`

### My questions
* What do you think about the plan outlined above?
* Do you think this is a good way to tackle unaffected vulnerabilities?
* Do you think `ovalutil` package is a good place for the code I added?

Thank you for your inputs!

Signed-off-by: Jan Zmeskal <jzmeskal@redhat.com>