### PR TITLE
cicd: use golang major version tag for dev env

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,7 +27,7 @@ services:
       start_period: 10s
 
   libindexhttp:
-    image: quay.io/projectquay/golang:1.15.2
+    image: quay.io/projectquay/golang:1.15
     container_name: libindexhttp
     ports:
       - "8080:8080"
@@ -43,7 +43,7 @@ services:
       [ "bash", "-c", "cd /src/claircore/cmd/libindexhttp; go run -mod vendor ." ]
 
   libvulnhttp:
-    image: quay.io/projectquay/golang:1.15.2
+    image: quay.io/projectquay/golang:1.15
     container_name: libvulnhttp
     ports:
       - "8081:8081"


### PR DESCRIPTION
Signed-off-by: Jan Zmeskal <jzmeskal@redhat.com>