### PR TITLE
crda: remote matcher with new crda api, source, and key

### DIFF
--- a/crda/matcherfactory.go
+++ b/crda/matcherfactory.go
@@ -1,0 +1,92 @@
+package crda
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/quay/zlog"
+	"go.opentelemetry.io/otel/baggage"
+	"go.opentelemetry.io/otel/label"
+
+	"github.com/quay/claircore/libvuln/driver"
+)
+
+// Factory contains the configuration to connect with CRDA remote matcher.
+type Factory struct {
+	url        *url.URL
+	client     *http.Client
+	ecosystems []string
+}
+
+// MatcherFactory implements driver.MatcherFactory.
+func (f *Factory) Matcher(ctx context.Context) ([]driver.Matcher, error) {
+	ctx = baggage.ContextWithValues(ctx,
+		label.String("component", "crda/MatcherFactory.Matcher"))
+EcosystemSubSet:
+	for _, e := range f.ecosystems {
+		for _, se := range supportedEcosystems {
+			if e == se {
+				continue EcosystemSubSet
+			}
+		}
+		return nil, fmt.Errorf("invalid ecosystems:%#v", f.ecosystems)
+	}
+
+	if len(f.ecosystems) > 0 {
+		zlog.Info(ctx).
+			Msg("using configured ecosystems")
+	} else {
+		f.ecosystems = supportedEcosystems
+		zlog.Info(ctx).
+			Msg("using default ecosystems")
+	}
+
+	var matchers []driver.Matcher
+	for _, e := range f.ecosystems {
+		m, err := NewMatcher(e, WithClient(f.client), WithURL(f.url))
+		if err != nil {
+			return nil, err
+		}
+		matchers = append(matchers, m)
+	}
+	return matchers, nil
+}
+
+// To decode the config.
+type FactoryConfig struct {
+	URL        string   `json:"url" yaml:"url"`
+	Ecosystems []string `json:"ecosystems" yaml:"ecosystems"`
+}
+
+// MatcherFactory implements driver.MatcherConfigurable.
+func (f *Factory) Configure(ctx context.Context, cfg driver.MatcherConfigUnmarshaler, c *http.Client) error {
+	ctx = baggage.ContextWithValues(ctx,
+		label.String("component", "crda/MatcherFactory.Configure"))
+	var fc FactoryConfig
+
+	if err := cfg(&fc); err != nil {
+		return err
+	}
+	zlog.Debug(ctx).Msg("loaded incoming config")
+
+	if fc.URL != "" {
+		u, err := url.Parse(fc.URL)
+		if err != nil {
+			return err
+		}
+		zlog.Info(ctx).
+			Str("url", u.String()).
+			Msg("configured manifest URL")
+		f.url = u
+	}
+
+	if c != nil {
+		zlog.Info(ctx).
+			Msg("configured HTTP client")
+		f.client = c
+	}
+	f.ecosystems = fc.Ecosystems
+	return nil
+}

--- a/crda/matcherfactory.go
+++ b/crda/matcherfactory.go
@@ -18,6 +18,8 @@ type Factory struct {
 	url        *url.URL
 	client     *http.Client
 	ecosystems []string
+	source     string
+	key        string
 }
 
 // MatcherFactory implements driver.MatcherFactory.
@@ -45,7 +47,7 @@ EcosystemSubSet:
 
 	var matchers []driver.Matcher
 	for _, e := range f.ecosystems {
-		m, err := NewMatcher(e, WithClient(f.client), WithURL(f.url))
+		m, err := NewMatcher(e, WithClient(f.client), WithURL(f.url), WithKey(f.key), WithSource(f.source))
 		if err != nil {
 			return nil, err
 		}
@@ -58,6 +60,8 @@ EcosystemSubSet:
 type FactoryConfig struct {
 	URL        string   `json:"url" yaml:"url"`
 	Ecosystems []string `json:"ecosystems" yaml:"ecosystems"`
+	Source     string   `json:"source" yaml:"source"`
+	Key        string   `json:"key" yaml:"key"`
 }
 
 // MatcherFactory implements driver.MatcherConfigurable.
@@ -78,13 +82,25 @@ func (f *Factory) Configure(ctx context.Context, cfg driver.MatcherConfigUnmarsh
 		}
 		zlog.Info(ctx).
 			Str("url", u.String()).
-			Msg("configured manifest URL")
+			Msg("configured API URL")
 		f.url = u
 	}
 
