### PR TITLE
crda: remove default key

### DIFF
--- a/crda/remotematcher.go
+++ b/crda/remotematcher.go
@@ -7,44 +7,37 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/quay/zlog"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/libvuln/driver"
 )
 
 var (
-	_ driver.Matcher             = (*Matcher)(nil)
-	_ driver.RemoteMatcher       = (*Matcher)(nil)
-	_ driver.MatcherConfigurable = (*Matcher)(nil)
+	_ driver.Matcher       = (*matcher)(nil)
+	_ driver.RemoteMatcher = (*matcher)(nil)
 )
 
 const (
-	// Bounded concurrency limit.
-	defaultBatchSize          = 10
-	defaultEndPoint           = "/api/v2/vulnerability-analysis"
-	defaultRequestConcurrency = 10
-	defaultURL                = "https://gw.api.openshift.io/api/v2/"
-	defaultSource             = "clair-upstream"
-	defaultKey                = "207c527cfc2a6b8dcf4fa43ad7a976da"
+	batchSize     = 10
+	defaultURL    = "https://gw.api.openshift.io/api/v2/"
+	defaultSource = "clair-upstream"
 )
 
 var supportedEcosystems = []string{"pypi", "maven"}
 
-// Matcher attempts to correlate discovered python packages with reported
+// matcher attempts to correlate discovered python packages with reported
 // vulnerabilities.
