### PR TITLE
gc: add foreign key ON DELETE CASCADES to uo_enrich table (#470)

### DIFF
--- a/libvuln/migrations/migrations.go
+++ b/libvuln/migrations/migrations.go
@@ -39,4 +39,11 @@ var Migrations = []migrate.Migration{
 			return err
 		},
 	},
+	{
+		ID: 5,
+		Up: func(tx *sql.Tx) error {
+			_, err := tx.Exec(migration5)
+			return err
+		},
+	},
 }

--- a/libvuln/migrations/migrations5.go
+++ b/libvuln/migrations/migrations5.go
@@ -1,0 +1,13 @@
+package migrations
+
+const (
+	// this migration modifies the database to add a
+	// delete cascade constraint to the enrichments FKs
+	migration5 = `
+ALTER TABLE uo_enrich
+DROP CONSTRAINT uo_enrich_uo_fkey,
+DROP CONSTRAINT uo_enrich_enrich_fkey,
+ADD CONSTRAINT uo_enrich_uo_fkey FOREIGN KEY (uo) REFERENCES update_operation (id) ON DELETE CASCADE,
+ADD CONSTRAINT uo_enrich_enrich_fkey FOREIGN KEY (enrich) REFERENCES enrichment (id) ON DELETE CASCADE;
+`
+)


### PR DESCRIPTION
Right now the GC can error out with a violates foreign key constraint
when trying to delete entries in the update_operations table as
this table references it in a foreign key.

Signed-off-by: crozzy <joseph.crosland@gmail.com>
Backports: #470
(cherry picked from commit 056d5e7956c798b97cfc9539bde3847c7f3c62db)