### PR TITLE
Louis/backport 351

### DIFF
--- a/libvuln/migrations/migration2.go
+++ b/libvuln/migrations/migration2.go
@@ -1,0 +1,10 @@
+package migrations
+
+const (
+	migration2 = `
+CREATE INDEX ON update_operation (updater);
+CREATE INDEX ON vuln (updater);
+CREATE INDEX ON uo_vuln (vuln);
+CREATE INDEX ON uo_vuln (uo);
+`
+)

--- a/libvuln/migrations/migration3.go
+++ b/libvuln/migrations/migration3.go
@@ -1,0 +1,12 @@
+package migrations
+
+const (
+	// recent changes to the pyup updater were made.
+	// since pyup updates their sec-db slowly, this
+	// bumps out any existing fingerprint associated
+	// with the pyup sec-db and forces a re-fetch
+	// and re-download by the updater code.
+	migration3 = `
+UPDATE update_operation SET fingerprint = '' WHERE updater = 'pyupio';
+`
+)

--- a/libvuln/migrations/migrations.go
+++ b/libvuln/migrations/migrations.go
@@ -18,4 +18,11 @@ var Migrations = []migrate.Migration{
 			return err
 		},
 	},
+	{
+		ID: 2,
+		Up: func(tx *sql.Tx) error {
+			_, err := tx.Exec(migration2)
+			return err
+		},
+	},
 }

--- a/libvuln/migrations/migrations.go
+++ b/libvuln/migrations/migrations.go
@@ -25,4 +25,11 @@ var Migrations = []migrate.Migration{
 			return err
 		},
 	},
+	{
+		ID: 3,
+		Up: func(tx *sql.Tx) error {
+			_, err := tx.Exec(migration3)
+			return err
+		},
+	},
 }


### PR DESCRIPTION
This backports #351.

It was necessary to pull in "migration2.go" from commit: 78564563897a3f1573987ae05fb6ecb6539abe57 in order to not break the pending upgrade path from Clair 4.0 -> Clair 4.1