-	if c != nil {
+	if fc.Source != "" {
+		f.source = fc.Source
 		zlog.Info(ctx).
-			Msg("configured HTTP client")
+			Str("source", fc.Source).
+			Msg("configured source")
+	}
+
+	if fc.Key != "" {
+		f.key = fc.Key
+		zlog.Info(ctx).
+			Str("key", f.key).
+			Msg("configured API key")
+	}
+
+	if c != nil {
 		f.client = c
 	}
 	f.ecosystems = fc.Ecosystems

--- a/crda/normalizeseverity.go
+++ b/crda/normalizeseverity.go
@@ -1,0 +1,28 @@
+package crda
+
+import "github.com/quay/claircore"
+
+const (
+	Low       = "low"
+	Medium    = "medium"
+	High      = "high"
+	Critical  = "critical"
+)
+
+// NormalizeSeverity takes a string[1] and normalizes it to
+// a claircore.Severity.
+// [1] https://github.com/fabric8-analytics/fabric8-analytics-server/blob/master/api_specs/v2/stack_analyses.yaml#L178
+func NormalizeSeverity(severity string) claircore.Severity {
+	switch severity {
+	case Low:
+		return claircore.Low
+	case Medium:
+		return claircore.Medium
+	case High:
+		return claircore.High
+	case Critical:
+		return claircore.Critical
+	default:
+		return claircore.Unknown
+	}
+}

--- a/crda/normalizeseverity.go
+++ b/crda/normalizeseverity.go
@@ -3,16 +3,16 @@ package crda
 import "github.com/quay/claircore"
 
 const (
-	Low       = "low"
-	Medium    = "medium"
-	High      = "high"
-	Critical  = "critical"
+	Low      = "low"
+	Medium   = "medium"
+	High     = "high"
+	Critical = "critical"
 )
 
 // NormalizeSeverity takes a string[1] and normalizes it to
 // a claircore.Severity.
 // [1] https://github.com/fabric8-analytics/fabric8-analytics-server/blob/master/api_specs/v2/stack_analyses.yaml#L178
-func NormalizeSeverity(severity string) claircore.Severity {
+func normalizeSeverity(severity string) claircore.Severity {
 	switch severity {
 	case Low:
 		return claircore.Low

--- a/crda/remotematcher.go
+++ b/crda/remotematcher.go
@@ -1,0 +1,361 @@
+package crda
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/quay/zlog"
+	"go.opentelemetry.io/otel/baggage"
+	"go.opentelemetry.io/otel/label"
+
+	"github.com/quay/claircore"
+	"github.com/quay/claircore/libvuln/driver"
+)
+
+var (
+	_ driver.Matcher             = (*Matcher)(nil)
+	_ driver.RemoteMatcher       = (*Matcher)(nil)
+	_ driver.MatcherConfigurable = (*Matcher)(nil)
+)
+
+const (
+	// Bounded concurrency limit.
+	defaultBatchSize          = 100
+	defaultEndPoint           = "/api/v2/component-analyses"
+	defaultRequestConcurrency = 10
+	defaultURL                = "https://f8a-analytics-2445582058137.production.gw.apicast.io/?user_key=9e7da76708fe374d8c10fa752e72989f"
+)
+
+var (
+	supportedEcosystems = []string{"pypi", "maven"}
+)
+
+// Matcher attempts to correlate discovered python packages with reported
+// vulnerabilities.
+type Matcher struct {
+	batchSize          int
+	client             *http.Client
+	ecosystem          string
+	requestConcurrency int
+	url                *url.URL
+}
+
+// Build struct to model CRDA V2 ComponentAnalysis response which
+// delivers Snyk sourced Vulnerability information.
+type Vulnerability struct {
+	ID       string   `json:"id"`
+	CVSS     string   `json:"cvss"`
+	CVES     []string `json:"cve_ids"`
+	Severity string   `json:"severity"`
+	Title    string   `json:"title"`
+	URL      string   `json:"url"`
+	FixedIn  []string `json:"fixed_in"`
+}
+
+type VulnReport struct {
+	Name               string          `json:"package"`
+	Version            string          `json:"version"`
+	RecommendedVersion string          `json:"recommended_versions"`
+	Message            string          `json:"message"`
+	Vulnerabilities    []Vulnerability `json:"vulnerability"`
+}
+
+// Request model.
+type Package struct {
+	Name    string `json:"package"`
+	Version string `json:"version"`
+}
+
+type VulnRequest struct {
+	Ecosystem string    `json:"ecosystem"`
+	Packages  []Package `json:"package_versions"`
+}
+
+// Option controls the configuration of a Matcher.
+type Option func(*Matcher) error
+
+// NewMatcher returns a configured Matcher or reports an error.
+func NewMatcher(ecosystem string, opt ...Option) (*Matcher, error) {
+	if ecosystem == "" {
+		return nil, fmt.Errorf("empty ecosystem")
+	}
+	m := Matcher{ecosystem: ecosystem}
+
+	for _, f := range opt {
+		if err := f(&m); err != nil {
+			return nil, err
+		}
+	}
+
+	if m.url == nil {
+		var err error
+		m.url, err = url.Parse(defaultURL)
+		if err != nil {
+			return nil, err
+		}
+
+	}
+	m.url = &url.URL{
+		Scheme:   m.url.Scheme,
+		Host:     m.url.Host,
+		Path:     defaultEndPoint,
+		RawQuery: m.url.RawQuery,
+	}
+
+	if m.client == nil {
+		m.client = http.DefaultClient // TODO(hank) Remove DefaultClient
+	}
+
+	// defaults to a sane concurrency limit.
+	if m.requestConcurrency < 1 {
+		m.requestConcurrency = defaultRequestConcurrency
+	}
+
+	// defaults to a sane batch size.
+	if m.batchSize < 1 {
+		m.batchSize = defaultBatchSize
+	}
+
+	return &m, nil
+}
+
+// WithClient sets the http.Client that the matcher should use for requests.
+//
+// If not passed to NewMatcher, http.DefaultClient will be used.
+func WithClient(c *http.Client) Option {
+	return func(m *Matcher) error {
+		m.client = c
+		return nil
+	}
+}
+
+// WithHost sets the server host name that the matcher should use for requests.
+//
+// If not passed to NewMatcher, defaultHost will be used.
+func WithURL(url *url.URL) Option {
+	return func(m *Matcher) error {
+		m.url = url
+		return nil
+	}
+}
+
+// WithRequestConcurrency sets the concurrency limit for the network calls.
+//
+// If not passed to NewMatcher, a defaultRequestConcurrency will be used.
+func WithRequestConcurrency(requestConcurrency int) Option {
+	return func(m *Matcher) error {
+		m.requestConcurrency = requestConcurrency
+		return nil
+	}
+}
+
+// WithBatchSize sets the number of records to be batched per request.
+//
+// If not passed to NewMatcher, a defaultBatchSize will be used.
+func WithBatchSize(batchSize int) Option {
+	return func(m *Matcher) error {
+		m.batchSize = batchSize
+		return nil
+	}
+}
+
+// Name implements driver.Matcher.
+func (*Matcher) Name() string { return "crda" }
+
+// Maps the crda ecosystem to claircore.Repository.Name.
+func ecosystemToRepositoryName(ecosystem string) string {
+	switch ecosystem {
+	case "maven":
+		return "maven"
+	case "pypi":
+		return "pypi"
+	default:
+		panic(fmt.Sprintf("unknown ecosystem %s", ecosystem))
+	}
+}
+
+// Filter implements driver.Matcher.
+func (m *Matcher) Filter(record *claircore.IndexRecord) bool {
+	if record.Repository == nil {
+		return false
+	}
+	return record.Repository.Name == ecosystemToRepositoryName(m.ecosystem)
+}
+
+// Query implements driver.Matcher.
+func (*Matcher) Query() []driver.MatchConstraint {
+	panic("unreachable")
+}
+
+// Vulnerable implements driver.Matcher.
+func (*Matcher) Vulnerable(ctx context.Context, record *claircore.IndexRecord, vuln *claircore.Vulnerability) (bool, error) {
+	// RemoteMatcher can match Package and Vulnerability.
+	panic("unreachable")
+}
+
+// Config is the configuration accepted by the Matcher.
+//
+// By convention, it's in a map key called "crda".
+type Config struct {
+	URL         string `json:"url" yaml:"url"`
+	Concurrency int    `json:"concurrent_requests" yaml:"concurrent_requests"`
+}
+
+// Configure implements driver.MatcherConfigurable.
+func (m *Matcher) Configure(ctx context.Context, f driver.MatcherConfigUnmarshaler, c *http.Client) error {
+	ctx = baggage.ContextWithValues(ctx,
+		label.String("component", "crda/Matcher.Configure"))
+	var cfg Config
+	if err := f(&cfg); err != nil {
+		return err
+	}
+
+	if cfg.Concurrency > 0 {
+		m.requestConcurrency = cfg.Concurrency
+		zlog.Info(ctx).
+			Msg("configured concurrent requests")
+	}
+	if cfg.URL != "" {
+		u, err := url.Parse(cfg.URL)
+		if err != nil {
+			return err
+		}
+		m.url = u
+		zlog.Info(ctx).
+			Msg("configured API URL")
+	}
+	m.client = c
+	zlog.Info(ctx).
+		Msg("configured HTTP client")
+
+	return nil
+}
+
+// QueryRemoteMatcher implements driver.RemoteMatcher.
+func (m *Matcher) QueryRemoteMatcher(ctx context.Context, records []*claircore.IndexRecord) (map[string][]*claircore.Vulnerability, error) {
+	ctx = baggage.ContextWithValues(ctx,
+		label.String("component", "crda/Matcher.QueryRemoteMatcher"))
+	zlog.Debug(ctx).
+		Int("records", len(records)).
+		Msg("request")
+
+	// map Packge{name@version} to Packge to associate it with Vulnerability.
+	packageVersionToIndexRecord := make(map[string]*claircore.IndexRecord)
+	key := func(Name, Version string) string {
+		return fmt.Sprintf("%s@%s", Name, Version)
+	}
+	for _, ir := range records {
+		packageVersionToIndexRecord[key(ir.Package.Name, ir.Package.Version)] = ir
+	}
+
+	results := make(map[string][]*claircore.Vulnerability)
+	ctrlC, errorC := m.invokeComponentAnalysesInBatch(ctx, records)
+	err := <-errorC // guaranteed to have an err or be closed.
+	// Don't propagate error, log and move on.
+	if err != nil {
+		zlog.Error(ctx).Err(err).Msg("remote api call failure")
+		return results, nil
+	}
+	for vrs := range ctrlC {
+		for _, vr := range vrs {
+			ir := packageVersionToIndexRecord[key(vr.Name, vr.Version)]
+			// A package can have 0 or more vulnerabilities for a version.
+			var vulns []*claircore.Vulnerability
+			for _, vuln := range vr.Vulnerabilities {
+				vulns = append(vulns, &claircore.Vulnerability{
+					ID:                 vuln.ID,
+					Updater:            "CodeReadyAnalytics",
+					Name:               vuln.ID,
+					Description:        vuln.Title,
+					Links:              vuln.URL,
+					Severity:           vuln.Severity,
+					NormalizedSeverity: NormalizeSeverity(vuln.Severity),
+					FixedInVersion:     strings.Join(vuln.FixedIn, ", "),
+					Package:            ir.Package,
+					Repo:               ir.Repository,
+				})
+			}
+			results[ir.Package.ID] = append(results[ir.Package.ID], vulns...)
+		}
+	}
+	zlog.Debug(ctx).
+		Int("vulnerabilities", len(results)).
+		Msg("response")
+	return results, nil
+}
+
+func (m *Matcher) invokeComponentAnalysesInBatch(ctx context.Context, records []*claircore.IndexRecord) (<-chan []*VulnReport, <-chan error) {
+	inC := make(chan []*claircore.IndexRecord, m.requestConcurrency)
+	ctrlC := make(chan []*VulnReport, m.requestConcurrency)
+	errorC := make(chan error, 1)
+	batchSize := m.batchSize
+	go func() {
+		defer close(errorC)
+		defer close(ctrlC)
+		var g errgroup.Group
+		for start := 0; start < len(records); start += batchSize {
+			end := start + batchSize
+			if end > len(records) {
+				end = len(records)
+			}
+			g.Go(func() error {
+				vulns, err := m.invokeComponentAnalyses(ctx, <-inC)
+				if err != nil {
+					return err
+				}
+				ctrlC <- vulns
+				return nil
+			})
+			inC <- records[start:end]
+		}
+		close(inC)
+		if err := g.Wait(); err != nil {
+			errorC <- err
+		}
+	}()
+	return ctrlC, errorC
+}
+
+func (m *Matcher) invokeComponentAnalyses(ctx context.Context, records []*claircore.IndexRecord) ([]*VulnReport, error) {
+	// prepare request.
+	request := VulnRequest{
+		Ecosystem: m.ecosystem,
+		Packages:  make([]Package, len(records)),
+	}
+	for i, ir := range records {
+		request.Packages[i] = Package{
+			Name:    ir.Package.Name,
+			Version: ir.Package.Version,
+		}
+	}
+	// A request shouldn't go beyound 5s.
+	tctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	reqBody, _ := json.Marshal(request)
+	req, err := http.NewRequestWithContext(tctx, http.MethodPost, m.url.String(), bytes.NewBuffer(reqBody))
+	req.Header.Set("User-Agent", "claircore/crda/RemoteMatcher")
+	req.Header.Set("Content-Type", "application/json")
+	res, err := m.client.Do(req)
+	if res != nil {
+		defer res.Body.Close()
+	}
+	if err != nil {
+		return nil, err
+	}
+	var vulnReport []*VulnReport
+	data, _ := ioutil.ReadAll(res.Body)
+	err = json.Unmarshal(data, &vulnReport)
+	if err != nil {
+		return nil, err
+	}
+	return vulnReport, nil
+}

--- a/crda/remotematcher.go
+++ b/crda/remotematcher.go
@@ -31,9 +31,9 @@ const (
 	defaultBatchSize          = 10
 	defaultEndPoint           = "/api/v2/vulnerability-analysis"
 	defaultRequestConcurrency = 10
-	defaultURL                = "https://f8a-analytics-2445582058137.production.gw.apicast.io/api/v2/"
+	defaultURL                = "https://gw.api.openshift.io/api/v2/"
 	defaultSource             = "clair-upstream"
-	defaultKey                = "9e7da76708fe374d8c10fa752e72989f"
+	defaultKey                = "207c527cfc2a6b8dcf4fa43ad7a976da"
 )
 
 var (

--- a/crda/remotematcher_test.go
+++ b/crda/remotematcher_test.go
@@ -1,0 +1,245 @@
+package crda
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/quay/claircore"
+	"github.com/quay/zlog"
+)
+
+var (
+	pypiRepo = claircore.Repository{
+		Name: "python",
+		URI:  "https://python.org",
+	}
+)
+
+func (tc matcherTestcase) Run(t *testing.T) {
+	ctx := zlog.Test(context.Background(), t)
+	got, err := tc.Matcher.QueryRemoteMatcher(ctx, tc.R)
+	// RemoteMatcher never throws error, it just logs it.
+	if err != nil {
+		t.Errorf("RemoteMatcher error %v", err)
+	}
+	for k, expectedVulns := range tc.Expected {
+		got, ok := got[k]
+		if !ok {
+			t.Errorf("Expected key %s not found", k)
+		}
+		if diff := cmp.Diff(expectedVulns, got); diff != "" {
+			t.Errorf("Vuln mismatch (-want, +got):\n%s", diff)
+		}
+	}
+}
+
+type matcherTestcase struct {
+	Name     string
+	R        []*claircore.IndexRecord
+	Expected map[string][]*claircore.Vulnerability
+	Matcher  *Matcher
+}
+
+func newMatcher(t *testing.T, srv *httptest.Server) *Matcher {
+	url, _ := url.Parse(srv.URL)
+	m, err := NewMatcher("pypi", WithClient(srv.Client()), WithURL(url))
+	if err != nil {
+		t.Errorf("there should be no err %v", err)
+	}
+	return m
+}
+
+func TestRemoteMatcher(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		data, _ := ioutil.ReadAll(r.Body)
+		var vulnRequest VulnRequest
+		err := json.Unmarshal(data, &vulnRequest)
+		if err != nil {
+			t.Errorf("mock server unmarshall error %v", err)
+		}
+		var resp []VulnReport
+		for _, p := range vulnRequest.Packages {
+			res := VulnReport{
+				Name:    p.Name,
+				Version: p.Version,
+			}
+			testLocalPath := fmt.Sprintf("testdata/%s/%s/%s.json", vulnRequest.Ecosystem, p.Name, p.Version)
+			t.Logf("serving request for %v", testLocalPath)
+			jsonOut, err := ioutil.ReadFile(testLocalPath)
+			if err == nil {
+				err = json.Unmarshal(jsonOut, &res)
+				if err != nil {
+					t.Errorf("mock server unmarshall error %v", err)
+				}
+			}
+			resp = append(resp, res)
+		}
+		out, err := json.Marshal(&resp)
+		if err != nil {
+			t.Errorf("mock server marshall error %v", err)
+		}
+		w.Write(out)
+	}))
+	defer srv.Close()
+
+	tt := []matcherTestcase{
+		{
+			Name:     "pypi/empty",
+			R:        []*claircore.IndexRecord{},
+			Expected: map[string][]*claircore.Vulnerability{},
+			Matcher:  newMatcher(t, srv),
+		},
+		{
+			Name: "pypi/{pyyaml-vuln,flask-novuln}",
+			R: []*claircore.IndexRecord{
+				{
+					Package: &claircore.Package{
+						ID:      "pyyaml",
+						Name:    "pyyaml",
+						Version: "5.3",
+					},
+					Repository: &pypiRepo,
+				},
+				{
+					Package: &claircore.Package{
+						ID:      "flask",
+						Name:    "flask",
+						Version: "1.1.0",
+					},
+					Repository: &pypiRepo,
+				},
+			},
+			Expected: map[string][]*claircore.Vulnerability{
+				"pyyaml": []*claircore.Vulnerability{
+					{
+						ID:                 "SNYK-PYTHON-PYYAML-559098",
+						Updater:            "CodeReadyAnalytics",
+						Name:               "SNYK-PYTHON-PYYAML-559098",
+						Description:        "Arbitrary Code Execution",
+						Links:              "https://snyk.io/vuln/SNYK-PYTHON-PYYAML-559098",
+						Severity:           "critical",
+						NormalizedSeverity: claircore.Critical,
+						Package: &claircore.Package{
+							ID:      "pyyaml",
+							Name:    "pyyaml",
+							Version: "5.3",
+						},
+						Repo:           &pypiRepo,
+						FixedInVersion: "5.3.1",
+					},
+				},
+			},
+			Matcher: newMatcher(t, srv),
+		},
+		{
+			Name: "pypi/{pyyaml-novuln,flask-novuln}",
+			R: []*claircore.IndexRecord{
+				{
+					Package: &claircore.Package{
+						ID:      "pyyaml",
+						Name:    "pyyaml",
+						Version: "5.3.1",
+					},
+					Repository: &pypiRepo,
+				},
+				{
+					Package: &claircore.Package{
+						ID:      "flask",
+						Name:    "flask",
+						Version: "1.1.0",
+					},
+					Repository: &pypiRepo,
+				},
+			},
+			Expected: map[string][]*claircore.Vulnerability{},
+			Matcher:  newMatcher(t, srv),
+		},
+		{
+			Name: "pypi/{pyyaml-vuln,flask-vuln}",
+			R: []*claircore.IndexRecord{
+				{
+					Package: &claircore.Package{
+						ID:      "pyyaml",
+						Name:    "pyyaml",
+						Version: "5.3",
+					},
+					Repository: &pypiRepo,
+				},
+				{
+					Package: &claircore.Package{
+						ID:      "flask",
+						Name:    "flask",
+						Version: "0.12",
+					},
+					Repository: &pypiRepo,
+				},
+			},
+			Expected: map[string][]*claircore.Vulnerability{
+				"pyyaml": []*claircore.Vulnerability{
+					{
+						ID:                 "SNYK-PYTHON-PYYAML-559098",
+						Updater:            "CodeReadyAnalytics",
+						Name:               "SNYK-PYTHON-PYYAML-559098",
+						Description:        "Arbitrary Code Execution",
+						Links:              "https://snyk.io/vuln/SNYK-PYTHON-PYYAML-559098",
+						Severity:           "critical",
+						NormalizedSeverity: claircore.Critical,
+						Package: &claircore.Package{
+							ID:      "pyyaml",
+							Name:    "pyyaml",
+							Version: "5.3",
+						},
+						Repo:           &pypiRepo,
+						FixedInVersion: "5.3.1",
+					},
+				},
+				"flask": []*claircore.Vulnerability{
+					{
+						ID:                 "SNYK-PYTHON-FLASK-42185",
+						Updater:            "CodeReadyAnalytics",
+						Name:               "SNYK-PYTHON-FLASK-42185",
+						Description:        "Improper Input Validation",
+						Links:              "https://snyk.io/vuln/SNYK-PYTHON-FLASK-42185",
+						Severity:           "high",
+						NormalizedSeverity: claircore.High,
+						Package: &claircore.Package{
+							ID:      "flask",
+							Name:    "flask",
+							Version: "0.12",
+						},
+						Repo:           &pypiRepo,
+						FixedInVersion: "0.12.3",
+					},
+					{
+						ID:                 "SNYK-PYTHON-FLASK-42185-xx",
+						Updater:            "CodeReadyAnalytics",
+						Name:               "SNYK-PYTHON-FLASK-42185-xx",
+						Description:        "Improper Input Validation",
+						Links:              "https://snyk.io/vuln/SNYK-PYTHON-FLASK-42185",
+						Severity:           "high",
+						NormalizedSeverity: claircore.High,
+						Package: &claircore.Package{
+							ID:      "flask",
+							Name:    "flask",
+							Version: "0.12",
+						},
+						Repo:           &pypiRepo,
+						FixedInVersion: "0.12.3, 0.12.4",
+					},
+				},
+			},
+			Matcher: newMatcher(t, srv),
+		}}
+	for _, tc := range tt {
+		t.Run(tc.Name, tc.Run)
+	}
+}

