### PR TITLE
jar: handle manifests with multiple sections

### DIFF
--- a/java/jar/testdata/manifestSection/individual
+++ b/java/jar/testdata/manifestSection/individual
@@ -1,0 +1,5 @@
+Manifest-Version: 1.0
+Created-By: 1.2 (Sun Microsystems Inc.)
+Sealed: true
+Name: foo/bar/
+Sealed: false


### PR DESCRIPTION
I misread the jar manifest spec and expected sections to be delimited by
blank lines. On closer inspection, the spec says the sections are
delimited by the "Name" member itself.

This commit implements an io.Reader adapter that only reads the main
section.

Signed-off-by: Hank Donnay <hdonnay@redhat.com>