### PR TITLE
[WIP] Bounded concurrency affected manifests

### DIFF
--- a/libindex/libindex.go
+++ b/libindex/libindex.go
@@ -178,8 +178,7 @@ func (l *Libindex) IndexReport(ctx context.Context, hash claircore.Digest) (*cla
 
 // AffectedManifests retrieves a list of affected manifests when provided a list of vulnerabilities.
 func (l *Libindex) AffectedManifests(ctx context.Context, vulns []claircore.Vulnerability) (*claircore.AffectedManifests, error) {
-	// This concurrency number could be another opt for Libindex
-	sem := semaphore.NewWeighted(50)
+	sem := semaphore.NewWeighted(20)
 	ctx = baggage.ContextWithValues(ctx,
 		label.String("component", "libindex/Libindex.AffectedManifests"))
 

--- a/libindex/libindex.go
+++ b/libindex/libindex.go
@@ -178,6 +178,7 @@ func (l *Libindex) IndexReport(ctx context.Context, hash claircore.Digest) (*cla
 
 // AffectedManifests retrieves a list of affected manifests when provided a list of vulnerabilities.
 func (l *Libindex) AffectedManifests(ctx context.Context, vulns []claircore.Vulnerability) (*claircore.AffectedManifests, error) {
+	// This concurrency number could be another opt for Libindex
 	sem := semaphore.NewWeighted(50)
 	ctx = baggage.ContextWithValues(ctx,
 		label.String("component", "libindex/Libindex.AffectedManifests"))

--- a/libindex/libindex_test.go
+++ b/libindex/libindex_test.go
@@ -1,0 +1,104 @@
+package libindex
+
+import (
+	"context"
+	"crypto/sha256"
+	"io"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/quay/claircore"
+	"github.com/quay/claircore/internal/indexer"
+	"github.com/quay/zlog"
+)
+
+var testVulns = []claircore.Vulnerability{
+	{
+		ID:                 "123",
+		Name:               "CVE-2018-20187",
+		Links:              "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-20187",
+		Updater:            "alpine-community-v3.10-updater",
+		FixedInVersion:     "2.9.0-r0",
+		NormalizedSeverity: claircore.Unknown,
+		Package: &claircore.Package{
+			Name: "botan",
+			Kind: claircore.BINARY,
+		},
+	},
+	{
+		ID:                 "456",
+		Name:               "CVE-2018-12435",
+		Links:              "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12435",
+		Updater:            "alpine-community-v3.10-updater",
+		FixedInVersion:     "2.7.0-r0",
+		NormalizedSeverity: claircore.Unknown,
+		Package: &claircore.Package{
+			Name: "botan",
+			Kind: claircore.BINARY,
+		},
+	},
+}
+
+func digest(inp string) claircore.Digest {
+	h := sha256.New()
+	io.WriteString(h, inp)
+	d, err := claircore.NewDigest("sha256", h.Sum(nil))
+	if err != nil {
+		panic(err)
+	}
+	return d
+}
+
+func TestAffectedManifests(t *testing.T) {
+	ctx, done := context.WithCancel(context.Background())
+	defer done()
+	var tt = []struct {
+		name                 string
+		inputVulns           []claircore.Vulnerability
+		numExpectedVulns     int
+		numExpectedManifests int
+		err                  bool
+		mockStore            func(t *testing.T) indexer.Store
+	}{
+		{
+			name:                 "Simple path",
+			inputVulns:           testVulns,
+			numExpectedVulns:     2,
+			numExpectedManifests: 2,
+			mockStore: func(t *testing.T) indexer.Store {
+				ctrl := gomock.NewController(t)
+				s := indexer.NewMockStore(ctrl)
+				s.EXPECT().AffectedManifests(gomock.Any(), gomock.Any()).Return(
+					[]claircore.Digest{
+						digest("first digest"),
+						digest("second digest"),
+					},
+					nil,
+				).MaxTimes(2)
+				return s
+			},
+		},
+	}
+
+	for _, table := range tt {
+		t.Run(table.name, func(t *testing.T) {
+			ctx, done := context.WithCancel(ctx)
+			defer done()
+			ctx = zlog.Test(ctx, t)
+			s := table.mockStore(t)
+			li := &Libindex{store: s}
+
+			affected, err := li.AffectedManifests(ctx, table.inputVulns)
+			if (err == nil) == table.err {
+				t.Fatalf("did not expect error: %v", err)
+			}
+
+			if table.numExpectedVulns != len(affected.Vulnerabilities) {
+				t.Fatalf("got: %d vulnerabilities, want: %d", len(affected.Vulnerabilities), table.numExpectedVulns)
+			}
+			if table.numExpectedManifests != len(affected.Vulnerabilities) {
+				t.Fatalf("got: %d vulnerabilities, want: %d", len(affected.Vulnerabilities), table.numExpectedManifests)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This concurrency pattern may help with DB load, particularly burst load. Instead of starting 100 goroutines, waiting for them to all finish, then firing off 100 more, this change will block creating new goroutines until a currently running one has returned. 

This means you aren't waiting for the slowest routine in every 100. In this case, where it's a DB lookup with the same query, all the routines probably complete within a similar time bound, but it may help spread the DB load rather than being spikey.

TODO
- [x] Find a good way to benchmark
- [x] Clean up tests
- [x] Find a good concurrency number
- [x] Discuss concurrency number as opt (as the pg instance is variable depending on deployment)