### PR TITLE
java: ignore whiteout files

### DIFF
--- a/java/common.go
+++ b/java/common.go
@@ -1,0 +1,36 @@
+package java
+
+import (
+	"archive/tar"
+	"context"
+	"path"
+	"strings"
+
+	"github.com/quay/zlog"
+)
+
+// IsArchive reports whether the file described by the passed tar.Header is some
+// form of Java archive.
+//
+// Assumes slash-separated paths.
+func isArchive(ctx context.Context, h *tar.Header) bool {
+	base := path.Base(h.Name)
+Outer:
+	switch {
+	case h.Typeflag != tar.TypeReg:
+	case strings.HasPrefix(base, ".wh."):
+	default:
+		switch ext := path.Ext(base); ext {
+		case ".jar":
+			zlog.Debug(ctx).Str("file", h.Name).Msg("found jar")
+		case ".war":
+			zlog.Debug(ctx).Str("file", h.Name).Msg("found war")
+		case ".ear":
+			zlog.Debug(ctx).Str("file", h.Name).Msg("found ear")
+		default:
+			break Outer
+		}
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
As described in the OCI image [spec][1], whiteout files are used to
indicate file or directory removals. The jar scanner was not considering
file prefixes and instead only looking at the suffixes.

[1]: https://github.com/opencontainers/image-spec/blob/master/layer.md#representing-changes
