### PR TITLE
bug: xml decoding

### DIFF
--- a/aws/client.go
+++ b/aws/client.go
@@ -19,6 +19,7 @@ import (
 	"go.opentelemetry.io/otel/baggage"
 	"go.opentelemetry.io/otel/label"
 
+	"github.com/quay/claircore/internal/xmlutil"
 	"github.com/quay/claircore/pkg/tmp"
 )
 
@@ -86,8 +87,9 @@ func (c *Client) RepoMD(ctx context.Context) (alas.RepoMD, error) {
 		}
 
 		repoMD := alas.RepoMD{}
-		err = xml.NewDecoder(resp.Body).Decode(&repoMD)
-		if err != nil {
+		dec := xml.NewDecoder(resp.Body)
+		dec.CharsetReader = xmlutil.CharsetReader
+		if err := dec.Decode(&repoMD); err != nil {
 			zlog.Error(ctx).
 				Err(err).
 				Msg("failed xml unmarshal")

--- a/aws/updater.go
+++ b/aws/updater.go
@@ -15,6 +15,7 @@ import (
 	"go.opentelemetry.io/otel/label"
 
 	"github.com/quay/claircore"
+	"github.com/quay/claircore/internal/xmlutil"
 	"github.com/quay/claircore/libvuln/driver"
 )
 
@@ -82,8 +83,9 @@ func (u *Updater) Fetch(ctx context.Context, fingerprint driver.Fingerprint) (io
 
 func (u *Updater) Parse(ctx context.Context, contents io.ReadCloser) ([]*claircore.Vulnerability, error) {
 	var updates alas.Updates
-	err := xml.NewDecoder(contents).Decode(&updates)
-	if err != nil {
+	dec := xml.NewDecoder(contents)
+	dec.CharsetReader = xmlutil.CharsetReader
+	if err := dec.Decode(&updates); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal updates xml: %v", err)
 	}
 	dist := releaseToDist(u.release)

--- a/debian/parser.go
+++ b/debian/parser.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/label"
 
 	"github.com/quay/claircore"
+	"github.com/quay/claircore/internal/xmlutil"
 	"github.com/quay/claircore/pkg/ovalutil"
 )
 
@@ -21,7 +22,9 @@ func (u *Updater) Parse(ctx context.Context, r io.ReadCloser) ([]*claircore.Vuln
 	zlog.Info(ctx).Msg("starting parse")
 	defer r.Close()
 	root := oval.Root{}
-	if err := xml.NewDecoder(r).Decode(&root); err != nil {
+	dec := xml.NewDecoder(r)
+	dec.CharsetReader = xmlutil.CharsetReader
+	if err := dec.Decode(&root); err != nil {
 		return nil, fmt.Errorf("debian: unable to decode OVAL document: %w", err)
 	}
 	zlog.Debug(ctx).Msg("xml decoded")

--- a/internal/xmlutil/charset.go
+++ b/internal/xmlutil/charset.go
@@ -1,0 +1,22 @@
+package xmlutil
+
+import (
+	"io"
+
+	"golang.org/x/text/encoding/ianaindex"
+)
+
+// CharsetReader is a function suitable for using as an xml.Decoder's
+// CharsetReader member.
+func CharsetReader(charset string, r io.Reader) (io.Reader, error) {
+	// equivalence hacks
+	switch charset {
+	case "ASCII":
+		charset = `US-ASCII`
+	}
+	enc, err := ianaindex.IANA.Encoding(charset)
+	if err != nil {
+		return nil, err
+	}
+	return enc.NewDecoder().Reader(r), nil
+}

--- a/internal/xmlutil/xmlutil.go
+++ b/internal/xmlutil/xmlutil.go
@@ -1,0 +1,2 @@
+// Package xmlutil contains some helpers for working with XML data.
+package xmlutil

--- a/oracle/parser.go
+++ b/oracle/parser.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/label"
 
 	"github.com/quay/claircore"
+	"github.com/quay/claircore/internal/xmlutil"
 	"github.com/quay/claircore/libvuln/driver"
 	"github.com/quay/claircore/pkg/ovalutil"
 )
@@ -39,7 +40,9 @@ func (u *Updater) Parse(ctx context.Context, r io.ReadCloser) ([]*claircore.Vuln
 	zlog.Info(ctx).Msg("starting parse")
 	defer r.Close()
 	root := oval.Root{}
-	if err := xml.NewDecoder(r).Decode(&root); err != nil {
+	dec := xml.NewDecoder(r)
+	dec.CharsetReader = xmlutil.CharsetReader
+	if err := dec.Decode(&root); err != nil {
 		return nil, fmt.Errorf("oracle: unable to decode OVAL document: %w", err)
 	}
 	zlog.Debug(ctx).Msg("xml decoded")

--- a/rhel/parser.go
+++ b/rhel/parser.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/label"
 
 	"github.com/quay/claircore"
+	"github.com/quay/claircore/internal/xmlutil"
 	"github.com/quay/claircore/pkg/cpe"
 	"github.com/quay/claircore/pkg/ovalutil"
 )
@@ -22,7 +23,9 @@ func (u *Updater) Parse(ctx context.Context, r io.ReadCloser) ([]*claircore.Vuln
 	zlog.Info(ctx).Msg("starting parse")
 	defer r.Close()
 	root := oval.Root{}
-	if err := xml.NewDecoder(r).Decode(&root); err != nil {
+	dec := xml.NewDecoder(r)
+	dec.CharsetReader = xmlutil.CharsetReader
+	if err := dec.Decode(&root); err != nil {
 		return nil, fmt.Errorf("rhel: unable to decode OVAL document: %w", err)
 	}
 	zlog.Debug(ctx).Msg("xml decoded")

--- a/suse/parser.go
+++ b/suse/parser.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/label"
 
 	"github.com/quay/claircore"
+	"github.com/quay/claircore/internal/xmlutil"
 	"github.com/quay/claircore/libvuln/driver"
 	"github.com/quay/claircore/pkg/ovalutil"
 )
@@ -24,7 +25,9 @@ func (u *Updater) Parse(ctx context.Context, r io.ReadCloser) ([]*claircore.Vuln
 	zlog.Info(ctx).Msg("starting parse")
 	defer r.Close()
 	root := oval.Root{}
-	if err := xml.NewDecoder(r).Decode(&root); err != nil {
+	dec := xml.NewDecoder(r)
+	dec.CharsetReader = xmlutil.CharsetReader
+	if err := dec.Decode(&root); err != nil {
 		return nil, fmt.Errorf("suse: unable to decode OVAL document: %w", err)
 	}
 	zlog.Debug(ctx).Msg("xml decoded")
@@ -41,7 +44,8 @@ func (u *Updater) Parse(ctx context.Context, r io.ReadCloser) ([]*claircore.Vuln
 				// specific xml database. we'll use the updater's release
 				// to map the parsed vulnerabilities
 				Dist: releaseToDist(u.release),
-			}}, nil
+			},
+		}, nil
 	}
 	vulns, err := ovalutil.RPMDefsToVulns(ctx, &root, protoVulns)
 	if err != nil {

--- a/ubuntu/parser.go
+++ b/ubuntu/parser.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/label"
 
 	"github.com/quay/claircore"
+	"github.com/quay/claircore/internal/xmlutil"
 	"github.com/quay/claircore/pkg/ovalutil"
 )
 
@@ -21,7 +22,9 @@ func (u *Updater) Parse(ctx context.Context, r io.ReadCloser) ([]*claircore.Vuln
 	zlog.Info(ctx).Msg("starting parse")
 	defer r.Close()
 	root := oval.Root{}
-	if err := xml.NewDecoder(r).Decode(&root); err != nil {
+	dec := xml.NewDecoder(r)
+	dec.CharsetReader = xmlutil.CharsetReader
+	if err := dec.Decode(&root); err != nil {
 		return nil, fmt.Errorf("ubuntu: unable to decode OVAL document: %w", err)
 	}
 	zlog.Debug(ctx).Msg("xml decoded")


### PR DESCRIPTION
Debian recently added an `encoding` attribute to the XML text element in their OVAL feeds, which causes the stdlib xml decoder to call the `CharsetReader` member. We should populate this for robustness' sake.