### PR TITLE
postgres: run creates before creating transaction

### DIFF
--- a/internal/vulnstore/postgres/enrichment.go
+++ b/internal/vulnstore/postgres/enrichment.go
@@ -109,12 +109,6 @@ DO
 	)
 	ctx = zlog.ContextWithValues(ctx, "component", "internal/vulnstore/postgres/UpdateEnrichments")
 
-	tx, err := s.pool.Begin(ctx)
-	if err != nil {
-		return uuid.Nil, fmt.Errorf("unable to start transaction: %w", err)
-	}
-	defer tx.Rollback(ctx)
-
 	var id uint64
 	var ref uuid.UUID
 
@@ -126,6 +120,12 @@ DO
 
 	updateEnrichmentsCounter.WithLabelValues("create").Add(1)
 	updateEnrichmentsDuration.WithLabelValues("create").Observe(time.Since(start).Seconds())
+
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("unable to start transaction: %w", err)
+	}
+	defer tx.Rollback(ctx)
 
 	zlog.Debug(ctx).
 		Str("ref", ref.String()).

--- a/internal/vulnstore/postgres/updatevulnerabilities.go
+++ b/internal/vulnstore/postgres/updatevulnerabilities.go
@@ -81,12 +81,6 @@ func updateVulnerabilites(ctx context.Context, pool *pgxpool.Pool, updater strin
 	)
 	ctx = zlog.ContextWithValues(ctx, "component", "internal/vulnstore/postgres/updateVulnerabilities")
 
-	tx, err := pool.Begin(ctx)
-	if err != nil {
-		return uuid.Nil, fmt.Errorf("unable to start transaction: %w", err)
-	}
-	defer tx.Rollback(ctx)
-
 	var id uint64
 	var ref uuid.UUID
 
@@ -98,6 +92,12 @@ func updateVulnerabilites(ctx context.Context, pool *pgxpool.Pool, updater strin
 
 	updateVulnerabilitiesCounter.WithLabelValues("create").Add(1)
 	updateVulnerabilitiesDuration.WithLabelValues("create").Observe(time.Since(start).Seconds())
+
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("unable to start transaction: %w", err)
+	}
+	defer tx.Rollback(ctx)
 
 	zlog.Debug(ctx).
 		Str("ref", ref.String()).


### PR DESCRIPTION
Signed-off-by: Iain Duncan <iain.duncan@uk.ibm.com>

This fixes #616 and has been tested in our local setup.

I wasn't sure if using the transaction was the right approach, if the `QueryRow` commands were moved above the `pool.Begin` commands then that would also fix the problem without having to put these commands in the transaction.