### PR TITLE
dpkg: replace go-dpkg dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,6 @@ require (
 	github.com/quay/zlog v0.0.0-20210113185248-ce16eed1dcec
 	github.com/remind101/migrate v0.0.0-20170729031349-52c1edff7319
 	github.com/rs/zerolog v1.20.0
-	github.com/tadasv/go-dpkg v0.0.0-20160704224136-c2cf9188b763
 	github.com/ulikunitz/xz v0.5.7
 	go.opentelemetry.io/otel v0.15.0
 	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a

--- a/go.sum
+++ b/go.sum
@@ -559,8 +559,6 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
-github.com/tadasv/go-dpkg v0.0.0-20160704224136-c2cf9188b763 h1:9+CrSWP3mpB6e6sxXU5o/RIrf1A2DV/sOg9Cb9/+XNs=
-github.com/tadasv/go-dpkg v0.0.0-20160704224136-c2cf9188b763/go.mod h1:F1AdFgT4EQYvMcvrrWTQuX/25WmY7JCOs1Zxf0LevSw=
 github.com/temoto/robotstxt v1.1.1/go.mod h1:+1AmkuG3IYkh1kv0d2qEB9Le88ehNO0zwOr3ujewlOo=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=


### PR DESCRIPTION
The package github.com/tadasv/go-dpkg was used in the dpkg package, and
it went unnoticed that it doesn't have a valid license. This removes it
and replaces the functionality.

Signed-off-by: Hank Donnay <hdonnay@redhat.com>