### PR TITLE
ubuntu: update releaseToDist to correct cosmic error

### DIFF
--- a/ubuntu/releases.go
+++ b/ubuntu/releases.go
@@ -140,7 +140,7 @@ func releaseToDist(r Release) *claircore.Distribution {
 	case Bionic:
 		return bionicDist
 	case Cosmic:
-		return bionicDist
+		return cosmicDist
 	case Disco:
 		return discoDist
 	case Precise:


### PR DESCRIPTION
Currently the releaseToDist function returns discoDist
when it finds a Cosmic release. Correct that.

Signed-off-by: crozzy <joseph.crosland@gmail.com>