### PR TITLE
cpe: JSON marshaling breaking API contract

### DIFF
--- a/pkg/cpe/json.go
+++ b/pkg/cpe/json.go
@@ -7,7 +7,7 @@ func (w *WFN) MarshalText() ([]byte, error) {
 	switch err := w.Valid(); {
 	case err == nil:
 	case errors.Is(err, ErrUnset):
-		return nil, nil
+		return []byte(""), nil
 	default:
 		return nil, err
 	}


### PR DESCRIPTION
when Quay parses the vulnerability_report it's possible that
the cpe field is null due to returning a nil byte slice from
the MarshalText function and it seems the github.com/ugorji/go/codec
library will interpret that as null as opposed to `""`.

The standard encoding/json lib has different behavior https://play.golang.org/p/0fBCtlt_5R4.

Without this change I am seeing this error:
```
gunicorn-web stdout | 2021-04-23 12:10:42,911 [284] [DEBUG] [urllib3.connectionpool] http://clair-traefik:6060 "GET /matcher/api/v1/vulnerability_report/sha256:384ae1b1718ddf42c1db7cf35a3c53b599ef5f14a05b707b8f214f5bae212254 HTTP/1.1" 200 None
gunicorn-web stdout | 2021-04-23 12:10:42,977 [284] [ERROR] [util.secscan.v4.api] Security scanner response failed OpenAPI validation
gunicorn-web stdout | Traceback (most recent call last):
gunicorn-web stdout |   File "/quay-registry/util/secscan/v4/api.py", line 336, in is_valid_response
gunicorn-web stdout |     validate(resp.json(), schema, resolver=resolver)
gunicorn-web stdout |   File "/usr/local/lib/python3.6/site-packages/jsonschema/validators.py", line 934, in validate
gunicorn-web stdout |     raise error
gunicorn-web stdout | jsonschema.exceptions.ValidationError: None is not of type 'string'
gunicorn-web stdout | Failed validating 'type' in schema['properties']['vulnerabilities']['additionalProperties']['properties']['distribution']['properties']['cpe']:
gunicorn-web stdout |     {'type': 'string'}
gunicorn-web stdout | On instance['vulnerabilities']['31079']['distribution']['cpe']:
```

It's possible there is a nicer way to solve this with struct tags or something, but I'm not sure of it.

TODO:

- [ ]  check valid issue
- [ ] tests

Signed-off-by: crozzy <joseph.crosland@gmail.com>