### PR TITLE
chore: Improve check for go versions

### DIFF
--- a/.github/scripts/get-latest-golang-minor-version.sh
+++ b/.github/scripts/get-latest-golang-minor-version.sh
@@ -4,10 +4,12 @@ LOGFILE=$2
 
 LATEST_MINOR_VERSION=0
 
+LATEST_VERSION="none"
+CHECK_VERSION=$MAJOR_VERSION
+
 while true
 do
-    let CHECK_MINOR_VERSION=LATEST_MINOR_VERSION+1
-    URL=https://dl.google.com/go/go${MAJOR_VERSION}.${CHECK_MINOR_VERSION}.linux-amd64.tar.gz
+    URL=https://dl.google.com/go/go${CHECK_VERSION}.linux-amd64.tar.gz
     echo -n "${URL} " >> ${LOGFILE}
     HTTP_RESP_CODE=`curl -I -o /dev/null -s -w "%{http_code}\n" "${URL}"`
     echo "${HTTP_RESP_CODE}" >> ${LOGFILE}
@@ -15,8 +17,10 @@ do
     then
         break
     fi
-    let LATEST_MINOR_VERSION++
+    LATEST_VERSION=${CHECK_VERSION}
+    let CHECK_MINOR_VERSION++
+    CHECK_VERSION=${MAJOR_VERSION}.${CHECK_MINOR_VERSION}
 done
 
 # Return latest Golang version available for download in format "1.15.6"
-echo "${MAJOR_VERSION}.${LATEST_MINOR_VERSION}"
+echo "${LATEST_VERSION}"


### PR DESCRIPTION
Previously checking for the first major version would
yield something like 1.17.0, Go will refer to it as 1.17
hence the URL generated would 404
(https://dl.google.com/go/go1.17.0.linux-arm64.tar.gz).

Signed-off-by: crozzy <joseph.crosland@gmail.com>