### PR TITLE
Diagnostics groundwork

### DIFF
--- a/toolkit/events/events.go
+++ b/toolkit/events/events.go
@@ -1,0 +1,164 @@
+// Package events is a small event logging system.
+package events
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"runtime"
+	"strings"
+	"sync"
+)
+
+// Group is a grouping of log events going to a common Sink.
+type Group struct {
+	mu   sync.Mutex // Protects errs
+	sink Sink
+	name string
+	errs errs
+}
+
+// NewGroup creates a new Group "name" writing to Sink "sink".
+//
+// The passed Context is only used for the duration of the NewGroup call.
+func NewGroup(ctx context.Context, sink Sink, name string) (*Group, error) {
+	if err := sink.StartGroup(ctx, name); err != nil {
+		return nil, err
+	}
+	g := &Group{
+		sink: sink,
+		name: name,
+	}
+	_, file, line, _ := runtime.Caller(1)
+	runtime.SetFinalizer(g, func(g *Group) {
+		panic(fmt.Sprintf("%s:%d: Group not finished", file, line))
+	})
+	return g, nil
+}
+
+// Finish signals to the underlying sink that this group is done and reports any
+// errors accumulated by derived Log objects.
+func (g *Group) Finish(ctx context.Context) error {
+	runtime.SetFinalizer(g, nil)
+	if err := g.sink.FinishGroup(ctx, g.name); err != nil {
+		g.pushErr(err)
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.errs != nil {
+		return g.errs
+	}
+	return nil
+}
+
+func (g *Group) event(topic string, ev Event) {
+	if err := g.sink.Event(g.name, topic, ev); err != nil {
+		g.pushErr(err)
+	}
+}
+
+func (g *Group) pushErr(err error) {
+	g.mu.Lock()
+	g.errs = append(g.errs, err)
+	g.mu.Unlock()
+}
+
+type errs []error
+
+func (e errs) Error() string {
+	switch len(e) {
+	case 0:
+		return "<nil>" // ???
+	case 1:
+		return e[0].Error()
+	default:
+		var b strings.Builder
+		b.WriteString("errors while emitting logs:\n")
+		for _, e := range e {
+			b.WriteByte('\t')
+			b.WriteString(e.Error())
+			b.WriteByte('\n')
+		}
+		return b.String()
+	}
+}
+
+func (e errs) Is(target error) bool {
+	for _, e := range e {
+		if errors.Is(e, target) {
+			return true
+		}
+	}
+	return false
+}
+
+func (e errs) As(target interface{}) bool {
+	for _, e := range e {
+		if errors.As(e, target) {
+			return true
+		}
+	}
+	return false
+}
+
+// Log is the facade that "user" code should expect.
+type Log interface {
+	Printf(format string, v ...interface{})
+	Errorf(format string, v ...interface{})
+	// Finish should be called in a defer, right after FromContext.
+	Finish()
+}
+
+type opaque struct{}
+
+var ctxKey = (*opaque)(nil)
+
+// WithGroup returns a Context with the provided Group embedded.
+//
+// Functions further down the call stack can derive Log interfaces with
+// FromContext.
+func WithGroup(ctx context.Context, g *Group) context.Context {
+	return context.WithValue(ctx, ctxKey, g)
+}
+
+// FromContext returns a Log implementation grouping messages under the provided
+// topic.
+//
+// The returned implementation may be all no-op methods, so callers should avoid
+// logging "expensive" data.
+func FromContext(ctx context.Context, topic string) Log {
+	g := ctx.Value(ctxKey).(*Group)
+	if g == nil {
+		return noop{}
+	}
+	l := log{
+		g:     g,
+		topic: topic,
+	}
+	g.sink.Topic(topic)
+	l.buf.Grow(4 * 1024) // Guess
+	return &l
+}
+
+// Sink is the interface that event sinks must implement.
+type Sink interface {
+	// StartGroup is called when a new group is created. The Context should only
+	// be used for the duration of the StartGroup call.
+	StartGroup(ctx context.Context, group string) error
+	// Topic notifies the Sink that a topic has been started. The same topic may
+	// be passed multiple times.
+	Topic(string)
+	// Event is called once per event, some time between StartGroup and
+	// FinishGroup.
+	Event(group, topic string, ev Event) error
+	// FinishGroup is called when the group is finished. The Context may be
+	// canceled when this method is called.
+	FinishGroup(ctx context.Context, group string) error
+}
+
+// Event is the event information delivered to a Sink.
+type Event struct {
+	_key    struct{}
+	Message string
+	Error   bool
+}

--- a/toolkit/events/log.go
+++ b/toolkit/events/log.go
@@ -1,0 +1,60 @@
+package events
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// Log implements Log by writing prints to a strings.Builder.
+//
+// Using a Builder should prevent extra copying. The log "lines" are written
+// with invalid UTF-8 sequences between them, which lets the resulting giant
+// string be split easily with very little chance of mangling inputs.
+type log struct {
+	g     *Group
+	buf   bytes.Buffer
+	topic string
+}
+
+func (l *log) Printf(format string, v ...interface{}) {
+	if format == "" {
+		return
+	}
+	l.msg(fmt.Sprintf(format, v...), false)
+}
+
+func (l *log) Errorf(format string, v ...interface{}) {
+	if format == "" {
+		return
+	}
+	l.msg(fmt.Sprintf(format, v...), true)
+}
+
+func (l *log) msg(msg string, err bool) {
+	if err {
+		l.buf.WriteByte('\xFF')
+	}
+	l.buf.WriteString(msg)
+	l.buf.WriteByte('\x00')
+}
+
+func (l *log) Finish() {
+	b := l.buf.Bytes()
+	for len(b) != 0 {
+		i := bytes.IndexByte(b, '\x00')
+		var m []byte
+		m, b = b[:i], b[i+1:]
+		err := m[0] == '\xFF'
+		if err {
+			m = m[1:]
+		}
+		l.g.event(l.topic, Event{Error: err, Message: string(m)})
+	}
+}
+
+// Noop is an implementer of Log that does nothing.
+type noop struct{}
+
+func (noop) Printf(_ string, _ ...interface{}) {}
+func (noop) Errorf(_ string, _ ...interface{}) {}
+func (noop) Finish()                           {}

--- a/toolkit/events/log_test.go
+++ b/toolkit/events/log_test.go
@@ -1,0 +1,117 @@
+package events
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+)
+
+type testSink struct{ *testing.T }
+
+var _ Sink = (*testSink)(nil)
+
+func (s *testSink) StartGroup(ctx context.Context, group string) error {
+	s.Logf("group start: %s", group)
+	return nil
+}
+
+func (s *testSink) Topic(t string) {
+	s.Logf("topic: %s", t)
+}
+
+func (s *testSink) Event(group, topic string, ev Event) error {
+	s.Logf("%s/%s: err?%v %s", group, topic, ev.Error, ev.Message)
+	return nil
+}
+
+func (s *testSink) FinishGroup(ctx context.Context, group string) error {
+	s.Logf("group finish: %s", group)
+	return nil
+}
+
+func TestLog(t *testing.T) {
+	ctx := context.Background()
+	sink := &testSink{T: t}
+	g, err := NewGroup(ctx, sink, t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := g.Finish(ctx); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	ctx = WithGroup(ctx, g)
+	l := FromContext(ctx, "topic")
+	defer l.Finish()
+	l.Printf("")
+	l.Errorf("")
+	for i := 0; i < 10; i++ {
+		l.Printf("hello, %d", i)
+		l.Errorf("hello, %d", i)
+	}
+}
+
+type errSink struct {
+	start  error
+	event  error
+	finish error
+}
+
+var _ Sink = (*errSink)(nil)
+
+func (s *errSink) StartGroup(ctx context.Context, group string) (err error) {
+	err, s.start = s.start, nil
+	return err
+}
+
+func (s *errSink) Topic(t string) {}
+
+func (s *errSink) Event(group, topic string, ev Event) (err error) {
+	err, s.event = s.event, nil
+	return err
+}
+
+func (s *errSink) FinishGroup(ctx context.Context, group string) (err error) {
+	err, s.finish = s.finish, nil
+	return err
+}
+
+func TestLogError(t *testing.T) {
+	startErr := errors.New("start")
+	eventErr := errors.New("event")
+	finishErr := errors.New("finish")
+	ctx := context.Background()
+	sink := &errSink{
+		start:  startErr,
+		event:  eventErr,
+		finish: finishErr,
+	}
+	_, err := NewGroup(ctx, sink, t.Name())
+	if !errors.Is(err, startErr) {
+		t.Errorf("got: %v, want: %v", err, startErr)
+	}
+	g, err := NewGroup(ctx, sink, t.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx = WithGroup(ctx, g)
+	l := FromContext(ctx, "topic")
+	l.Printf("hello, test")
+	l.Finish()
+
+	err = g.Finish(ctx)
+	if got, want := err, eventErr; !errors.Is(got, want) {
+		t.Errorf("got: %v, want: %v", got, want)
+	}
+	if got, want := err, finishErr; !errors.Is(got, want) {
+		t.Errorf("got: %v, want: %v", got, want)
+	}
+	if got, want := err, io.EOF; errors.Is(got, want) {
+		t.Errorf("got: %v, want: %v", got, want)
+	}
+	t.Log(err)
+}


### PR DESCRIPTION
As a part of PROJQUAY-3147, this PR lays groundwork for having all the modular components emit event logs.