### PR TITLE
updates: Record in a new table each time updaters check for vulns

### DIFF
--- a/internal/vulnstore/postgres/recordupdatetime.go
+++ b/internal/vulnstore/postgres/recordupdatetime.go
@@ -1,0 +1,84 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/quay/zlog"
+	"go.opentelemetry.io/otel/baggage"
+	"go.opentelemetry.io/otel/label"
+)
+
+// recordUpdaterUpdateTime records that an updater is up to date with vulnerabilities at this time
+// inserts an updater with last update timestamp, or updates an existing updater with a new update time
+func recordUpdaterUpdateTime(ctx context.Context, pool *pgxpool.Pool, updaterName string, updateTime time.Time) error {
+	const (
+		// upsert inserts or updates a record of the last time an updater was checked for new vulns
+		upsert = `INSERT INTO update_time (
+			updater_name,
+			last_update_time
+		) VALUES (
+			$1,
+			$2
+		)
+		ON CONFLICT (updater_name) DO UPDATE
+		SET last_update_time = $2
+		RETURNING updater_name;`
+	)
+
+	ctx = baggage.ContextWithValues(ctx,
+		label.String("component", "internal/vulnstore/postgres/recordUpdaterUpdateTime"))
+
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("unable to start transaction: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	var returnedUpdaterName string
+
+	if err := pool.QueryRow(ctx, upsert, updaterName, updateTime).Scan(&returnedUpdaterName); err != nil {
+		return fmt.Errorf("failed to upsert last update time: %w", err)
+	}
+
+	zlog.Debug(ctx).
+		Str("updater", updaterName).
+		Msg("Updater last update time stored in database")
+
+	return nil
+}
+
+// recordUpdaterSetUpdateTime records that all updaters for a single updaterSet are up to date with vulnerabilities at this time
+// updates all existing updaters from this upater set with the new update time
+// the updater set parameteer passed needs to match the prefix of the given udpdater set name format
+func recordUpdaterSetUpdateTime(ctx context.Context, pool *pgxpool.Pool, updaterSet string, updateTime time.Time) error {
+	const (
+		update = `UPDATE update_time
+		SET last_update_time = $1
+		WHERE updater_name like $2 || '%'
+		RETURNING updater_name;`
+	)
+
+	ctx = baggage.ContextWithValues(ctx,
+		label.String("component", "internal/vulnstore/postgres/recordUpdaterSetUpdateTime"))
+
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("unable to start transaction: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	var updaterName string
+
+	if err := pool.QueryRow(ctx, update, updateTime, updaterSet).Scan(&updaterName); err != nil {
+		return fmt.Errorf("failed to update all last update times for updater set %s: %w", updaterSet, err)
+	}
+
+	zlog.Debug(ctx).
+		Str("updaterSet", updaterSet).
+		Msg(fmt.Sprintf("Last update time stored in database for all %s updaters", updaterSet))
+
+	return nil
+}

--- a/internal/vulnstore/postgres/store.go
+++ b/internal/vulnstore/postgres/store.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -57,4 +58,14 @@ func (s *Store) DeleteUpdateOperations(ctx context.Context, id ...uuid.UUID) (in
 		return 0, fmt.Errorf("failed to delete: %w", err)
 	}
 	return tag.RowsAffected(), nil
+}
+
+// RecordUpdaterUpdateTime records that an updater is up to date with vulnerabilities at this time
+func (s *Store) RecordUpdaterUpdateTime(ctx context.Context, updaterName string, updateTime time.Time) error {
+	return recordUpdaterUpdateTime(ctx, s.pool, updaterName, updateTime)
+}
+
+// RecordUpdaterSetUpdateTime records that all updaters from a updater set are up to date with vulnerabilities at this time
+func (s *Store) RecordUpdaterSetUpdateTime(ctx context.Context, updaterSet string, updateTime time.Time) error {
+	return recordUpdaterSetUpdateTime(ctx, s.pool, updaterSet, updateTime)
 }

--- a/internal/vulnstore/postgres/update_e2e_test.go
+++ b/internal/vulnstore/postgres/update_e2e_test.go
@@ -7,6 +7,7 @@ import (
 	"hash/fnv"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -77,6 +78,7 @@ func (e *e2e) Run(ctx context.Context) func(*testing.T) {
 
 		{"Update", e.Update},
 		{"GetUpdateOperations", e.GetUpdateOperations},
+		{"recordUpdaterUpdateTime", e.recordUpdateTimes},
 		{"Diff", e.Diff},
 		{"DeleteUpdateOperations", e.DeleteUpdateOperations},
 	}
@@ -160,6 +162,34 @@ func (e *e2e) GetUpdateOperations(ctx context.Context) func(*testing.T) {
 				t.Fatal(cmp.Diff(want, got, updateOpCmp))
 			}
 		}
+		t.Log("ok")
+	}
+}
+
+// recordUpdateTimes confirms multiple updates to record last update times
+// and then an update to an whole updater set
+func (e *e2e) recordUpdateTimes(ctx context.Context) func(*testing.T) {
+	return func(t *testing.T) {
+		ctx := zlog.Test(ctx, t)
+		expectedTableContents := make(map[string]time.Time)
+		updates := make(map[string]time.Time)
+		updates["test-updater-1"] = time.Date(2021, time.Month(2), 21, 1, 10, 30, 0, time.UTC)
+		updates["test-updater-2"] = time.Date(2021, time.Month(2), 21, 1, 10, 30, 0, time.UTC)
+		updates["test-updater-1"] = time.Date(2021, time.Month(2), 22, 1, 10, 30, 0, time.UTC)
+		for updater, updateTime := range updates {
+			err := e.s.RecordUpdaterUpdateTime(ctx, updater, updateTime)
+			if err != nil {
+				t.Fatalf("failed to perform update: %v", err)
+			}
+			expectedTableContents[updater] = updateTime
+		}
+		checkUpdateTimes(ctx, t, e.pool, expectedTableContents)
+
+		newUpdaterSetTime := time.Date(2021, time.Month(2), 25, 1, 10, 30, 0, time.UTC)
+		e.s.RecordUpdaterSetUpdateTime(ctx, "test", newUpdaterSetTime)
+		expectedTableContents["test-updater-1"] = newUpdaterSetTime
+		expectedTableContents["test-updater-2"] = newUpdaterSetTime
+		checkUpdateTimes(ctx, t, e.pool, expectedTableContents)
 		t.Log("ok")
 	}
 }
