### PR TITLE
dockerfile: correctly parse env declarations that span multiple lines

### DIFF
--- a/rhel/dockerfile/dockerfile_test.go
+++ b/rhel/dockerfile/dockerfile_test.go
@@ -88,6 +88,22 @@ func TestSplit(t *testing.T) {
 			In: "k=' v '	\v k=\"   \"",
 			Want: []string{`k=' v '`, `k="   "`},
 		},
+		{
+			In: `k="v" \
+				k=v`,
+			Want: []string{`k="v"`, `k=v`},
+		},
+		{
+			In: `k=v \
+			k="v" k=v`,
+			Want: []string{`k=v`, `k="v"`, `k=v`},
+		},
+		{
+			In: `k="v" \
+
+				k=v`,
+			Want: []string{`k="v"`, `k=v`},
+		},
 	} {
 		t.Logf("input: %#q", p.In)
 		got, err := splitKV('\\', p.In)


### PR DESCRIPTION
the dockerfile parser would treat new line escape as an extra key
value pair, then panic when it did not contain an equals character

Fixes #526

Note: I've made it so that the new line escape and following whitespace is trimmed as that generates the pair as expected - using the first test I added as an example, it finds the 2nd pair as `"k=v"` rather than `"\\\n\t\t\t\tk=v"`