### PR TITLE
dpkg: update identification method of dpkg DB dir

### DIFF
--- a/dpkg/scanner.go
+++ b/dpkg/scanner.go
@@ -27,7 +27,7 @@ import (
 const (
 	name    = "dpkg"
 	kind    = "package"
-	version = "v0.0.2"
+	version = "v0.0.3"
 )
 
 var (
@@ -98,9 +98,13 @@ Find:
 			return nil, fmt.Errorf("reading next header failed: %w", err)
 		}
 		switch filepath.Base(h.Name) {
-		case "status", "available":
+		case "status":
 			if h.Typeflag == tar.TypeReg {
 				loc[filepath.Dir(h.Name)]++
+			}
+		case "info":
+			if h.Typeflag == tar.TypeDir {
+				loc[filepath.Dir(filepath.Dir(h.Name))]++
 			}
 		}
 	}


### PR DESCRIPTION
The current way to identify a dpkg DB can be too
exclusive in some scenarios and the "available" dir
does not always exist. This change checks the info
dir is there. This could result in some more false
positives given how generic the names are but this
is highly unlikely to lead to false positives due
to DB file format we expect.`

Signed-off-by: crozzy <joseph.crosland@gmail.com>