### PR TITLE
vulnstore: enrichment migration backport

### DIFF
--- a/libvuln/migrations/migration4.go
+++ b/libvuln/migrations/migration4.go
@@ -1,0 +1,38 @@
+package migrations
+
+const (
+	// this migration modifies the database to support
+	// enrichments.
+	// see: https://github.com/quay/clair-enrichment-spec
+	migration4 = `
+ALTER TABLE update_operation
+    ADD COLUMN kind text;
+CREATE INDEX on update_operation (kind);
+
+UPDATE update_operation
+SET kind = 'vulnerability';
+
+CREATE TABLE enrichment
+(
+    id        BIGSERIAL PRIMARY KEY,
+    hash_kind text,
+    hash      bytea,
+    updater   text,
+    tags      text[],
+    data      jsonb
+);
+CREATE UNIQUE INDEX ON enrichment (hash_kind, hash);
+-- use inverted index for tags index
+CREATE INDEX ON enrichment USING gin (tags);
+
+CREATE TABLE uo_enrich
+(
+    uo          BIGINT REFERENCES update_operation (id),
+    enrich      BIGINT REFERENCES enrichment (id),
+    updater     text,
+    fingerprint text,
+    date        timestamptz,
+    PRIMARY KEY (uo, enrich)
+);
+`
+)

--- a/libvuln/migrations/migrations.go
+++ b/libvuln/migrations/migrations.go
@@ -32,4 +32,11 @@ var Migrations = []migrate.Migration{
 			return err
 		},
 	},
+	{
+		ID: 4,
+		Up: func(tx *sql.Tx) error {
+			_, err := tx.Exec(migration4)
+			return err
+		},
+	},
 }


### PR DESCRIPTION
This commit adds the necessary migration to support the Enrichment feature
per out specification: https://github.com/quay/clair-enrichment-spec/

Backports: bfafd2f7ad2b4d4b33fb0ab644bb09191d42732c
Signed-off-by: ldelossa <ldelossa@redhat.com>
Signed-off-by: Hank Donnay <hdonnay@redhat.com>