### PR TITLE
alpine: ingest alpine vulnerabilities as type SOURCE

### DIFF
--- a/alpine/parser.go
+++ b/alpine/parser.go
@@ -42,7 +42,7 @@ func (u *Updater) parse(ctx context.Context, sdb *SecurityDB) ([]*claircore.Vuln
 			NormalizedSeverity: claircore.Unknown,
 			Package: &claircore.Package{
 				Name: pkg.Pkg.Name,
-				Kind: claircore.BINARY,
+				Kind: claircore.SOURCE,
 			},
 			Dist: releaseToDist(u.release),
 		}

--- a/alpine/parser_test.go
+++ b/alpine/parser_test.go
@@ -22,7 +22,7 @@ var V3_10_community_truncated_vulns = []*claircore.Vulnerability{
 		NormalizedSeverity: claircore.Unknown,
 		Package: &claircore.Package{
 			Name: "botan",
-			Kind: claircore.BINARY,
+			Kind: claircore.SOURCE,
 		},
 		Dist: releaseToDist(V3_10),
 	},
@@ -34,7 +34,7 @@ var V3_10_community_truncated_vulns = []*claircore.Vulnerability{
 		NormalizedSeverity: claircore.Unknown,
 		Package: &claircore.Package{
 			Name: "botan",
-			Kind: claircore.BINARY,
+			Kind: claircore.SOURCE,
 		},
 		Dist: releaseToDist(V3_10),
 	},
@@ -46,7 +46,7 @@ var V3_10_community_truncated_vulns = []*claircore.Vulnerability{
 		NormalizedSeverity: claircore.Unknown,
 		Package: &claircore.Package{
 			Name: "botan",
-			Kind: claircore.BINARY,
+			Kind: claircore.SOURCE,
 		},
 		Dist: releaseToDist(V3_10),
 	},
@@ -58,7 +58,7 @@ var V3_10_community_truncated_vulns = []*claircore.Vulnerability{
 		NormalizedSeverity: claircore.Unknown,
 		Package: &claircore.Package{
 			Name: "botan",
-			Kind: claircore.BINARY,
+			Kind: claircore.SOURCE,
 		},
 		Dist: releaseToDist(V3_10),
 	},
@@ -70,7 +70,7 @@ var V3_10_community_truncated_vulns = []*claircore.Vulnerability{
 		NormalizedSeverity: claircore.Unknown,
 		Package: &claircore.Package{
 			Name: "cfengine",
-			Kind: claircore.BINARY,
+			Kind: claircore.SOURCE,
 		},
 		Dist: releaseToDist(V3_10),
 	},
@@ -82,7 +82,7 @@ var V3_10_community_truncated_vulns = []*claircore.Vulnerability{
 		NormalizedSeverity: claircore.Unknown,
 		Package: &claircore.Package{
 			Name: "chicken",
-			Kind: claircore.BINARY,
+			Kind: claircore.SOURCE,
 		},
 		Dist: releaseToDist(V3_10),
 	},
@@ -94,7 +94,7 @@ var V3_10_community_truncated_vulns = []*claircore.Vulnerability{
 		NormalizedSeverity: claircore.Unknown,
 		Package: &claircore.Package{
 			Name: "chicken",
-			Kind: claircore.BINARY,
+			Kind: claircore.SOURCE,
 		},
 		Dist: releaseToDist(V3_10),
 	},
@@ -106,7 +106,7 @@ var V3_10_community_truncated_vulns = []*claircore.Vulnerability{
 		NormalizedSeverity: claircore.Unknown,
 		Package: &claircore.Package{
 			Name: "chicken",
-			Kind: claircore.BINARY,
+			Kind: claircore.SOURCE,
 		},
 		Dist: releaseToDist(V3_10),
 	},
@@ -118,7 +118,7 @@ var V3_10_community_truncated_vulns = []*claircore.Vulnerability{
 		NormalizedSeverity: claircore.Unknown,
 		Package: &claircore.Package{
 			Name: "chicken",
-			Kind: claircore.BINARY,
+			Kind: claircore.SOURCE,
 		},
 		Dist: releaseToDist(V3_10),
 	},

--- a/libvuln/migrations/07-force-alpine-update.sql
+++ b/libvuln/migrations/07-force-alpine-update.sql
@@ -1,0 +1,14 @@
+DELETE FROM update_operation WHERE updater IN (
+	'alpine-community-v3.10-updater', 'alpine-community-v3.11-updater',
+	'alpine-community-v3.12-updater', 'alpine-community-v3.13-updater',
+	'alpine-community-v3.14-updater', 'alpine-community-v3.15-updater',
+	'alpine-community-v3.4-updater', 'alpine-community-v3.5-updater',
+	'alpine-community-v3.6-updater', 'alpine-community-v3.7-updater',
+	'alpine-community-v3.8-updater', 'alpine-community-v3.9-updater',
+	'alpine-main-v3.10-updater', 'alpine-main-v3.11-updater',
+	'alpine-main-v3.12-updater', 'alpine-main-v3.13-updater',
+	'alpine-main-v3.14-updater', 'alpine-main-v3.15-updater',
+	'alpine-main-v3.3-updater', 'alpine-main-v3.4-updater',
+	'alpine-main-v3.5-updater', 'alpine-main-v3.6-updater',
+	'alpine-main-v3.7-updater', 'alpine-main-v3.8-updater',
+	'alpine-main-v3.9-updater');

--- a/libvuln/migrations/migrations.go
+++ b/libvuln/migrations/migrations.go
@@ -50,4 +50,8 @@ var Migrations = []migrate.Migration{
 		ID: 6,
 		Up: runFile("06-delete-debian-update_operation.sql"),
 	},
+	{
+		ID: 7,
+		Up: runFile("07-force-alpine-update.sql"),
+	},
 }


### PR DESCRIPTION
Alpine's security feeds list vulnerabilites by source
package and not binary package, hence we are currently
missing all the vulnerabilites where the binary package
is named differently from the source package.

Signed-off-by: crozzy <joseph.crosland@gmail.com>