--- a/crda/remotematcher_test.go
+++ b/crda/remotematcher_test.go
@@ -78,14 +78,14 @@ func TestRemoteMatcher(t *testing.T) {
 			if err == nil {
 				err = json.Unmarshal(jsonOut, &res)
 				if err != nil {
-					t.Errorf("mock server unmarshall error %v", err)
+					t.Errorf("mock server unmarshal error %v", err)
 				}
 			}
 			resp = append(resp, res)
 		}
 		out, err := json.Marshal(&resp)
 		if err != nil {
-			t.Errorf("mock server marshall error %v", err)
+			t.Errorf("mock server marshal error %v", err)
 		}
 		w.Write(out)
 	}))
@@ -220,11 +220,11 @@ func TestRemoteMatcher(t *testing.T) {
 						FixedInVersion: "0.12.3",
 					},
 					{
-						ID:                 "SNYK-PYTHON-FLASK-42185-xx",
+						ID:                 "SNYK-PYTHON-FLASK-451637",
 						Updater:            "CodeReadyAnalytics",
-						Name:               "SNYK-PYTHON-FLASK-42185-xx",
-						Description:        "Improper Input Validation",
-						Links:              "https://snyk.io/vuln/SNYK-PYTHON-FLASK-42185",
+						Name:               "SNYK-PYTHON-FLASK-451637",
+						Description:        "Denial of Service (DoS)",
+						Links:              "https://snyk.io/vuln/SNYK-PYTHON-FLASK-451637",
 						Severity:           "high",
 						NormalizedSeverity: claircore.High,
 						Package: &claircore.Package{
@@ -233,7 +233,7 @@ func TestRemoteMatcher(t *testing.T) {
 							Version: "0.12",
 						},
 						Repo:           &pypiRepo,
-						FixedInVersion: "0.12.3, 0.12.4",
+						FixedInVersion: "1.0",
 					},
 				},
 			},

