### PR TITLE
java: account for zip reporting file with bad format

### DIFF
--- a/java/jar/jar.go
+++ b/java/jar/jar.go
@@ -245,9 +245,18 @@ func extractInner(ctx context.Context, outer string, z *zip.Reader) ([]Info, err
 		}
 		// Okay, now reasonably certain this is a jar.
 		zr, err := zip.NewReader(bytes.NewReader(bs), sz)
-		if err != nil {
+		switch {
+		case errors.Is(err, nil):
+		case errors.Is(err, zip.ErrFormat):
+			zlog.Debug(ctx).
+				Str("member", name).
+				Err(err).
+				Msg("not actually a jar: invalid zip")
+			return nil
+		default:
 			return err
 		}
+
 		ps, err := Parse(ctx, name, zr)
 		switch {
 		case errors.Is(err, nil):

--- a/java/jar/jar_test.go
+++ b/java/jar/jar_test.go
@@ -196,27 +196,32 @@ func TestJAR(t *testing.T) {
 			ctx := zlog.Test(ctx, t)
 			f, err := td.Open(ent.Name())
 			if err != nil {
-				t.Fatal(err)
+				t.Error(err)
+				return
 			}
 			defer f.Close()
 			fi, err := ent.Info()
 			if err != nil {
-				t.Fatal(err)
+				t.Error(err)
+				return
 			}
 			sz := fi.Size()
 			buf.Reset()
 			buf.Grow(int(sz))
 			if _, err := buf.ReadFrom(f); err != nil {
 				t.Error(err)
+				return
 			}
 
 			z, err := zip.NewReader(bytes.NewReader(buf.Bytes()), fi.Size())
 			if err != nil {
-				t.Error(err)
+				t.Fatal(err)
+				return
 			}
 			i, err := Parse(ctx, n, z)
 			if err != nil {
 				t.Error(err)
+				return
 			}
 			for _, i := range i {
 				t.Log(i.String())

--- a/java/packagescanner.go
+++ b/java/packagescanner.go
@@ -140,9 +140,18 @@ func (s *Scanner) Scan(ctx context.Context, layer *claircore.Layer) ([]*claircor
 			continue
 		}
 		z, err := zip.NewReader(bytes.NewReader(zb), sz)
-		if err != nil {
+		switch {
+		case errors.Is(err, nil):
+		case errors.Is(err, zip.ErrFormat):
+			zlog.Info(ctx).
+				Str("file", h.Name).
+				Err(err).
+				Msg("not actually a jar: invalid zip")
+			continue
+		default:
 			return nil, err
 		}
+
 		infos, err := jar.Parse(ctx, h.Name, z)
 		switch {
 		case err == nil:


### PR DESCRIPTION
It's possible that badly formatted jars can escape detection
and zip.NewReader will report back an error. We can't really
advance from here so report error and return.

Signed-off-by: crozzy <joseph.crosland@gmail.com>