### PR TITLE
java: bump scanner version

### DIFF
--- a/java/packagescanner.go
+++ b/java/packagescanner.go
@@ -36,7 +36,7 @@ type Scanner struct{}
 func (*Scanner) Name() string { return "java" }
 
 // Version implements scanner.VersionedScanner.
-func (*Scanner) Version() string { return "0.0.1" }
+func (*Scanner) Version() string { return "2" }
 
 // Kind implements scanner.VersionedScanner.
 func (*Scanner) Kind() string { return "package" }


### PR DESCRIPTION
I forgot to increment this when adding the `peek` function. Without it,
layers that failed due to phony jars will never get picked back up.

See-also: #435
Signed-off-by: Hank Donnay <hdonnay@redhat.com>