--- a/crda/testdata/pypi/flask/0.12.json
+++ b/crda/testdata/pypi/flask/0.12.json
@@ -1,0 +1,47 @@
+{
+    "recommended_versions": "1.1.2",
+    "registration_link": "https://app.snyk.io/login",
+    "vulnerability": [
+        {
+            "id": "SNYK-PYTHON-FLASK-42185",
+            "cvss": "7.5",
+            "is_private": false,
+            "cwes": [
+                "CWE-20"
+            ],
+            "cvss_v3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "severity": "high",
+            "title": "Improper Input Validation",
+            "url": "https://snyk.io/vuln/SNYK-PYTHON-FLASK-42185",
+            "cve_ids": [
+                "CVE-2018-1000656"
+            ],
+            "fixed_in": [
+                "0.12.3"
+            ]
+        },
+        {
+            "id": "SNYK-PYTHON-FLASK-42185-xx",
+            "cvss": "7.5",
+            "is_private": false,
+            "cwes": [
+                "CWE-20"
+            ],
+            "cvss_v3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "severity": "high",
+            "title": "Improper Input Validation",
+            "url": "https://snyk.io/vuln/SNYK-PYTHON-FLASK-42185",
+            "cve_ids": [
+                "CVE-2018-1000656"
+            ],
+            "fixed_in": [
+                "0.12.3",
+                "0.12.4"
+            ]
+        }
+    ],
+    "message": "flask - 0.12 has 1 known security vulnerability having high severity. Recommendation: use version 1.1.2.",
+    "severity": "high",
+    "known_security_vulnerability_count": 1,
+    "security_advisory_count": 0
+}

