### PR TITLE
libindex, libvuln: allow empty connection string

### DIFF
--- a/libindex/opts.go
+++ b/libindex/opts.go
@@ -2,7 +2,6 @@ package libindex
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/quay/claircore/alpine"
@@ -22,7 +21,10 @@ const (
 
 // Opts are dependencies and options for constructing an instance of libindex
 type Opts struct {
-	// the connection string for the datastore specified above
+	// The connection string for the data store.
+	//
+	// TODO(hank) This should be a factory function so the data store can be
+	// a clean abstraction.
 	ConnString string
 	// how often we should try to acquire a lock for scanning a given manifest if lock is taken
 	ScanLockRetry time.Duration
@@ -59,11 +61,6 @@ type Opts struct {
 }
 
 func (o *Opts) Parse(ctx context.Context) error {
-	// required
-	if o.ConnString == "" {
-		return fmt.Errorf("ConnString not provided")
-	}
-
 	// optional
 	if (o.ScanLockRetry == 0) || (o.ScanLockRetry < time.Second) {
 		o.ScanLockRetry = DefaultScanLockRetry

--- a/libvuln/opts.go
+++ b/libvuln/opts.go
@@ -32,6 +32,9 @@ type Opts struct {
 	// connection pool.
 	MaxConnPool int32
 	// A connection string to the database Libvuln will use.
+	//
+	// TODO(hank) This should be a factory function so the data store can be
+	// a clean abstraction.
 	ConnString string
 	// An interval on which Libvuln will check for new security database
 	// updates.
@@ -125,9 +128,6 @@ func (o *Opts) parse(ctx context.Context) error {
 	ctx = baggage.ContextWithValues(ctx,
 		label.String("component", "libvuln/Opts.parse"))
 	// required
-	if o.ConnString == "" {
-		return fmt.Errorf("no connection string provided")
-	}
 	if o.UpdateRetention == 1 || o.UpdateRetention < 0 {
 		return fmt.Errorf("update retention must be 0 or greater then 1")
 	}


### PR DESCRIPTION
These changes just allow a connection string to be empty, which currently has the database driver use the environment.

Enables quay/clair#1467.