### PR TITLE
alpine: Ignore any vulns that have 0 as the secfixes version

### DIFF
--- a/alpine/parser.go
+++ b/alpine/parser.go
@@ -55,6 +55,10 @@ func (u *Updater) parse(ctx context.Context, sdb *SecurityDB) ([]*claircore.Vuln
 func unpackSecFixes(partial claircore.Vulnerability, secFixes map[string][]string) []*claircore.Vulnerability {
 	out := []*claircore.Vulnerability{}
 	for fixedIn, IDs := range secFixes {
+		if fixedIn == "0" {
+			// This means "not-affected" in the Alpine secfixes context
+			continue
+		}
 		for _, id := range IDs {
 			v := partial
 			v.Name = id

--- a/alpine/parser_test.go
+++ b/alpine/parser_test.go
@@ -124,6 +124,57 @@ var V3_10_community_truncated_vulns = []*claircore.Vulnerability{
 	},
 }
 
+var V3_15_main_truncated_vulns = []*claircore.Vulnerability{
+	{
+		Name:               "CVE-2017-15873",
+		Links:              "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-15873",
+		Updater:            "alpine-main-v3.15-updater",
+		FixedInVersion:     "1.27.2-r4",
+		NormalizedSeverity: claircore.Unknown,
+		Package: &claircore.Package{
+			Name: "busybox",
+			Kind: claircore.BINARY,
+		},
+		Dist: releaseToDist(V3_15),
+	},
+	{
+		Name:               "CVE-2016-0634",
+		Links:              "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-0634",
+		Updater:            "alpine-main-v3.15-updater",
+		FixedInVersion:     "4.4.12-r1",
+		NormalizedSeverity: claircore.Unknown,
+		Package: &claircore.Package{
+			Name: "bash",
+			Kind: claircore.BINARY,
+		},
+		Dist: releaseToDist(V3_15),
+	},
+	{
+		Name:               "CVE-2017-16544",
+		Links:              "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-16544",
+		Updater:            "alpine-main-v3.15-updater",
+		FixedInVersion:     "1.27.2-r4",
+		NormalizedSeverity: claircore.Unknown,
+		Package: &claircore.Package{
+			Name: "busybox",
+			Kind: claircore.BINARY,
+		},
+		Dist: releaseToDist(V3_15),
+	},
+	{
+		Name:               "CVE-2017-15874",
+		Links:              "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-15874",
+		Updater:            "alpine-main-v3.15-updater",
+		FixedInVersion:     "1.27.2-r4",
+		NormalizedSeverity: claircore.Unknown,
+		Package: &claircore.Package{
+			Name: "busybox",
+			Kind: claircore.BINARY,
+		},
+		Dist: releaseToDist(V3_15),
+	},
+}
+
 func TestParser(t *testing.T) {
 	t.Parallel()
 	ctx, done := context.WithCancel(context.Background())
@@ -139,6 +190,12 @@ func TestParser(t *testing.T) {
 			repo:     Community,
 			testFile: "v3_10_community_truncated.json",
 			expected: V3_10_community_truncated_vulns,
+		},
+		{
+			release:  V3_15,
+			repo:     Main,
+			testFile: "v3_15_main_truncated.json",
+			expected: V3_15_main_truncated_vulns,
 		},
 	}
 

--- a/alpine/testdata/v3_15_main_truncated.json
+++ b/alpine/testdata/v3_15_main_truncated.json
@@ -1,0 +1,44 @@
+{
+    "apkurl": "{{urlprefix}}/{{distroversion}}/{{reponame}}/{{arch}}/{{pkg.name}}-{{pkg.ver}}.apk",
+    "archs": [
+        "aarch64",
+        "armhf",
+        "armv7",
+        "ppc64le",
+        "s390x",
+        "x86",
+        "x86_64"
+    ],
+    "reponame": "main",
+    "urlprefix": "https://dl-cdn.alpinelinux.org/alpine",
+    "distroversion": "v3.15",
+    "packages": [
+        {
+            "pkg": {
+                "name": "bash",
+                "secfixes": {
+                    "4.4.12-r1": [
+                        "CVE-2016-0634"
+                    ]
+                }
+            }
+        },
+        {
+            "pkg": {
+                "name": "busybox",
+                "secfixes": {
+                    "0": [
+                        "CVE-2021-42373",
+                        "CVE-2021-42376",
+                        "CVE-2021-42377"
+                    ],
+                    "1.27.2-r4": [
+                        "CVE-2017-16544",
+                        "CVE-2017-15873",
+                        "CVE-2017-15874"
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/libvuln/migrations/07-delete-alpine-update_operation.sql
+++ b/libvuln/migrations/07-delete-alpine-update_operation.sql
@@ -1,0 +1,7 @@
+-- Delete all the alpine updaters that have fixed_in_version of 0.
+DELETE FROM update_operation WHERE updater IN (
+	'alpine-community-v3.13-updater', 'alpine-community-v3.14-updater',
+	'alpine-community-v3.15-updater', 'alpine-main-v3.10-updater',
+	'alpine-main-v3.11-updater', 'alpine-main-v3.12-updater'
+	'alpine-main-v3.13-updater', 'alpine-main-v3.14-updater'
+	'alpine-main-v3.15-updater', 'alpine-main-v3.8-updater');

--- a/libvuln/migrations/migrations.go
+++ b/libvuln/migrations/migrations.go
@@ -50,4 +50,8 @@ var Migrations = []migrate.Migration{
 		ID: 6,
 		Up: runFile("06-delete-debian-update_operation.sql"),
 	},
+	{
+		ID: 7,
+		Up: runFile("07-delete-alpine-update_operation.sql"),
+	},
 }


### PR DESCRIPTION
Alpine apparently uses 0 to denote that the distro was
"never affected", hence it shouldn't show up in any
vulnerability reports. This change does no save any vulns
to the DB that have a 0 version.

Signed-off-by: crozzy <joseph.crosland@gmail.com>