--- a/crda/testdata/pypi/flask/0.12.json
+++ b/crda/testdata/pypi/flask/0.12.json
@@ -1,47 +1,24 @@
 {
-    "recommended_versions": "1.1.2",
-    "registration_link": "https://app.snyk.io/login",
-    "vulnerability": [
+    "name": "flask",
+    "version": "0.12",
+    "vulnerabilities": [
         {
-            "id": "SNYK-PYTHON-FLASK-42185",
-            "cvss": "7.5",
-            "is_private": false,
-            "cwes": [
-                "CWE-20"
-            ],
-            "cvss_v3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            "severity": "high",
-            "title": "Improper Input Validation",
-            "url": "https://snyk.io/vuln/SNYK-PYTHON-FLASK-42185",
-            "cve_ids": [
-                "CVE-2018-1000656"
-            ],
             "fixed_in": [
                 "0.12.3"
-            ]
-        },
-        {
-            "id": "SNYK-PYTHON-FLASK-42185-xx",
-            "cvss": "7.5",
-            "is_private": false,
-            "cwes": [
-                "CWE-20"
             ],
-            "cvss_v3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "id": "SNYK-PYTHON-FLASK-42185",
             "severity": "high",
             "title": "Improper Input Validation",
-            "url": "https://snyk.io/vuln/SNYK-PYTHON-FLASK-42185",
-            "cve_ids": [
-                "CVE-2018-1000656"
-            ],
+            "url": "https://snyk.io/vuln/SNYK-PYTHON-FLASK-42185"
+        },
+        {
             "fixed_in": [
-                "0.12.3",
-                "0.12.4"
-            ]
+                "1.0"
+            ],
+            "id": "SNYK-PYTHON-FLASK-451637",
+            "severity": "high",
+            "title": "Denial of Service (DoS)",
+            "url": "https://snyk.io/vuln/SNYK-PYTHON-FLASK-451637"
         }
-    ],
-    "message": "flask - 0.12 has 1 known security vulnerability having high severity. Recommendation: use version 1.1.2.",
-    "severity": "high",
-    "known_security_vulnerability_count": 1,
-    "security_advisory_count": 0
+    ]
 }

