### PR TITLE
Add Release Alpine 3.16

### DIFF
--- a/alpine/distributionscanner.go
+++ b/alpine/distributionscanner.go
@@ -40,6 +40,10 @@ type alpineRegex struct {
 // ex: "Welcome to Alpine Linux 3.3"
 var alpineRegexes = []alpineRegex{
 	{
+		dist:   alpine3_16Dist,
+		regexp: regexp.MustCompile(`Alpine Linux v?3\.16`),
+	},
+	{
 		dist:   alpine3_15Dist,
 		regexp: regexp.MustCompile(`Alpine Linux v?3\.15`),
 	},

--- a/alpine/distributionscanner_test.go
+++ b/alpine/distributionscanner_test.go
@@ -87,6 +87,11 @@ func TestDistributionScanner(t *testing.T) {
 			OSRelease: mustRead(t, `testdata/3.15/etc/os-release`),
 			Issue:     mustRead(t, `testdata/3.15/etc/issue`),
 		},
+		{
+			Release:   V3_16,
+			OSRelease: mustRead(t, `testdata/3.16/etc/os-release`),
+			Issue:     mustRead(t, `testdata/3.16/etc/issue`),
+		},
 	}
 	for _, tt := range table {
 		t.Run(string(tt.Release), func(t *testing.T) {

--- a/alpine/release.go
+++ b/alpine/release.go
@@ -16,6 +16,7 @@ type Release string
 
 // These are known releases.
 const (
+	V3_16 Release = "v3.16"
 	V3_15 Release = "v3.15"
 	V3_14 Release = "v3.14"
 	V3_13 Release = "v3.13"
@@ -60,6 +61,7 @@ var (
 	alpine3_13Dist = mkdist(3, 13)
 	alpine3_14Dist = mkdist(3, 14)
 	alpine3_15Dist = mkdist(3, 15)
+	alpine3_16Dist = mkdist(3, 16)
 )
 
 func releaseToDist(r Release) *claircore.Distribution {
@@ -90,6 +92,8 @@ func releaseToDist(r Release) *claircore.Distribution {
 		return alpine3_14Dist
 	case V3_15:
 		return alpine3_15Dist
+	case V3_16:
+		return alpine3_16Dist
 	default:
 		// return empty dist
 		return &claircore.Distribution{}

--- a/alpine/testdata/3.16/etc/issue
+++ b/alpine/testdata/3.16/etc/issue
@@ -1,0 +1,3 @@
+Welcome to Alpine Linux 3.16
+Kernel \r on an \m (\l)
+

--- a/alpine/testdata/3.16/etc/os-release
+++ b/alpine/testdata/3.16/etc/os-release
@@ -1,0 +1,6 @@
+NAME="Alpine Linux"
+ID=alpine
+VERSION_ID=3.16.0
+PRETTY_NAME="Alpine Linux v3.16"
+HOME_URL="https://alpinelinux.org/"
+BUG_REPORT_URL="https://bugs.alpinelinux.org/"

--- a/alpine/testdata/3.16/want
+++ b/alpine/testdata/3.16/want
@@ -1,0 +1,1 @@
+[{"did":"alpine","name":"Alpine Linux","version":"3.16","pretty_name":"Alpine Linux v3.16"}]

--- a/alpine/updaterset.go
+++ b/alpine/updaterset.go
@@ -8,8 +8,8 @@ import (
 )
 
 var alpineMatrix = map[Repo][]Release{
-	Main:      []Release{V3_15, V3_14, V3_13, V3_12, V3_11, V3_10, V3_9, V3_8, V3_7, V3_6, V3_5, V3_4, V3_3},
-	Community: []Release{V3_15, V3_14, V3_13, V3_12, V3_11, V3_10, V3_9, V3_8, V3_7, V3_6, V3_5, V3_4, V3_3},
+	Main:      []Release{V3_16, V3_15, V3_14, V3_13, V3_12, V3_11, V3_10, V3_9, V3_8, V3_7, V3_6, V3_5, V3_4, V3_3},
+	Community: []Release{V3_16, V3_15, V3_14, V3_13, V3_12, V3_11, V3_10, V3_9, V3_8, V3_7, V3_6, V3_5, V3_4, V3_3},
 }
 
 func UpdaterSet(_ context.Context) (driver.UpdaterSet, error) {


### PR DESCRIPTION
Alpine 3.16 will probably be released on 01.05.22 (https://gitlab.alpinelinux.org/alpine/aports/-/milestones/183#tab-issues). 
Preparing the project for being able to handle this version.

Implemented Alpine 3.16 similar to https://github.com/quay/claircore/pull/464 & https://github.com/quay/claircore/pull/524

