### PR TITLE
ubuntu: add impish

### DIFF
--- a/ubuntu/distributionscanner.go
+++ b/ubuntu/distributionscanner.go
@@ -62,6 +62,10 @@ var ubuntuRegexes = []ubuntuRegex{
 		release: Focal,
 		regexp:  regexp.MustCompile(`(?is)\bubuntu\b.*\bfocal\b`),
 	},
+	{
+		release: Impish,
+		regexp:  regexp.MustCompile(`(?is)\bubuntu\b.*\bimpish\b`),
+	},
 }
 
 const osReleasePath = `etc/os-release`

--- a/ubuntu/distributionscanner_test.go
+++ b/ubuntu/distributionscanner_test.go
@@ -7,6 +7,25 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
+// impish test data
+var impishOSRelease []byte = []byte(`PRETTY_NAME="Ubuntu 21.10"
+NAME="Ubuntu"
+VERSION_ID="21.10"
+VERSION="21.10 (Impish Indri)"
+VERSION_CODENAME=impish
+ID=ubuntu
+ID_LIKE=debian
+HOME_URL="https://www.ubuntu.com/"
+SUPPORT_URL="https://help.ubuntu.com/"
+BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
+PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+UBUNTU_CODENAME=impish`)
+
+var impishLSBRelease []byte = []byte(`DISTRIB_ID=Ubuntu
+DISTRIB_RELEASE=21.10
+DISTRIB_CODENAME=impish
+DISTRIB_DESCRIPTION="Ubuntu 21.10"`)
+
 // eoan test data
 var eoanOSRelease []byte = []byte(`NAME="Ubuntu"
 VERSION="19.10 (Eoan Ermine)"
@@ -228,6 +247,12 @@ func TestDistributionScanner(t *testing.T) {
 			release:    Eoan,
 			osRelease:  eoanOSRelease,
 			lsbRelease: eoanLSBRelease,
+		},
+		{
+			name:       "impish",
+			release:    Impish,
+			osRelease:  impishOSRelease,
+			lsbRelease: impishLSBRelease,
 		},
 	}
 	for _, tt := range table {

--- a/ubuntu/releases.go
+++ b/ubuntu/releases.go
@@ -16,6 +16,7 @@ const (
 	Xenial  Release = "xenial"
 	Eoan    Release = "eoan"
 	Focal   Release = "focal"
+	Impish  Release = "impish"
 )
 
 var AllReleases = map[Release]struct{}{
@@ -28,6 +29,7 @@ var AllReleases = map[Release]struct{}{
 	Xenial:  struct{}{},
 	Eoan:    struct{}{},
 	Focal:   struct{}{},
+	Impish:  struct{}{},
 }
 
 var ReleaseToVersionID = map[Release]string{
@@ -40,6 +42,7 @@ var ReleaseToVersionID = map[Release]string{
 	Xenial:  "16.04",
 	Eoan:    "19.10",
 	Focal:   "20.04",
+	Impish:  "21.10",
 }
 
 var artfulDist = &claircore.Distribution{
@@ -121,6 +124,15 @@ var focalDist = &claircore.Distribution{
 	VersionCodeName: "focal",
 }
 
+var impishDist = &claircore.Distribution{
+	Name:            "Ubuntu",
+	Version:         "21.10 (Impish Indri)",
+	DID:             "ubuntu",
+	PrettyName:      "Ubuntu 21.10",
+	VersionID:       "21.10",
+	VersionCodeName: "impish",
+}
+
 func releaseToDist(r Release) *claircore.Distribution {
 	switch r {
 	case Artful:
@@ -141,6 +153,8 @@ func releaseToDist(r Release) *claircore.Distribution {
 		return eoanDist
 	case Focal:
 		return focalDist
+	case Impish:
+		return impishDist
 	default:
 		// return empty dist
 		return &claircore.Distribution{}

--- a/ubuntu/updater.go
+++ b/ubuntu/updater.go
@@ -32,6 +32,7 @@ var shouldBzipFetch = map[Release]bool{
 	Xenial:  true,
 	Focal:   true,
 	Eoan:    true,
+	Impish:  true,
 }
 
 var (


### PR DESCRIPTION
The time is nigh, the canonical gods have spoken, the latest
offspring shall be named impish. Adding the boilerplate to
fetch, scan and match on.

Signed-off-by: crozzy <joseph.crosland@gmail.com>