### PR TITLE
all: return empty byte slices from MarshalText

### DIFF
--- a/pkg/cpe/json.go
+++ b/pkg/cpe/json.go
@@ -7,7 +7,7 @@ func (w *WFN) MarshalText() ([]byte, error) {
 	switch err := w.Valid(); {
 	case err == nil:
 	case errors.Is(err, ErrUnset):
-		return nil, nil
+		return []byte{}, nil
 	default:
 		return nil, err
 	}

--- a/version.go
+++ b/version.go
@@ -24,7 +24,7 @@ func VersionSort(vs []Version) func(int, int) bool {
 // MarshalText implments encoding.TextMarshaler.
 func (v *Version) MarshalText() ([]byte, error) {
 	if v.Kind == "" {
-		return nil, nil
+		return []byte{}, nil
 	}
 	var buf bytes.Buffer
 	b := make([]byte, 0, 16) // 16 byte wide scratch buffer


### PR DESCRIPTION
Here's a short test program to prove the change does the right thing:
https://play.golang.org/p/wM6S9H83E2v

Fixes [PROJQUAY-1918](https://issues.redhat.com/browse/PROJQUAY-1918).