### PR TITLE
Add Release Alpine 3.15

### DIFF
--- a/alpine/distributionscanner.go
+++ b/alpine/distributionscanner.go
@@ -36,6 +36,10 @@ type alpineRegex struct {
 // ex: "Welcome to Alpine Linux 3.3"
 var alpineRegexes = []alpineRegex{
 	{
+		dist:   alpine3_15Dist,
+		regexp: regexp.MustCompile(`Alpine Linux v?3\.15`),
+	},
+	{
 		dist:   alpine3_14Dist,
 		regexp: regexp.MustCompile(`Alpine Linux v?3\.14`),
 	},

--- a/alpine/distributionscanner_test.go
+++ b/alpine/distributionscanner_test.go
@@ -75,6 +75,11 @@ func TestDistributionScanner(t *testing.T) {
 			OSRelease: v3_14_OSRelease,
 			Issue:     v3_14_Issue,
 		},
+		{
+			Release:   V3_15,
+			OSRelease: v3_15_OSRelease,
+			Issue:     v3_15_Issue,
+		},
 	}
 	for _, tt := range table {
 		t.Run(string(tt.Release), func(t *testing.T) {
@@ -175,7 +180,7 @@ HOME_URL="https://alpinelinux.org/"
 BUG_REPORT_URL="https://bugs.alpinelinux.org/"`
 	v3_12_Issue = `Welcome to Alpine Linux 3.12
 Kernel \r on an \m (\l)`
-    v3_13_OSRelease = `NAME="Alpine Linux"
+	v3_13_OSRelease = `NAME="Alpine Linux"
 ID=alpine
 VERSION_ID=3.13.4
 PRETTY_NAME="Alpine Linux v3.13"
@@ -183,12 +188,20 @@ HOME_URL="https://alpinelinux.org/"
 BUG_REPORT_URL="https://bugs.alpinelinux.org/"`
 	v3_13_Issue = `Welcome to Alpine Linux 3.13
 Kernel \r on an \m (\l)`
-    v3_14_OSRelease = `NAME="Alpine Linux"
+	v3_14_OSRelease = `NAME="Alpine Linux"
 ID=alpine
 VERSION_ID=3.14.1
 PRETTY_NAME="Alpine Linux v3.14"
 HOME_URL="https://alpinelinux.org/"
 BUG_REPORT_URL="https://bugs.alpinelinux.org/"`
 	v3_14_Issue = `Welcome to Alpine Linux 3.14
+Kernel \r on an \m (\l)`
+	v3_15_OSRelease = `NAME="Alpine Linux"
+ID=alpine
+VERSION_ID=3.15.0
+PRETTY_NAME="Alpine Linux v3.15"
+HOME_URL="https://alpinelinux.org/"
+BUG_REPORT_URL="https://bugs.alpinelinux.org/"`
+	v3_15_Issue = `Welcome to Alpine Linux 3.15
 Kernel \r on an \m (\l)`
 )

--- a/alpine/release.go
+++ b/alpine/release.go
@@ -16,6 +16,7 @@ type Release string
 
 // These are known releases.
 const (
+	V3_15 Release = "v3.15"
 	V3_14 Release = "v3.14"
 	V3_13 Release = "v3.13"
 	V3_12 Release = "v3.12"
@@ -58,6 +59,7 @@ var (
 	alpine3_12Dist = mkdist(3, 12)
 	alpine3_13Dist = mkdist(3, 13)
 	alpine3_14Dist = mkdist(3, 14)
+	alpine3_15Dist = mkdist(3, 15)
 )
 
 func releaseToDist(r Release) *claircore.Distribution {
@@ -86,6 +88,8 @@ func releaseToDist(r Release) *claircore.Distribution {
 		return alpine3_13Dist
 	case V3_14:
 		return alpine3_14Dist
+	case V3_15:
+		return alpine3_15Dist
 	default:
 		// return empty dist
 		return &claircore.Distribution{}

--- a/alpine/updaterset.go
+++ b/alpine/updaterset.go
@@ -8,8 +8,8 @@ import (
 )
 
 var alpineMatrix = map[Repo][]Release{
-	Main:      []Release{V3_14, V3_13, V3_12, V3_11, V3_10, V3_9, V3_8, V3_7, V3_6, V3_5, V3_4, V3_3},
-	Community: []Release{V3_14, V3_13, V3_12, V3_11, V3_10, V3_9, V3_8, V3_7, V3_6, V3_5, V3_4, V3_3},
+	Main:      []Release{V3_15, V3_14, V3_13, V3_12, V3_11, V3_10, V3_9, V3_8, V3_7, V3_6, V3_5, V3_4, V3_3},
+	Community: []Release{V3_15, V3_14, V3_13, V3_12, V3_11, V3_10, V3_9, V3_8, V3_7, V3_6, V3_5, V3_4, V3_3},
 }
 
 func UpdaterSet(_ context.Context) (driver.UpdaterSet, error) {


### PR DESCRIPTION
Implemented Alpine 3.15 similar to [alpine: add new releases 3.13 and 3.14](https://github.com/quay/claircore/pull/464)

Fixed indentation in [alpine/distributionscanner_test.go](https://github.com/quay/claircore/compare/main...xXPOLYGONXx:add_alpine_release_3.15?expand=1#diff-5fb50dfdf52a36fbee6aa96e54351867e53d17a8284dca7c84fa30862bfec15d)