### PR TITLE
python: force re-fetch/parse

### DIFF
--- a/libvuln/migrations/migration3.go
+++ b/libvuln/migrations/migration3.go
@@ -1,0 +1,12 @@
+package migrations
+
+const (
+	// recent changes to the pyup updater were made.
+	// since pyup updates their sec-db slowly, this
+	// bumps out any existing fingerprint associated
+	// with the pyup sec-db and forces a re-fetch
+	// and re-download by the updater code.
+	migration3 = `
+UPDATE update_operation SET fingerprint = '' WHERE updater = 'pyupio';
+`
+)

--- a/libvuln/migrations/migrations.go
+++ b/libvuln/migrations/migrations.go
@@ -25,4 +25,11 @@ var Migrations = []migrate.Migration{
 			return err
 		},
 	},
+	{
+		ID: 3,
+		Up: func(tx *sql.Tx) error {
+			_, err := tx.Exec(migration3)
+			return err
+		},
+	},
 }


### PR DESCRIPTION
recent changes to the python updater were made but
pyup databse updates slowly.

this migration forces a re-fetch/parse of the pyup
database, fixing python matching in the upgrade path.

Signed-off-by: ldelossa <ldelossa@redhat.com>