### PR TITLE
testing: maxConns to 10

### DIFF
--- a/test/integration/db.go
+++ b/test/integration/db.go
@@ -75,7 +75,7 @@ func NewDB(ctx context.Context, t testing.TB) (*DB, error) {
 		return nil, err
 	}
 	cfg.ConnConfig.Logger = testingadapter.NewLogger(t)
-
+	cfg.MaxConns = 10
 	dbid, roleid := mkIDs()
 	database := fmt.Sprintf("db%x", dbid)
 	role := fmt.Sprintf("role%x", roleid)


### PR DESCRIPTION
When running integration tests locally, acquiring the advisory locks will exhaust the `maxConns`, meaning any subsequent DB transactions will hang. Here are the relevant rows from Postgres pg_stat_activity:

```
db5a7e55f57007bc0e=> SELECT 
    pid               
    ,datname
    ,usename
    ,application_name
    ,client_hostname
    ,client_port
    ,backend_start
    ,query_start
    ,query
    ,state
FROM pg_stat_activity
WHERE state = 'idle in transaction';
  pid  |      datname       |       usename       | application_name | client_hostname | client_port |         backend_start         |          query_start          |                 query                 |        state        
-------+--------------------+---------------------+------------------+-----------------+-------------+-------------------------------+-------------------------------+---------------------------------------+---------------------
 21449 | dbcc21b635b66f982e | role9c5b7aaec85b38a |                  |                 |       53084 | 2021-04-19 19:35:02.284117+00 | 2021-04-19 19:35:02.288358+00 | SELECT pg_try_advisory_xact_lock($1); | idle in transaction
 21447 | dbcc21b635b66f982e | role9c5b7aaec85b38a |                  |                 |       53078 | 2021-04-19 19:35:02.283606+00 | 2021-04-19 19:35:02.288383+00 | SELECT pg_try_advisory_xact_lock($1); | idle in transaction
 21448 | dbcc21b635b66f982e | role9c5b7aaec85b38a |                  |                 |       53080 | 2021-04-19 19:35:02.283674+00 | 2021-04-19 19:35:02.288832+00 | SELECT pg_try_advisory_xact_lock($1); | idle in transaction
 21445 | dbcc21b635b66f982e | role9c5b7aaec85b38a |                  |                 |       53066 | 2021-04-19 19:35:02.228804+00 | 2021-04-19 19:35:02.283749+00 | SELECT pg_try_advisory_xact_lock($1); | idle in transaction
```

As has been mentioned; pgx will default to 4 for maxConns (`var defaultMaxConns = int32(4)`), so why the hell does the CI work?

```go
		config.MaxConns = defaultMaxConns
		if numCPU := int32(runtime.NumCPU()); numCPU > config.MaxConns {
			config.MaxConns = numCPU
		}
```
I'm guessing the box running the CI is bigger than my lowly box. This hypothesis could be completely wrong if other people are running the tests fine with 4 or less cores.

Signed-off-by: crozzy <joseph.crosland@gmail.com>