--- a/crda/testdata/pypi/pyyaml/5.3.json
+++ b/crda/testdata/pypi/pyyaml/5.3.json
@@ -1,0 +1,28 @@
+{
+    "recommended_versions": "5.3.1",
+    "registration_link": "https://app.snyk.io/login",
+    "vulnerability": [
+        {
+            "id": "SNYK-PYTHON-PYYAML-559098",
+            "cvss": "9.8",
+            "is_private": false,
+            "cwes": [
+                "CWE-20"
+            ],
+            "cvss_v3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "severity": "critical",
+            "title": "Arbitrary Code Execution",
+            "url": "https://snyk.io/vuln/SNYK-PYTHON-PYYAML-559098",
+            "cve_ids": [
+                "CVE-2020-1747"
+            ],
+            "fixed_in": [
+                "5.3.1"
+            ]
+        }
+    ],
+    "message": "pyyaml - 5.3 has 1 known security vulnerability having critical severity. Recommendation: use version 5.3.1.",
+    "severity": "critical",
+    "known_security_vulnerability_count": 1,
+    "security_advisory_count": 0
+}

--- a/crda/testdata/pypi/pyyaml/5.3.json
+++ b/crda/testdata/pypi/pyyaml/5.3.json
@@ -1,28 +1,15 @@
 {
-    "recommended_versions": "5.3.1",
-    "registration_link": "https://app.snyk.io/login",
-    "vulnerability": [
+    "name": "pyyaml",
+    "version": "5.3",
+    "vulnerabilities": [
         {
-            "id": "SNYK-PYTHON-PYYAML-559098",
-            "cvss": "9.8",
-            "is_private": false,
-            "cwes": [
-                "CWE-20"
-            ],
-            "cvss_v3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-            "severity": "critical",
-            "title": "Arbitrary Code Execution",
-            "url": "https://snyk.io/vuln/SNYK-PYTHON-PYYAML-559098",
-            "cve_ids": [
-                "CVE-2020-1747"
-            ],
             "fixed_in": [
                 "5.3.1"
-            ]
+            ],
+            "id": "SNYK-PYTHON-PYYAML-559098",
+            "severity": "critical",
+            "title": "Arbitrary Code Execution",
+            "url": "https://snyk.io/vuln/SNYK-PYTHON-PYYAML-559098"
         }
-    ],
-    "message": "pyyaml - 5.3 has 1 known security vulnerability having critical severity. Recommendation: use version 5.3.1.",
-    "severity": "critical",
-    "known_security_vulnerability_count": 1,
-    "security_advisory_count": 0
+    ]
 }

