### PR TITLE
libvuln: log the names of all the configured matchers

### DIFF
--- a/crda/remotematcher.go
+++ b/crda/remotematcher.go
@@ -195,7 +195,7 @@ func WithBatchSize(batchSize int) Option {
 }
 
 // Name implements driver.Matcher.
-func (*Matcher) Name() string { return "crda" }
+func (m *Matcher) Name() string { return fmt.Sprintf("crda-%s)", m.ecosystem) }
 
 // Maps the crda ecosystem to claircore.Repository.Name.
 func ecosystemToRepositoryName(ecosystem string) string {

--- a/libvuln/libvuln.go
+++ b/libvuln/libvuln.go
@@ -70,10 +70,15 @@ func New(ctx context.Context, opts *Opts) (*Libvuln, error) {
 		matchers.WithConfigs(opts.MatcherConfigs),
 		matchers.WithOutOfTree(opts.Matchers),
 	)
-	zlog.Info(ctx).Int("len", len(l.matchers)).Msg("matchers created")
 	if err != nil {
 		return nil, err
 	}
+
+	matcherNames := make([]string, 0, len(l.matchers))
+	for _, m := range l.matchers {
+		matcherNames = append(matcherNames, m.Name())
+	}
+	zlog.Info(ctx).Strs("matchers", matcherNames).Msg("matchers created")
 
 	// create update manager
 	locks, err := ctxlock.New(ctx, pool)


### PR DESCRIPTION
This logs the name of each of the matchers that the matcher
instance will use. This info on startup helps when debugging
reports.

Signed-off-by: crozzy <joseph.crosland@gmail.com>