### PR TITLE
crda: Stop using the Client Clair instanciates

### DIFF
--- a/crda/matcherfactory.go
+++ b/crda/matcherfactory.go
@@ -108,7 +108,6 @@ func (f *Factory) Configure(ctx context.Context, cfg driver.MatcherConfigUnmarsh
 			Msg("configured API key")
 	}
 
-	f.client = c
 	f.ecosystems = fc.Ecosystems
 	return nil
 }

--- a/crda/remotematcher.go
+++ b/crda/remotematcher.go
@@ -100,9 +100,10 @@ func newMatcher(ecosystem string, key string, opt ...option) (*matcher, error) {
 	if m.source == "" {
 		m.source = defaultSource
 	}
-	if m.client == nil {
-		m.client = http.DefaultClient // TODO(hank) Remove DefaultClient
-	}
+	// The CRDA remote matcher doesn't use the clair roundtripper
+	// client as the ratelimiting doesn't apply and a specific
+	// timeout is preferred.
+	m.client = &http.Client{Timeout: 5 * time.Second}
 
 	return &m, nil
 }


### PR DESCRIPTION
The remote matcher is currently getting passed the client
used for all updating that includes more specific settings
for that workload (like ratelimiting API calls). This change
moves the CRDA matcher to use its own client with a specific
timeout that matches the context deadline.

Signed-off-by: crozzy <joseph.crosland@gmail.com>