--- a/libvuln/opts.go
+++ b/libvuln/opts.go
@@ -79,6 +79,7 @@ type Opts struct {
 	// "rhel"
 	// "suse"
 	// "ubuntu"
+	// "crda" - remotematcher calls hosted api via RPC.
 	MatcherNames []string
 
 	// Config holds configuration blocks for MatcherFactories and Matchers,

--- a/matchers/defaults/defaults.go
+++ b/matchers/defaults/defaults.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/quay/claircore/alpine"
 	"github.com/quay/claircore/aws"
+	"github.com/quay/claircore/crda"
 	"github.com/quay/claircore/debian"
 	"github.com/quay/claircore/libvuln/driver"
 	"github.com/quay/claircore/matchers/registry"
@@ -52,9 +53,12 @@ var defaultMatchers = []driver.Matcher{
 }
 
 func inner(ctx context.Context) error {
+	registry.Register("crda", &crda.Factory{})
+
 	for _, m := range defaultMatchers {
 		mf := driver.MatcherStatic(m)
 		registry.Register(m.Name(), mf)
 	}
+
 	return nil
 }


### PR DESCRIPTION
 - [x] Add back crda remote matcher
 - [x] Add new api
 - [x] Add unit tests
 - [x] Add configurable api-key
 - [x] Add configurable source 

The default api in crda remote matcher will serve 100rpm
The other key which can be optained by making an api call will be able to serve 1800 rpm to start with . We are positive about
increasing it even more.

Our api will have proper 3scale limits in place and we have removed the scenario which resulted in our system downtime.

Continued from https://github.com/quay/claircore/pull/419