### PR TITLE
postgres: fix query in GetLatestUpdateRefs

### DIFF
--- a/internal/vulnstore/postgres/getupdateoperations.go
+++ b/internal/vulnstore/postgres/getupdateoperations.go
@@ -113,7 +113,7 @@ func (s *Store) GetLatestUpdateRefs(ctx context.Context, kind driver.UpdateKind)
 	const (
 		query              = `SELECT DISTINCT ON (updater) updater, ref, fingerprint, date FROM update_operation ORDER BY updater, id USING >;`
 		queryEnrichment    = `SELECT DISTINCT ON (updater) updater, ref, fingerprint, date FROM update_operation WHERE kind = 'enrichment' ORDER BY updater, id USING >;`
-		queryVulnerability = `SELECT DISTINCT ON (updater) updater, ref, fingerprint, date FROM update_operation WHERE kind = 'enrichment' ORDER BY updater, id USING >;`
+		queryVulnerability = `SELECT DISTINCT ON (updater) updater, ref, fingerprint, date FROM update_operation WHERE kind = 'vulnerability' ORDER BY updater, id USING >;`
 	)
 
 	var q string


### PR DESCRIPTION
This commit fixes query in GetLatestUpdateRefs which instead of
vulnerabilities was looking for enrichments.

Signed-off-by: Jakub Vulgan <jvulgan@redhat.com>