### PR TITLE
backport: rpm: handle cross-layer hardlinks when extracting

### DIFF
--- a/rpm/packagescanner.go
+++ b/rpm/packagescanner.go
@@ -26,7 +26,7 @@ import (
 const (
 	pkgName    = "rpm"
 	pkgKind    = "package"
-	pkgVersion = "3"
+	pkgVersion = "4"
 )
 
 // DbNames is a set of files that make up an rpm database.
@@ -130,6 +130,14 @@ func (ps *Scanner) Scan(ctx context.Context, layer *claircore.Layer) ([]*clairco
 			zlog.Error(ctx).Err(err).Msg("error removing extracted files")
 		}
 	}()
+	empty := filepath.Join(os.TempDir(), "rpm.emptyfile")
+	ef, err := os.Create(empty)
+	if err != nil {
+		return nil, err
+	}
+	if err := ef.Close(); err != nil {
+		return nil, err
+	}
 
 	// Extract tarball
 	if err := ctx.Err(); err != nil {
@@ -233,10 +241,12 @@ func (ps *Scanner) Scan(ctx context.Context, layer *claircore.Layer) ([]*clairco
 	}
 	for _, l := range deferLn {
 		if err := os.Link(l[0], l[1]); err != nil {
-			zlog.Error(ctx).
+			zlog.Debug(ctx).
 				Err(err).
-				Msg("failed to finish links")
-			return nil, err
+				Msg("cross-layer (or invalid) hardlink found")
+			if err := os.Link(empty, l[1]); err != nil {
+				return nil, err
+			}
 		}
 	}
 	if ct := len(deferLn); ct != 0 {


### PR DESCRIPTION
Logically, cross-layer links are allowed, although we hadn't run across
them in testing.

Because layers are defined to be applied in-order, a container runtime
-- which never extracts layers in isolation -- never runs into this
issue and rightly errors out when attempting to link to a nonexistent
file. Clair's use case means the program should link to an empty file,
which needs to exist on the same filesystem. The file being empty should
be okay, because the contents will be seen in a different index.

There may be an edge case where the layer dodges all the indexers by not
having the "right" name in a lower layer and linking it in a higher
layer. I don't think this is avoidable.

Signed-off-by: Hank Donnay <hdonnay@redhat.com>
Backports: #465
(cherry picked from commit 64f62498c29e314f41bf01d3f85e3dfc378eadeb)