### PR TITLE
alpine: Ignore any vulns that have 0 as the fixed_in_version

### DIFF
--- a/alpine/matcher.go
+++ b/alpine/matcher.go
@@ -55,7 +55,7 @@ func (*Matcher) Vulnerable(ctx context.Context, record *claircore.IndexRecord, v
 	}
 
 	if vuln.FixedInVersion == "0" {
-		return true, nil
+		return false, nil
 	}
 
 	if v1.LessThan(v2) {


### PR DESCRIPTION
Alpine apparently uses 0 to denote that the distro was
"never affected", hence it shouldn't show up in any
vulnerability reports. This change checks the fixed_in_version
and indicates not vulnerable if it's 0.

Signed-off-by: crozzy <joseph.crosland@gmail.com>