-type Matcher struct {
-	client             *http.Client
-	url                *url.URL
-	ecosystem          string
-	key                string
-	source             string
-	batchSize          int
-	requestConcurrency int
+type matcher struct {
+	client    *http.Client
+	url       *url.URL
+	ecosystem string
+	source    string
 }
 
 // Build struct to model CRDA V2 ComponentAnalysis response which
@@ -74,15 +67,17 @@ type VulnRequest struct {
 	Packages  []Package `json:"package_versions"`
 }
 
-// Option controls the configuration of a Matcher.
-type Option func(*Matcher) error
+// option controls the configuration of a Matcher.
+type option func(*matcher) error
 
-// NewMatcher returns a configured Matcher or reports an error.
-func NewMatcher(ecosystem string, opt ...Option) (*Matcher, error) {
+// newMatcher returns a configured Matcher or reports an error.
+func newMatcher(ecosystem string, key string, opt ...option) (*matcher, error) {
 	if ecosystem == "" {
 		return nil, fmt.Errorf("empty ecosystem")
 	}
-	m := Matcher{ecosystem: ecosystem}
+	m := matcher{
+		ecosystem: ecosystem,
+	}
 
 	for _, f := range opt {
 		if err := f(&m); err != nil {
@@ -96,177 +91,70 @@ func NewMatcher(ecosystem string, opt ...Option) (*Matcher, error) {
 		if err != nil {
 			return nil, err
 		}
-
 	}
-
-	if m.key == "" {
-		m.key = defaultKey
-	}
-
+	m.url.Path = path.Join(m.url.Path, `vulnerability-analysis`)
+	m.url.ForceQuery = true
+	v := m.url.Query()
+	v.Set("user_key", key)
+	m.url.RawQuery = v.Encode()
 	if m.source == "" {
 		m.source = defaultSource
 	}
-
-	m.url = &url.URL{
-		Scheme:     m.url.Scheme,
-		Host:       m.url.Host,
-		Path:       defaultEndPoint,
-		ForceQuery: true,
-		RawQuery:   "user_key=" + m.key,
-	}
-
 	if m.client == nil {
 		m.client = http.DefaultClient // TODO(hank) Remove DefaultClient
-	}
-
-	// defaults to a sane concurrency limit.
-	if m.requestConcurrency < 1 {
-		m.requestConcurrency = defaultRequestConcurrency
-	}
-
-	// defaults to a sane batch size.
-	if m.batchSize < 1 {
-		m.batchSize = defaultBatchSize
 	}
 
 	return &m, nil
 }
 
 // WithClient sets the http.Client that the matcher should use for requests.
-//
-// If not passed to NewMatcher, http.DefaultClient will be used.
-func WithClient(c *http.Client) Option {
-	return func(m *Matcher) error {
+func withClient(c *http.Client) option {
+	return func(m *matcher) error {
 		m.client = c
 		return nil
 	}
 }
 
-// WithHost sets the server host name that the matcher should use for requests.
-//
-// If not passed to NewMatcher, defaultHost will be used.
-func WithURL(url *url.URL) Option {
-	return func(m *Matcher) error {
+// WithURL sets the URL that the matcher should use for requests.
+func withURL(url *url.URL) option {
+	return func(m *matcher) error {
 		m.url = url
 		return nil
 	}
 }
 
-// WithKey sets the api key that the matcher should use for requests.
-//
-// If not passed to NewMatcher, defaultKey will be used.
-func WithKey(key string) Option {
-	return func(m *Matcher) error {
-		m.key = key
-		return nil
-	}
-}
-
 // WithSource sets the source that the matcher should use for requests.
-//
-// If not passed to NewMatcher, defaultSource will be used.
-func WithSource(source string) Option {
-	return func(m *Matcher) error {
+func withSource(source string) option {
+	return func(m *matcher) error {
 		m.source = source
 		return nil
 	}
 }
 
-// WithRequestConcurrency sets the concurrency limit for the network calls.
-//
-// If not passed to NewMatcher, a defaultRequestConcurrency will be used.
-func WithRequestConcurrency(requestConcurrency int) Option {
-	return func(m *Matcher) error {
-		m.requestConcurrency = requestConcurrency
-		return nil
-	}
-}
-
-// WithBatchSize sets the number of records to be batched per request.
-//
-// If not passed to NewMatcher, a defaultBatchSize will be used.
-func WithBatchSize(batchSize int) Option {
-	return func(m *Matcher) error {
-		m.batchSize = batchSize
-		return nil
-	}
-}
-
 // Name implements driver.Matcher.
-func (m *Matcher) Name() string { return fmt.Sprintf("crda-%s", m.ecosystem) }
-
-// Maps the crda ecosystem to claircore.Repository.Name.
-func ecosystemToRepositoryName(ecosystem string) string {
-	switch ecosystem {
-	case "maven":
-		return "maven"
-	case "pypi":
-		return "pypi"
-	default:
-		panic(fmt.Sprintf("unknown ecosystem %s", ecosystem))
-	}
-}
+func (m *matcher) Name() string { return fmt.Sprintf("crda-%s", m.ecosystem) }
 
 // Filter implements driver.Matcher.
-func (m *Matcher) Filter(record *claircore.IndexRecord) bool {
+func (m *matcher) Filter(record *claircore.IndexRecord) bool {
 	if record.Repository == nil {
 		return false
 	}
-	return record.Repository.Name == ecosystemToRepositoryName(m.ecosystem)
+	return record.Repository.Name == m.ecosystem
 }
 
 // Query implements driver.Matcher.
-func (*Matcher) Query() []driver.MatchConstraint {
+func (*matcher) Query() []driver.MatchConstraint {
 	panic("unreachable")
 }
 
 // Vulnerable implements driver.Matcher.
-func (*Matcher) Vulnerable(ctx context.Context, record *claircore.IndexRecord, vuln *claircore.Vulnerability) (bool, error) {
+func (*matcher) Vulnerable(ctx context.Context, record *claircore.IndexRecord, vuln *claircore.Vulnerability) (bool, error) {
 	// RemoteMatcher can match Package and Vulnerability.
 	panic("unreachable")
 }
 
-// Config is the configuration accepted by the Matcher.
-//
-// By convention, it's in a map key called "crda".
-type Config struct {
-	URL         string `json:"url" yaml:"url"`
-	Source      string `json:"source" yaml:"source"`
-	Key         string `json:"key" yaml:"key"`
-	Concurrency int    `json:"concurrent_requests" yaml:"concurrent_requests"`
-}
-
-// Configure implements driver.MatcherConfigurable.
-func (m *Matcher) Configure(ctx context.Context, f driver.MatcherConfigUnmarshaler, c *http.Client) error {
-	var cfg Config
-	if err := f(&cfg); err != nil {
-		return err
-	}
-
-	if cfg.Concurrency > 0 {
-		m.requestConcurrency = cfg.Concurrency
-	}
-
-	if cfg.URL != "" {
-		u, err := url.Parse(cfg.URL)
-		if err != nil {
-			return err
-		}
-		m.url = u
-	}
-	if cfg.Source != "" {
-		m.source = cfg.Source
-	}
-	if cfg.Key != "" {
-		m.key = cfg.Key
-	}
-	m.client = c
-
-	return nil
-}
-
 // QueryRemoteMatcher implements driver.RemoteMatcher.
-func (m *Matcher) QueryRemoteMatcher(ctx context.Context, records []*claircore.IndexRecord) (map[string][]*claircore.Vulnerability, error) {
+func (m *matcher) QueryRemoteMatcher(ctx context.Context, records []*claircore.IndexRecord) (map[string][]*claircore.Vulnerability, error) {
 	ctx = zlog.ContextWithValues(ctx, "component", "crda/Matcher.QueryRemoteMatcher")
 	zlog.Debug(ctx).
 		Int("records", len(records)).
@@ -312,28 +200,31 @@ func (m *Matcher) QueryRemoteMatcher(ctx context.Context, records []*claircore.I
 	return results, nil
 }
 
-func (m *Matcher) invokeComponentAnalysesInBatch(ctx context.Context, records []*claircore.IndexRecord) []*VulnReport {
+func (m *matcher) invokeComponentAnalysesInBatch(ctx context.Context, records []*claircore.IndexRecord) []*VulnReport {
 	ctrlC := make(chan []*VulnReport, len(records))
 	results := []*VulnReport{}
-	batchSize := m.batchSize
-	var g errgroup.Group
+	var wg sync.WaitGroup
+	ct := len(records) / batchSize
+	if len(records)%batchSize != 0 {
+		ct++
+	}
+	wg.Add(ct)
 	for start := 0; start < len(records); start += batchSize {
 		start := start
 		end := start + batchSize
 		if end > len(records) {
 			end = len(records)
 		}
-		g.Go(func() error {
+		go func() {
+			defer wg.Done()
 			vulns, err := m.invokeComponentAnalyses(ctx, records[start:end])
 			if err != nil {
 				zlog.Error(ctx).Err(err).Msg("remote api call failure")
-				return nil
 			}
 			ctrlC <- vulns
-			return nil
-		})
+		}()
 	}
-	g.Wait()
+	wg.Wait()
 	close(ctrlC)
 
 	for res := range ctrlC {
@@ -343,7 +234,7 @@ func (m *Matcher) invokeComponentAnalysesInBatch(ctx context.Context, records []
 	return results
 }
 
-func (m *Matcher) invokeComponentAnalyses(ctx context.Context, records []*claircore.IndexRecord) ([]*VulnReport, error) {
+func (m *matcher) invokeComponentAnalyses(ctx context.Context, records []*claircore.IndexRecord) ([]*VulnReport, error) {
 	// prepare request.
 	request := VulnRequest{
 		Ecosystem: m.ecosystem,


### PR DESCRIPTION
This patchset changes the `crda` defaults so that it's disabled without
a config providing an API key.

Signed-off-by: Hank Donnay <hdonnay@redhat.com>