### PR TITLE
dpkg: fix path handling

### DIFF
--- a/dpkg/scanner.go
+++ b/dpkg/scanner.go
@@ -124,7 +124,8 @@ Find:
 		var db io.Reader
 		var h *tar.Header
 		for h, err = tr.Next(); err == nil; h, err = tr.Next() {
-			if h.Name == fn {
+			// The location from above is cleaned, so make sure to do that.
+			if c := filepath.Clean(h.Name); c == fn {
 				db = tr
 				break
 			}

--- a/test/fetch/layer.go
+++ b/test/fetch/layer.go
@@ -27,6 +27,7 @@ const (
 var registry = map[string]*client{
 	"docker.io": &client{Root: "https://registry-1.docker.io/"},
 	"quay.io":   &client{Root: "https://quay.io/"},
+	"gcr.io":    &client{Root: "https://gcr.io/"},
 }
 
 func Layer(ctx context.Context, t *testing.T, c *http.Client, from, repo string, blob claircore.Digest) (*os.File, error) {


### PR DESCRIPTION
This fixes a bug reported via #381 where paths weren't normalized the
same way after reading the names from the tar header.

Closes #381.

Signed-off-by: Hank Donnay <hdonnay@redhat.com>