### PR TITLE
rpm: permissions madness

### DIFF
--- a/rpm/packagescanner_test.go
+++ b/rpm/packagescanner_test.go
@@ -3,7 +3,9 @@ package rpm
 import (
 	"context"
 	"net/http"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -15,6 +17,12 @@ import (
 )
 
 func TestScan(t *testing.T) {
+	pat := filepath.Join(os.TempDir(), "rpmscanner.*")
+	prevs, err := filepath.Glob(pat)
+	if err != nil {
+		t.Error(err)
+	}
+
 	hash, err := claircore.ParseDigest("sha256:729ec3a6ada3a6d26faca9b4779a037231f1762f759ef34c08bdd61bf52cd704")
 	if err != nil {
 		t.Fatal(err)
@@ -1618,5 +1626,13 @@ func TestScan(t *testing.T) {
 	t.Logf("found %d packages", len(got))
 	if !cmp.Equal(got, want) {
 		t.Fatal(cmp.Diff(got, want))
+	}
+
+	ms, err := filepath.Glob(pat)
+	if err != nil {
+		t.Error(err)
+	}
+	if got, want := ms, prevs; !cmp.Equal(got, want) {
+		t.Error(cmp.Diff(got, want))
 	}
 }


### PR DESCRIPTION
The root of permission errors seems to be from directories not being
writable. This isn't an issue for root, since they're allowed to touch
files however they like no matter what (assuming no xattrs are at play
-- I really hope they're not).  However, when a normal user extracts a
tarball, they can take away their own write bit, which must be added to
remove any files (i.e. write the dirent).

This is compounded by the behavior of `chmod`, which is to operate on the target.
If the walk hasn't fixed the directory of the target yet, it will fail.