### PR TITLE
python: update package scanner version

### DIFF
--- a/python/packagescanner.go
+++ b/python/packagescanner.go
@@ -39,7 +39,7 @@ type Scanner struct{}
 func (*Scanner) Name() string { return "python" }
 
 // Version implements scanner.VersionedScanner.
-func (*Scanner) Version() string { return "0.0.1" }
+func (*Scanner) Version() string { return "0.1.0" }
 
 // Kind implements scanner.VersionedScanner.
 func (*Scanner) Kind() string { return "package" }


### PR DESCRIPTION
This makes it so the changes in 2cef538 cause layers to get re-scanned
and re-matched.

Signed-off-by: Hank Donnay <hdonnay@redhat.com>