### PR TITLE
v0.1 backport: dpkg: fix path handling

### DIFF
--- a/dpkg/scanner.go
+++ b/dpkg/scanner.go
@@ -126,7 +126,8 @@ Find:
 		var db io.Reader
 		var h *tar.Header
 		for h, err = tr.Next(); err == nil; h, err = tr.Next() {
-			if h.Name == fn {
+			// The location from above is cleaned, so make sure to do that.
+			if c := filepath.Clean(h.Name); c == fn {
 				db = tr
 				break
 			}


### PR DESCRIPTION
This fixes a bug reported via #381 where paths weren't normalized the
same way after reading the names from the tar header.

This backports #402 without the accompanying test, due to fetcher
changes.

Signed-off-by: Hank Donnay <hdonnay@redhat.com>