### PR TITLE
matcher: add ability to return multiple matchers from a factory

### DIFF
--- a/crda/matcherfactory.go
+++ b/crda/matcherfactory.go
@@ -2,6 +2,7 @@ package crda
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/url"
 
@@ -14,22 +15,49 @@ import (
 
 // Factory contains the configuration to connect with CRDA remote matcher.
 type Factory struct {
-	url    *url.URL
-	client *http.Client
+	url        *url.URL
+	client     *http.Client
+	ecosystems []string
 }
 
 // MatcherFactory implements driver.MatcherFactory.
-func (f *Factory) Matcher(ctx context.Context) (driver.Matcher, error) {
-	m, err := NewMatcher(WithClient(f.client), WithURL(f.url))
-	if err != nil {
-		return nil, err
+func (f *Factory) Matcher(ctx context.Context) ([]driver.Matcher, error) {
+	ctx = baggage.ContextWithValues(ctx,
+		label.String("component", "crda/MatcherFactory.Matcher"))
+EcosystemSubSet:
+	for _, e := range f.ecosystems {
+		for _, se := range supportedEcosystems {
+			if e == se {
+				continue EcosystemSubSet
+			}
+		}
+		return nil, fmt.Errorf("invalid ecosystems:%#v", f.ecosystems)
 	}
-	return m, nil
+
+	if len(f.ecosystems) > 0 {
+		zlog.Info(ctx).
+			Msg("using configured ecosystems")
+	} else {
+		f.ecosystems = supportedEcosystems
+		zlog.Info(ctx).
+			Msg("using default ecosystems")
+	}
+
+	var matchers []driver.Matcher
+	for _, e := range f.ecosystems {
+		m, err := NewMatcher(e, WithClient(f.client), WithURL(f.url))
+		if err != nil {
+			return nil, err
+		}
+		matchers = append(matchers, m)
+	}
+	return matchers, nil
 }
 
 // To decode the config.
 type FactoryConfig struct {
-	URL string `json:"url" yaml:"url"`
+	URL        string   `json:"url" yaml:"url"`
+	Ecosystems []string `json:"ecosystems" yaml:"ecosystems"`
 }
 
 // MatcherFactory implements driver.MatcherConfigurable.
@@ -59,6 +87,6 @@ func (f *Factory) Configure(ctx context.Context, cfg driver.MatcherConfigUnmarsh
 			Msg("configured HTTP client")
 		f.client = c
 	}
-
+	f.ecosystems = fc.Ecosystems
 	return nil
 }

--- a/crda/remotematcher_test.go
+++ b/crda/remotematcher_test.go
@@ -50,7 +50,7 @@ type matcherTestcase struct {
 
 func newMatcher(t *testing.T, srv *httptest.Server) *Matcher {
 	url, _ := url.Parse(srv.URL)
-	m, err := NewMatcher(WithClient(srv.Client()), WithURL(url))
+	m, err := NewMatcher("pypi", WithClient(srv.Client()), WithURL(url))
 	if err != nil {
 		t.Errorf("there should be no err %v", err)
 	}

--- a/libvuln/driver/matcherfactory.go
+++ b/libvuln/driver/matcherfactory.go
@@ -8,7 +8,7 @@ import (
 
 // MatcherFactory is used to construct matchers at run-time.
 type MatcherFactory interface {
-	Matcher(context.Context) (Matcher, error)
+	Matcher(context.Context) ([]Matcher, error)
 }
 
 // MatcherConfigUnmarshaler can be thought of as an Unmarshal function with the byte
@@ -26,15 +26,15 @@ type MatcherConfigurable interface {
 
 // MatcherFactoryFunc would ease the registration of Matchers which don't
 // need Configurability.
-type MatcherFactoryFunc func(context.Context) (Matcher, error)
+type MatcherFactoryFunc func(context.Context) ([]Matcher, error)
 
-func (u MatcherFactoryFunc) Matcher(ctx context.Context) (Matcher, error) {
+func (u MatcherFactoryFunc) Matcher(ctx context.Context) ([]Matcher, error) {
 	return u(ctx)
 }
 
 // MatcherStatic creates an MatcherFactoryFunc returning the provided matcher.
 func MatcherStatic(s Matcher) MatcherFactory {
-	return MatcherFactoryFunc(func(_ context.Context) (Matcher, error) {
-		return s, nil
+	return MatcherFactoryFunc(func(_ context.Context) ([]Matcher, error) {
+		return []Matcher{s}, nil
 	})
 }

--- a/matchers/matchers.go
+++ b/matchers/matchers.go
@@ -63,7 +63,7 @@ func NewMatchers(ctx context.Context, client *http.Client, opts ...MatchersOptio
 			zlog.Error(ctx).Err(err).Msg("failed constructing factory, excluding from run")
 			continue
 		}
-		matchers = append(matchers, matcher)
+		matchers = append(matchers, matcher...)
 	}
 
 	// merge default matchers with any out-of-tree specified.


### PR DESCRIPTION
This PR adds the ability to return multiple matchers from single matcherfactory.

Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>