@@ -412,6 +442,60 @@ WHERE uo.ref = $1::uuid;`
 	for name := range expectedVulns {
 		if _, ok := queriedVulns[name]; !ok {
 			t.Fatalf("expected vuln %v was not found in query", name)
+		}
+	}
+}
+
+// checkUpdateTimes confirms updater update times are upserted into the database correctly when
+// store.RecordUpaterUptdateTime is called.
+func checkUpdateTimes(ctx context.Context, t *testing.T, pool *pgxpool.Pool, updates map[string]time.Time) {
+	const query = `SELECT updater_name, last_update_time
+FROM update_time`
+
+	rows, err := pool.Query(ctx, query)
+	if err != nil {
+		t.Fatalf("query failed: %v", err)
+	}
+	defer rows.Close()
+
+	type updateRecord struct {
+		updaterName    string
+		lastUpdateTime time.Time
+	}
+
+	queriedUpdates := make(map[string]time.Time)
+	for rows.Next() {
+		var updaterName string
+		var lastUpdateTime time.Time
+		err := rows.Scan(
+			&updaterName,
+			&lastUpdateTime,
+		)
+		if err != nil {
+			t.Fatalf("failed to scan update: %v", err)
+		}
+		queriedUpdates[updaterName] = lastUpdateTime
+	}
+	if err := rows.Err(); err != nil {
+		t.Error(err)
+	}
+
+	// confirm we did not receive unexpected updates
+	for name, got := range queriedUpdates {
+		if want, ok := updates[name]; !ok {
+			t.Fatalf("received unexpected update: %s %v", name, got)
+		} else {
+			// compare update time
+			if !cmp.Equal(want, got) {
+				t.Fatal(cmp.Diff(want, got))
+			}
+		}
+	}
+
+	// confirm queriedUpdates contain all expected updates
+	for name := range updates {
+		if _, ok := queriedUpdates[name]; !ok {
+			t.Fatalf("expected update %v was not found in query", name)
 		}
 	}
 }

--- a/internal/vulnstore/updater.go
+++ b/internal/vulnstore/updater.go
@@ -2,6 +2,7 @@ package vulnstore
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -55,4 +56,8 @@ type Updater interface {
 	GC(ctx context.Context, keep int) (int64, error)
 	// Initialized reports whether the vulnstore contains vulnerabilities.
 	Initialized(context.Context) (bool, error)
+	// RecordUpdaterUpdateTime records that an updater is up to date with vulnerabilities at this time
+	RecordUpdaterUpdateTime(ctx context.Context, updaterName string, updateTime time.Time) error
+	// RecordUpdaterSetUpdateTime records that all updaters from a updater set are up to date with vulnerabilities at this time
+	RecordUpdaterSetUpdateTime(ctx context.Context, updaterSet string, updateTime time.Time) error
 }

--- a/libvuln/jsonblob/jsonblob.go
+++ b/libvuln/jsonblob/jsonblob.go
@@ -288,3 +288,13 @@ func (s *Store) UpdateEnrichments(ctx context.Context, kind string, fp driver.Fi
 	}}, s.ops[kind]...)
 	return ref, nil
 }
+
+// RecordUpdaterUpdateTime is unimplimented
+func (s *Store) RecordUpdaterUpdateTime(ctx context.Context, updaterName string, updateTime time.Time) error {
+	return nil
+}
+
+// recordUpdaterSetUpdateTime is unimplimented
+func (s *Store) RecordUpdaterSetUpdateTime(ctx context.Context, updaterSet string, updateTime time.Time) error {
+	return nil
+}

--- a/libvuln/migrations/migrations.go
+++ b/libvuln/migrations/migrations.go
@@ -46,4 +46,11 @@ var Migrations = []migrate.Migration{
 			return err
 		},
 	},
+	{
+		ID: 6,
+		Up: func(tx *sql.Tx) error {
+			_, err := tx.Exec(migration6)
+			return err
+		},
+	},
 }

--- a/libvuln/migrations/migrations6.go
+++ b/libvuln/migrations/migrations6.go
@@ -1,0 +1,13 @@
+package migrations
+
+const (
+	// this migration modifies the database to add a
+	// table to record update times
+	migration6 = `
+-- update_time is a table keeping a record of when updaters were last checked for new vulnerabilities
+CREATE TABLE IF NOT EXISTS update_time (
+	updater_name TEXT PRIMARY KEY,
+	last_update_time TIMESTAMP WITH TIME ZONE DEFAULT now()
+);
+`
+)

--- a/libvuln/updates/manager.go
+++ b/libvuln/updates/manager.go
@@ -149,9 +149,13 @@ func (m *Manager) Run(ctx context.Context) error {
 	// If construction fails, we will simply ignore those updater
 	// sets.
 	for _, factory := range m.factories {
+		updateTime := time.Now()
 		set, err := factory.UpdaterSet(ctx)
 		if err != nil {
 			zlog.Error(ctx).Err(err).Msg("failed constructing factory, excluding from run")
+			continue
+		}
+		if m.updaterSetUpToDate(ctx, set, updateTime) {
 			continue
 		}
 		updaters = append(updaters, set.Updaters()...)
@@ -206,9 +210,19 @@ func (m *Manager) Run(ctx context.Context) error {
 				return
 			}
 
+			updateTime := time.Now()
 			err = m.driveUpdater(ctx, u)
 			if err != nil {
 				errChan <- fmt.Errorf("%v: %w", u.Name(), err)
+			} else {
+				err = m.store.RecordUpdaterUpdateTime(ctx, u.Name(), updateTime)
+				if err != nil {
+					zlog.Error(ctx).
+						Err(err).
+						Str("updater", u.Name()).
+						Str("updateTime", updateTime.String()).
+						Msg("error while recording updater run time")
+				}
 			}
 		}(toRun[i])
 	}
@@ -249,6 +263,26 @@ func (m *Manager) Run(ctx context.Context) error {
 		return errors.New(b.String())
 	}
 	return nil
+}
+
+// updaterSetUpToDate checks for a stub updater set indicating that the whole updater set
+// is up to date and then be recorded the time in the db
+func (m *Manager) updaterSetUpToDate(ctx context.Context, set driver.UpdaterSet, updateTime time.Time) bool {
+	if len(set.Updaters()) == 1 {
+		if set.Updaters()[0].Name() == "rhel-all" {
+			updaterSet := "RHEL"
+			err := m.store.RecordUpdaterSetUpdateTime(ctx, updaterSet, updateTime)
+			if err != nil {
+				zlog.Error(ctx).
+					Err(err).
+					Str("updaterSet", updaterSet).
+					Str("updateTime", updateTime.String()).
+					Msg(fmt.Sprintf("error while recording update time for all updaters in updater set %s", updaterSet))
+			}
+			return true
+		}
+	}
+	return false
 }
 
 // DriveUpdater performs the business logic of fetching, parsing, and loading

--- a/rhel/updaterset.go
+++ b/rhel/updaterset.go
@@ -135,6 +135,9 @@ func (f *Factory) UpdaterSet(ctx context.Context) (driver.UpdaterSet, error) {
 	switch res.StatusCode {
 	case http.StatusOK:
 	case http.StatusNotModified:
+		// return stub updater to allow us to record that all rhel updaters are up to date
+		stubUpdater := Updater{name: "rhel-all"}
+		s.Add(&stubUpdater)
 		return s, nil
 	default:
 		return s, fmt.Errorf("unexpected response: %v", res.Status)


### PR DESCRIPTION
We needed a way to show how up to date the vulnerability database is
to prove the validity of a report, and also prove updaters are running
even when there are no new vulnerabilities