### PR TITLE
all: use GOMAXPROCS instead of NumCPU

### DIFF
--- a/internal/indexer/layerscanner/layerscanner.go
+++ b/internal/indexer/layerscanner/layerscanner.go
@@ -42,7 +42,7 @@ func New(ctx context.Context, concurrent int, opts *indexer.Opts) (indexer.Layer
 			Msg("rectifying nonsense 'concurrent' argument")
 		fallthrough
 	case concurrent == 0:
-		concurrent = runtime.NumCPU()
+		concurrent = runtime.GOMAXPROCS(0)
 	}
 
 	ps, ds, rs, err := indexer.EcosystemsToScanners(ctx, opts.Ecosystems, opts.Airgap)

--- a/internal/vulnstore/postgres/gc.go
+++ b/internal/vulnstore/postgres/gc.go
@@ -77,8 +77,8 @@ func (s *Store) GC(ctx context.Context, keep int) (int64, error) {
 	}
 
 	// issue concurrent chunked deletion for known updaters
-	// limit concurrency by available CPUs.
-	cpus := int64(runtime.NumCPU())
+	// limit concurrency by available goroutines.
+	cpus := int64(runtime.GOMAXPROCS(0))
 	sem := semaphore.NewWeighted(cpus)
 
 	errC := make(chan error, len(updaters))

--- a/libvuln/updates/manager.go
+++ b/libvuln/updates/manager.go
@@ -25,7 +25,7 @@ const (
 )
 
 var (
-	DefaultBatchSize = runtime.NumCPU()
+	DefaultBatchSize = runtime.GOMAXPROCS(0)
 )
 
 type Configs map[string]driver.ConfigUnmarshaler
@@ -71,7 +71,7 @@ func NewManager(ctx context.Context, store vulnstore.Updater, locks LockSource, 
 		store:     store,
 		locks:     locks,
 		factories: updater.Registered(),
-		batchSize: DefaultBatchSize,
+		batchSize: runtime.GOMAXPROCS(0),
 		interval:  DefaultInterval,
 		client:    client,
 	}

--- a/ubuntu/updaterset.go
+++ b/ubuntu/updaterset.go
@@ -72,7 +72,7 @@ func (f *Factory) UpdaterSet(ctx context.Context) (driver.UpdaterSet, error) {
 	us := make([]*Updater, len(f.Releases))
 	ch := make(chan int, len(f.Releases))
 	var wg sync.WaitGroup
-	for i, lim := 0, runtime.NumCPU(); i < lim; i++ {
+	for i, lim := 0, runtime.GOMAXPROCS(0); i < lim; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()


### PR DESCRIPTION
When running directly on an OS, these values will be the same. But in
containerized environments, the number of CPUs reported is the number on
the host, not the number allocated. Using the GOMAXPROCS means the
container orchestrator can configure things such that the go runtime is
less likely to constantly blow its cpu quota.