### PR TITLE
python: update package scanner version

### DIFF
--- a/python/packagescanner.go
+++ b/python/packagescanner.go
@@ -37,7 +37,7 @@ type Scanner struct{}
 func (*Scanner) Name() string { return "python" }
 
 // Version implements scanner.VersionedScanner.
-func (*Scanner) Version() string { return "0.0.1" }
+func (*Scanner) Version() string { return "0.1.0" }
 
 // Kind implements scanner.VersionedScanner.
 func (*Scanner) Kind() string { return "package" }


### PR DESCRIPTION
This makes it so the changes in 763ccdc cause layers to get re-scanned
and re-matched.

Backports #348.

Signed-off-by: Hank Donnay <hdonnay@redhat.com>