### PR TITLE
Database ID

### DIFF
--- a/internal/indexer/store.go
+++ b/internal/indexer/store.go
@@ -12,6 +12,9 @@ type Store interface {
 	Setter
 	Querier
 	Indexer
+	// DatabaseID should report a stable, opaque identifier for this database
+	// instance.
+	DatabaseID(context.Context) ([]byte, error)
 	// Close frees any resources associated with the Store.
 	Close(context.Context) error
 }

--- a/internal/indexer/store_mock.go
+++ b/internal/indexer/store_mock.go
@@ -63,6 +63,21 @@ func (mr *MockStoreMockRecorder) Close(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockStore)(nil).Close), arg0)
 }
 
+// DatabaseID mocks base method
+func (m *MockStore) DatabaseID(arg0 context.Context) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DatabaseID", arg0)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DatabaseID indicates an expected call of DatabaseID
+func (mr *MockStoreMockRecorder) DatabaseID(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DatabaseID", reflect.TypeOf((*MockStore)(nil).DatabaseID), arg0)
+}
+
 // DistributionsByLayer mocks base method
 func (m *MockStore) DistributionsByLayer(arg0 context.Context, arg1 claircore.Digest, arg2 VersionedScanners) ([]*claircore.Distribution, error) {
 	m.ctrl.T.Helper()

--- a/test/integration/db.go
+++ b/test/integration/db.go
@@ -97,6 +97,11 @@ func NewDB(ctx context.Context, t testing.TB) (*DB, error) {
 	if _, err := conn.Exec(ctx, loadUUID); err != nil {
 		return nil, err
 	}
+	var oid uint32
+	if err := conn.QueryRow(ctx, `SELECT oid::int4 FROM pg_database WHERE datname = current_database();`).Scan(&oid); err != nil {
+		return nil, err
+	}
+	t.Logf("database oid: %d", oid)
 	if err := conn.Close(ctx); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
These changes expose a database-specific ID, and then incorporates it into the `state` endpoint calculation.