### PR TITLE
debian: add bullseye

### DIFF
--- a/debian/distributionscanner.go
+++ b/debian/distributionscanner.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	scannerName    = "debian"
-	scannerVersion = "v0.0.1"
+	scannerVersion = "v0.0.2"
 	scannerKind    = "distribution"
 )
 
@@ -26,6 +26,10 @@ type debianRegex struct {
 }
 
 var debianRegexes = []debianRegex{
+	{
+		release: Bullseye,
+		regexp:  regexp.MustCompile(`(?is)debian gnu/linux 11`),
+	},
 	{
 		release: Buster,
 		regexp:  regexp.MustCompile(`(?is)debian gnu/linux 10`),

--- a/debian/distributionscanner_test.go
+++ b/debian/distributionscanner_test.go
@@ -7,6 +7,18 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
+var bullseyeOSRelease []byte = []byte(`PRETTY_NAME="Debian GNU/Linux 11 (bullseye)"
+NAME="Debian GNU/Linux"
+VERSION_ID="11"
+VERSION="11 (bullseye)"
+VERSION_CODENAME=bullseye
+ID=debian
+HOME_URL="https://www.debian.org/"
+SUPPORT_URL="https://www.debian.org/support"
+BUG_REPORT_URL="https://bugs.debian.org/"`)
+
+var bullseyeIssue []byte = []byte(`Debian GNU/Linux 11 \n \l`)
+
 var busterOSRelease []byte = []byte(`PRETTY_NAME="Debian GNU/Linux 10 (buster)"
 NAME="Debian GNU/Linux"
 VERSION_ID="10"
@@ -61,6 +73,12 @@ func TestDistributionScanner(t *testing.T) {
 		osRelease []byte
 		issue     []byte
 	}{
+		{
+			name:      "bullseye",
+			release:   Bullseye,
+			osRelease: bullseyeOSRelease,
+			issue:     bullseyeIssue,
+		},
 		{
 			name:      "buster",
 			release:   Buster,

--- a/debian/releases.go
+++ b/debian/releases.go
@@ -5,24 +5,36 @@ import "github.com/quay/claircore"
 type Release string
 
 const (
-	Buster  Release = "buster"
-	Jessie  Release = "jessie"
-	Stretch Release = "stretch"
-	Wheezy  Release = "wheezy"
+	Bullseye Release = "bullseye"
+	Buster   Release = "buster"
+	Jessie   Release = "jessie"
+	Stretch  Release = "stretch"
+	Wheezy   Release = "wheezy"
 )
 
 var AllReleases = map[Release]struct{}{
-	Buster:  struct{}{},
-	Jessie:  struct{}{},
-	Stretch: struct{}{},
-	Wheezy:  struct{}{},
+	Bullseye: struct{}{},
+	Buster:   struct{}{},
+	Jessie:   struct{}{},
+	Stretch:  struct{}{},
+	Wheezy:   struct{}{},
 }
 
 var ReleaseToVersionID = map[Release]string{
-	Buster:  "10",
-	Jessie:  "8",
-	Stretch: "9",
-	Wheezy:  "7",
+	Bullseye: "11",
+	Buster:   "10",
+	Jessie:   "8",
+	Stretch:  "9",
+	Wheezy:   "7",
+}
+
+var bullseyeDist = &claircore.Distribution{
+	PrettyName:      "Debian GNU/Linux 11 (bullseye)",
+	Name:            "Debian GNU/Linux",
+	VersionID:       "11",
+	Version:         "11 (bullseye)",
+	VersionCodeName: "bullseye",
+	DID:             "debian",
 }
 
 var busterDist = &claircore.Distribution{
@@ -61,6 +73,8 @@ var wheezyDist = &claircore.Distribution{
 
 func releaseToDist(r Release) *claircore.Distribution {
 	switch r {
+	case Bullseye:
+		return bullseyeDist
 	case Buster:
 		return busterDist
 	case Jessie:

--- a/debian/resolvevcn.go
+++ b/debian/resolvevcn.go
@@ -5,12 +5,14 @@ import (
 )
 
 func init() {
+	bullseyeRegex := regexp.MustCompile("bullseye")
 	busterRegex := regexp.MustCompile("buster")
 	jessieRegex := regexp.MustCompile("jessie")
 	stretchRegex := regexp.MustCompile("stretch")
 	wheezyRegex := regexp.MustCompile("wheezy")
 
 	resolvers = []vcnRegexp{
+		vcnRegexp{Bullseye, bullseyeRegex},
 		vcnRegexp{Buster, busterRegex},
 		vcnRegexp{Jessie, jessieRegex},
 		vcnRegexp{Stretch, stretchRegex},

--- a/debian/resolvevcn_test.go
+++ b/debian/resolvevcn_test.go
@@ -10,6 +10,14 @@ func TestResolveVersionCodeName(t *testing.T) {
 		expect string
 	}{
 		{
+			str:    "Debian GNU/Linux 11 (bullseye)",
+			expect: "bullseye",
+		},
+		{
+			str:    "11 (bullseye)",
+			expect: "bullseye",
+		},
+		{
 			str:    "Debian GNU/Linux 10 (buster)",
 			expect: "buster",
 		},

--- a/debian/updater_integration_test.go
+++ b/debian/updater_integration_test.go
@@ -33,6 +33,10 @@ func TestUpdater(t *testing.T) {
 			name:    "buster",
 			release: Buster,
 		},
+		{
+			name:    "bullseye",
+			release: Bullseye,
+		},
 	}
 
 	for _, table := range tt {

--- a/debian/updaterset.go
+++ b/debian/updaterset.go
@@ -7,6 +7,7 @@ import (
 )
 
 var debianReleases = []Release{
+	Bullseye,
 	Buster,
 	Jessie,
 	Stretch,


### PR DESCRIPTION
Adding boilerplate code to allow Clair to scan images
and save vulnerabilities that derive from debian:bullseye.

Signed-off-by: crozzy <joseph.crosland@gmail.com>