### PR TITLE
backport: rpm: prevent directory traversal when extracting

### DIFF
--- a/rpm/packagescanner.go
+++ b/rpm/packagescanner.go
@@ -169,7 +169,7 @@ func (ps *Scanner) Scan(ctx context.Context, layer *claircore.Layer) ([]*clairco
 			continue
 		}
 		// Build the path on the filesystem.
-		tgt := filepath.Join(root, filepath.Clean(h.Name))
+		tgt := relPath(root, h.Name)
 		// Since tar, as a format, doesn't impose ordering requirements, make
 		// sure to create all parent directories of the current entry.
 		d := filepath.Dir(tgt)
@@ -211,12 +211,12 @@ func (ps *Scanner) Scan(ctx context.Context, layer *claircore.Layer) ([]*clairco
 			stats.Reg++
 		case tar.TypeSymlink:
 			// Normalize the link target into the root.
-			ln := filepath.Join(root, filepath.Clean(h.Linkname))
+			ln := relPath(root, h.Linkname)
 			err = os.Symlink(ln, tgt)
 			stats.Symlink++
 		case tar.TypeLink:
 			// Normalize the link target into the root.
-			ln := filepath.Join(root, filepath.Clean(h.Linkname))
+			ln := relPath(root, h.Linkname)
 			_, exists := os.Lstat(ln)
 			switch {
 			case errors.Is(exists, nil):
@@ -421,4 +421,12 @@ func parsePackage(ctx context.Context, src map[string]*claircore.Package, buf *b
 			return nil, err
 		}
 	}
+}
+
+// RelPath takes a member and forcibly interprets it as a path underneath root.
+//
+// This should be used anytime a path for a new file on disk is needed when
+// unpacking a tar.
+func relPath(root, member string) string {
+	return filepath.Join(root, filepath.Join("/", member))
 }

--- a/rpm/packagescanner_test.go
+++ b/rpm/packagescanner_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -1634,5 +1635,41 @@ func TestScan(t *testing.T) {
 	}
 	if got, want := ms, prevs; !cmp.Equal(got, want) {
 		t.Error(cmp.Diff(got, want))
+	}
+}
+
+func TestRelPath(t *testing.T) {
+	root := `/tmp/fakedata`
+	tt := [][2]string{
+		{
+			"dev/null",
+			"/dev/null",
+		},
+		{
+			"dev/null",
+			"./dev/null",
+		},
+		{
+			"dev/null",
+			"dev/null",
+		},
+		{
+			"dev/null",
+			strings.Repeat("../", 10) + "dev/null",
+		},
+		{
+			"dev/null",
+			strings.Repeat("../", 10) + "dev/./../dev/null",
+		},
+	}
+
+	for _, tc := range tt {
+		want := filepath.Join(root, tc[0])
+		t.Logf("in: %q + %q", root, tc[1])
+		got := relPath(root, tc[1])
+		t.Logf("got: %q, want: %q", got, want)
+		if got != want {
+			t.Error()
+		}
 	}
 }


### PR DESCRIPTION
A malicious tar archive with a member consisting of multiple "parent"
elements could cause a file outside of the target directory to be
overwritten.

Fixes: CVE-2021-3762
Signed-off-by: Hank Donnay <hdonnay@redhat.com>
Backports: #478
(cherry picked from commit 691f2023a1720a0579e688b69a2f4bfe1f4b7821)