### PR TITLE
jar: fix text harness

### DIFF
--- a/java/jar/jar_test.go
+++ b/java/jar/jar_test.go
@@ -245,6 +245,7 @@ func TestJARBadManifest(t *testing.T) {
 	for _, n := range ls {
 		t.Log(n)
 		t.Run(n.Name(), func(t *testing.T) {
+			ctx := zlog.Test(ctx, t)
 			f, err := os.Open(filepath.Join(path, n.Name()))
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
Recent internal changes caused this test to emit logs, which
(purposefully) panics if not set up correctly.

Signed-off-by: Hank Donnay <hdonnay@redhat.com>