### PR TITLE
Check validator on 200 response

### DIFF
--- a/alpine/fetcher.go
+++ b/alpine/fetcher.go
@@ -36,7 +36,10 @@ func (u *Updater) Fetch(ctx context.Context, hint driver.Fingerprint) (io.ReadCl
 
 	switch res.StatusCode {
 	case http.StatusOK:
-		// break
+		if t := string(hint); t == "" || t != res.Header.Get("etag") {
+			break
+		}
+		fallthrough
 	case http.StatusNotModified:
 		zlog.Info(ctx).Msg("database unchanged since last fetch")
 		return nil, hint, driver.Unchanged

--- a/debian/updater.go
+++ b/debian/updater.go
@@ -114,7 +114,11 @@ func (u *Updater) Fetch(ctx context.Context, fingerprint driver.Fingerprint) (io
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		zlog.Info(ctx).Msg("fetching latest oval database")
+		if fingerprint == "" || string(fingerprint) != resp.Header.Get("etag") {
+			zlog.Info(ctx).Msg("fetching latest oval database")
+			break
+		}
+		fallthrough
 	case http.StatusNotModified:
 		return nil, fingerprint, driver.Unchanged
 	default:

--- a/pkg/ovalutil/fetcher.go
+++ b/pkg/ovalutil/fetcher.go
@@ -134,10 +134,13 @@ func (f *Fetcher) Fetch(ctx context.Context, hint driver.Fingerprint) (io.ReadCl
 		return nil, hint, err
 	}
 	switch res.StatusCode {
+	case http.StatusOK:
+		if fp.Etag == "" || fp.Etag != res.Header.Get("etag") {
+			break
+		}
+		fallthrough
 	case http.StatusNotModified:
 		return nil, hint, driver.Unchanged
-	case http.StatusOK:
-		// break
 	default:
 		return nil, hint, fmt.Errorf("ovalutil: fetcher got unexpected HTTP response: %d (%s)", res.StatusCode, res.Status)
 	}

--- a/pyupio/updater.go
+++ b/pyupio/updater.go
@@ -174,10 +174,13 @@ func (u *Updater) Fetch(ctx context.Context, hint driver.Fingerprint) (io.ReadCl
 		return nil, hint, err
 	}
 	switch res.StatusCode {
+	case http.StatusOK:
+		if t := string(hint); t == "" || t != res.Header.Get("etag") {
+			break
+		}
+		fallthrough
 	case http.StatusNotModified:
 		return nil, hint, driver.Unchanged
-	case http.StatusOK:
-		// break
 	default:
 		return nil, hint, fmt.Errorf("pyupio: fetcher got unexpected HTTP response: %d (%s)", res.StatusCode, res.Status)
 	}

--- a/rhel/updaterset.go
+++ b/rhel/updaterset.go
@@ -131,6 +131,10 @@ func (f *Factory) UpdaterSet(ctx context.Context) (driver.UpdaterSet, error) {
 
 	switch res.StatusCode {
 	case http.StatusOK:
+		if t := f.manifestEtag; t == "" || t != res.Header.Get("etag") {
+			break
+		}
+		fallthrough
 	case http.StatusNotModified:
 		return s, nil
 	default:

--- a/ubuntu/updater.go
+++ b/ubuntu/updater.go
@@ -131,7 +131,11 @@ func (u *Updater) Fetch(ctx context.Context, fingerprint driver.Fingerprint) (io
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		zlog.Info(ctx).Msg("fetching latest oval database")
+		if fp := string(fingerprint); fp == "" || fp != resp.Header.Get("etag") {
+			zlog.Info(ctx).Msg("fetching latest oval database")
+			break
+		}
+		fallthrough
 	case http.StatusNotModified:
 		return nil, fingerprint, driver.Unchanged
 	default:


### PR DESCRIPTION
This makes all the uses of an `if-none-match` header also check the response's Etag. Some servers send weak validators with non-identity content encodings, and don't validate them when sent back. This prevents processing unchanged resources, but doesn't prevent all the network traffic.

Closes #559