### PR TITLE
cicd: update doc building to main

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,10 +1,10 @@
 ---
-name: Deploy Master
+name: Deploy Main
 
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   deploy-documentation:


### PR DESCRIPTION
updates the gh action for building docs to
fire on pushes to main instead of master.

necessary due to master -> main rename done on this date.

Signed-off-by: ldelossa <ldelossa@redhat.com>