### PR TITLE
Release "quay.io/projectquay/golang" Docker Image for Linux/ARM64

### DIFF
--- a/.github/workflows/golang-image.yml
+++ b/.github/workflows/golang-image.yml
@@ -71,12 +71,17 @@ jobs:
           echo "TAG=${TAG}" >> $GITHUB_ENV
           echo "::add-mask::${{ secrets.QUAY_TOKEN }}"
         if: env.BUILD_IMAGE == 1
-      - name: Build golang image
-        run: |
-          docker build -f etc/Dockerfile -t ${TAG} --build-arg GO_VERSION=${GO_VERSION} etc
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@master
+        with:
+          platforms: all
         if: env.BUILD_IMAGE == 1
-      - name: Publish golang image
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        if: env.BUILD_IMAGE == 1
+      - name: Build and Publish golang image
         run: |
           docker login -u "${QUAY_USER}" -p '${{ secrets.QUAY_TOKEN }}' quay.io
-          docker push "${TAG}"
+          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+          docker buildx build --platform linux/amd64,linux/arm64 -f etc/Dockerfile -t ${TAG} --build-arg GO_VERSION=${GO_VERSION} --push etc
         if: env.BUILD_IMAGE == 1

--- a/etc/Dockerfile
+++ b/etc/Dockerfile
@@ -8,8 +8,8 @@ RUN dnf install -q -y \
 	dnf clean all
 ARG GO_VERSION
 ARG GO_CHECKSUM
-RUN curl -sLo /tmp/go.tar.gz "https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz" ;\
-	[ -z "${GO_CHECKSUM}" ] || echo "${GO_CHECKSUM} /tmp/go.tar.gz" | sha256sum -c -;\
+RUN if [ `uname -m` = "aarch64" ] ; then curl -sLo /tmp/go.tar.gz "https://dl.google.com/go/go${GO_VERSION}.linux-arm64.tar.gz" ; else curl -sLo /tmp/go.tar.gz "https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz" ; fi \
+	&& [ -z "${GO_CHECKSUM}" ] || echo "${GO_CHECKSUM} /tmp/go.tar.gz" | sha256sum -c -;\
 	tar -xz -C /usr/local/ -f /tmp/go.tar.gz;\
 	rm /tmp/go.tar.gz;\
 	/usr/local/go/bin/go version


### PR DESCRIPTION
Added platform check in the Dockerfile to download GO binary according to the host platform, and added buildx utility to the golang-image.yml file to release golang for both AMD64 and ARM64.

Signed-off-by: odidev <odidev@puresoftware.com>