### PR TITLE
rhcc: Update vulnerability details to match rhel patched

### DIFF
--- a/rhel/rhcc/matcher_integration_test.go
+++ b/rhel/rhcc/matcher_integration_test.go
@@ -39,19 +39,19 @@ func TestMatcherIntegration(t *testing.T) {
 		{
 			cvemap:      "cve-2021-3762",
 			indexReport: "clair-rhel8-v3.5.5-4",
-			cveID:       "CVE-2021-3762",
+			cveID:       "RHSA-2021:3665",
 			match:       true,
 		},
 		{
 			cvemap:      "cve-2020-8565",
 			indexReport: "rook-ceph-operator-container-4.6-115.d1788e1.release_4.6",
-			cveID:       "CVE-2020-8565",
+			cveID:       "RHSA-2021:2041",
 			match:       true,
 		},
 		{
 			cvemap:      "cve-2020-8565",
 			indexReport: "rook-ceph-operator-container-4.7-159.76b9b11.release_4.7",
-			cveID:       "CVE-2020-8565",
+			cveID:       "RHSA-2021:2041",
 			match:       false,
 		},
 	}

--- a/rhel/rhcc/parser_test.go
+++ b/rhel/rhcc/parser_test.go
@@ -30,13 +30,13 @@ func TestDB(t *testing.T) {
 			Name: "cve-2021-3762",
 			Want: []*claircore.Vulnerability{
 				{
-					Name:               "CVE-2021-3762",
+					Name:               "RHSA-2021:3665",
 					Description:        "A directory traversal vulnerability was found in the ClairCore engine of Clair. An attacker can exploit this by supplying a crafted container image which, when scanned by Clair, allows for arbitrary file write on the filesystem, potentially allowing for remote code execution.",
 					Package:            &claircore.Package{Name: "quay/clair-rhel8", Kind: claircore.BINARY},
 					Updater:            "rhel-container-updater",
 					Issued:             cve20213762issued,
-					Severity:           "important",
-					Links:              "https://access.redhat.com/errata/RHSA-2021:3665",
+					Severity:           "Important",
+					Links:              "https://access.redhat.com/errata/RHSA-2021:3665 https://access.redhat.com/security/cve/CVE-2021-3762",
 					NormalizedSeverity: claircore.High,
 					FixedInVersion:     "v3.5.7-8",
 					Repo:               &goldRepo,
@@ -61,13 +61,13 @@ func TestDB(t *testing.T) {
 			Name: "cve-2021-44228-ose-metering-hive",
 			Want: []*claircore.Vulnerability{
 				{
-					Name:               "CVE-2021-44228",
+					Name:               "RHSA-2021:5106",
 					Description:        "A flaw was found in the Apache Log4j logging library in versions from 2.0.0 and before 2.15.0. A remote attacker who can control log messages or log message parameters, can execute arbitrary code on the server via JNDI LDAP endpoint.",
 					Package:            &claircore.Package{Name: "openshift4/ose-metering-hive", Kind: claircore.BINARY},
 					Updater:            "rhel-container-updater",
 					Issued:             date_2021_12_16,
-					Severity:           "moderate",
-					Links:              "https://access.redhat.com/errata/RHSA-2021:5106",
+					Severity:           "Moderate",
+					Links:              "https://access.redhat.com/errata/RHSA-2021:5106 https://access.redhat.com/security/cve/CVE-2021-44228",
 					NormalizedSeverity: claircore.Medium,
 					Range: &claircore.Range{
 						Lower: claircore.Version{
@@ -83,13 +83,13 @@ func TestDB(t *testing.T) {
 					Repo:           &goldRepo,
 				},
 				{
-					Name:               "CVE-2021-44228",
+					Name:               "RHSA-2021:5107",
 					Description:        "A flaw was found in the Apache Log4j logging library in versions from 2.0.0 and before 2.15.0. A remote attacker who can control log messages or log message parameters, can execute arbitrary code on the server via JNDI LDAP endpoint.",
 					Package:            &claircore.Package{Name: "openshift4/ose-metering-hive", Kind: claircore.BINARY},
 					Updater:            "rhel-container-updater",
 					Issued:             date_2021_12_16,
 					Severity:           "Critical",
-					Links:              "https://access.redhat.com/errata/RHSA-2021:5107",
+					Links:              "https://access.redhat.com/errata/RHSA-2021:5107 https://access.redhat.com/security/cve/CVE-2021-44228",
 					NormalizedSeverity: claircore.Critical,
 					Range: &claircore.Range{
 						Lower: claircore.Version{
@@ -105,13 +105,13 @@ func TestDB(t *testing.T) {
 					Repo:           &goldRepo,
 				},
 				{
-					Name:               "CVE-2021-44228",
+					Name:               "RHSA-2021:5108",
 					Description:        "A flaw was found in the Apache Log4j logging library in versions from 2.0.0 and before 2.15.0. A remote attacker who can control log messages or log message parameters, can execute arbitrary code on the server via JNDI LDAP endpoint.",
 					Package:            &claircore.Package{Name: "openshift4/ose-metering-hive", Kind: claircore.BINARY},
 					Updater:            "rhel-container-updater",
 					Issued:             date_2021_12_14,
 					Severity:           "Critical",
-					Links:              "https://access.redhat.com/errata/RHSA-2021:5108",
+					Links:              "https://access.redhat.com/errata/RHSA-2021:5108 https://access.redhat.com/security/cve/CVE-2021-44228",
 					NormalizedSeverity: claircore.Critical,
 					Range: &claircore.Range{
 						Lower: claircore.Version{
@@ -132,13 +132,35 @@ func TestDB(t *testing.T) {
 			Name: "cve-2021-44228-openshift-logging",
 			Want: []*claircore.Vulnerability{
 				{
-					Name:               "CVE-2021-44228",
+					Name:               "RHSA-2021:5129",
 					Description:        "A flaw was found in the Apache Log4j logging library in versions from 2.0.0 and before 2.15.0. A remote attacker who can control log messages or log message parameters, can execute arbitrary code on the server via JNDI LDAP endpoint.",
 					Package:            &claircore.Package{Name: "openshift-logging/elasticsearch6-rhel8", Kind: claircore.BINARY},
 					Updater:            "rhel-container-updater",
 					Issued:             date_2021_12_14,
-					Severity:           "moderate",
-					Links:              "https://access.redhat.com/errata/RHSA-2021:5137",
+					Severity:           "Critical",
+					NormalizedSeverity: claircore.Critical,
+					Links:              "https://access.redhat.com/errata/RHSA-2021:5129 https://access.redhat.com/security/cve/CVE-2021-44228",
+					Range: &claircore.Range{
+						Lower: claircore.Version{
+							Kind: "rhctag",
+							V:    [10]int32{6, 8},
+						},
+						Upper: claircore.Version{
+							Kind: "rhctag",
+							V:    [10]int32{6, 8, math.MaxInt32},
+						},
+					},
+					FixedInVersion: "v6.8.1-65",
+					Repo:           &goldRepo,
+				},
+				{
+					Name:               "RHSA-2021:5137",
+					Description:        "A flaw was found in the Apache Log4j logging library in versions from 2.0.0 and before 2.15.0. A remote attacker who can control log messages or log message parameters, can execute arbitrary code on the server via JNDI LDAP endpoint.",
+					Package:            &claircore.Package{Name: "openshift-logging/elasticsearch6-rhel8", Kind: claircore.BINARY},
+					Updater:            "rhel-container-updater",
+					Issued:             date_2021_12_14,
+					Severity:           "Moderate",
+					Links:              "https://access.redhat.com/errata/RHSA-2021:5137 https://access.redhat.com/security/cve/CVE-2021-44228",
 					NormalizedSeverity: claircore.Medium,
 					Range: &claircore.Range{
 						Lower: claircore.Version{
@@ -153,41 +175,41 @@ func TestDB(t *testing.T) {
 					FixedInVersion: "v5.0.10-1",
 					Repo:           &goldRepo,
 				},
-				{
-					Name:               "CVE-2021-44228",
-					Description:        "A flaw was found in the Apache Log4j logging library in versions from 2.0.0 and before 2.15.0. A remote attacker who can control log messages or log message parameters, can execute arbitrary code on the server via JNDI LDAP endpoint.",
-					Package:            &claircore.Package{Name: "openshift-logging/elasticsearch6-rhel8", Kind: claircore.BINARY},
-					Updater:            "rhel-container-updater",
-					Issued:             date_2021_12_14,
-					Severity:           "Critical",
-					NormalizedSeverity: claircore.Critical,
-					Links:              "https://access.redhat.com/errata/RHSA-2021:5129",
-					Range: &claircore.Range{
-						Lower: claircore.Version{
-							Kind: "rhctag",
-							V:    [10]int32{6, 8},
-						},
-						Upper: claircore.Version{
-							Kind: "rhctag",
-							V:    [10]int32{6, 8, math.MaxInt32},
-						},
-					},
-					FixedInVersion: "v6.8.1-65",
-					Repo:           &goldRepo,
-				},
 			},
 		},
 		{
 			Name: "cve-2020-8565",
 			Want: []*claircore.Vulnerability{
 				{
-					Name:               "CVE-2020-8565",
+					Name:               "RHBA-2021:3003",
+					Description:        "A flaw was found in kubernetes. In Kubernetes, if the logging level is to at least 9, authorization and bearer tokens will be written to log files. This can occur both in API server logs and client tool output like `kubectl`. Previously, CVE-2019-11250 was assigned for the same issue for logging levels of at least 4.",
+					Package:            &claircore.Package{Name: "ocs4/rook-ceph-rhel8-operator", Kind: claircore.BINARY},
+					Updater:            "rhel-container-updater",
+					Issued:             date_2021_08_03,
+					Severity:           "Moderate",
+					NormalizedSeverity: claircore.Medium,
+					Links:              "https://access.redhat.com/errata/RHBA-2021:3003 https://access.redhat.com/security/cve/CVE-2020-8565",
+					Range: &claircore.Range{
+						Lower: claircore.Version{
+							Kind: "rhctag",
+							V:    [10]int32{4, 8},
+						},
+						Upper: claircore.Version{
+							Kind: "rhctag",
+							V:    [10]int32{4, 8, math.MaxInt32},
+						},
+					},
+					FixedInVersion: "4.8-167.9a9db5f.release_4.8",
+					Repo:           &goldRepo,
+				},
+				{
+					Name:               "RHSA-2021:2041",
 					Description:        "A flaw was found in kubernetes. In Kubernetes, if the logging level is to at least 9, authorization and bearer tokens will be written to log files. This can occur both in API server logs and client tool output like `kubectl`. Previously, CVE-2019-11250 was assigned for the same issue for logging levels of at least 4.",
 					Package:            &claircore.Package{Name: "ocs4/rook-ceph-rhel8-operator", Kind: claircore.BINARY},
 					Updater:            "rhel-container-updater",
 					Issued:             date_2021_05_19,
 					Severity:           "Moderate",
-					Links:              "https://access.redhat.com/errata/RHSA-2021:2041",
+					Links:              "https://access.redhat.com/errata/RHSA-2021:2041 https://access.redhat.com/security/cve/CVE-2020-8565",
 					NormalizedSeverity: claircore.Medium,
 					Range: &claircore.Range{
 						Lower: claircore.Version{
@@ -200,28 +222,6 @@ func TestDB(t *testing.T) {
 						},
 					},
 					FixedInVersion: "4.7-140.49a6fcf.release_4.7",
-					Repo:           &goldRepo,
-				},
-				{
-					Name:               "CVE-2020-8565",
-					Description:        "A flaw was found in kubernetes. In Kubernetes, if the logging level is to at least 9, authorization and bearer tokens will be written to log files. This can occur both in API server logs and client tool output like `kubectl`. Previously, CVE-2019-11250 was assigned for the same issue for logging levels of at least 4.",
-					Package:            &claircore.Package{Name: "ocs4/rook-ceph-rhel8-operator", Kind: claircore.BINARY},
-					Updater:            "rhel-container-updater",
-					Issued:             date_2021_08_03,
-					Severity:           "Moderate",
-					NormalizedSeverity: claircore.Medium,
-					Links:              "https://access.redhat.com/errata/RHBA-2021:3003",
-					Range: &claircore.Range{
-						Lower: claircore.Version{
-							Kind: "rhctag",
-							V:    [10]int32{4, 8},
-						},
-						Upper: claircore.Version{
-							Kind: "rhctag",
-							V:    [10]int32{4, 8, math.MaxInt32},
-						},
-					},
-					FixedInVersion: "4.8-167.9a9db5f.release_4.8",
 					Repo:           &goldRepo,
 				},
 			},

--- a/rhel/rhcc/rhcc.go
+++ b/rhel/rhcc/rhcc.go
@@ -39,6 +39,7 @@ type affectedRelease struct {
 
 type advisory struct {
 	XMLName xml.Name `xml:"Advisory"`
+	Text    string   `xml:",cdata"`
 	URL     string   `xml:"url,attr"`
 }
 
@@ -57,6 +58,7 @@ type consolidatedRelease struct {
 	FixedInVersions *rhctag.Versions
 	Severity        string
 	AdvisoryLink    string
+	AdvisoryName    string
 	Cpe             cpe.WFN
 }
 


### PR DESCRIPTION
The updater in rhcc matcher was using CVE Name as the vulnerability name
which more closely aligns with vulnerabilities coming from unpatched
OVAL definitions. This change switchs rhcc matcher to use the advisory
name in the vulnerablity name field.

See-Also: #627

Here's a vulnerability generated with this patch:

```
{
      "id": "5578",
      "updater": "rhel-container-updater",
      "name": "RHSA-2021:3665",
      "description": "A directory traversal vulnerability was found in the ClairCore engine of Clair. An attacker can exploit this by supplying a crafted container image which, when scanned by Clair, allows for arbitrary file write on the filesystem, potentially allowing for remote code execution.",
      "issued": "2021-09-28T00:00:00Z",
      "links": "https://access.redhat.com/errata/RHSA-2021:3665 https://access.redhat.com/security/cve/CVE-2021-3762",
      "severity": "Important",
      "normalized_severity": "High",
      "package": {
        "id": "",
        "name": "quay/clair-rhel8",
        "version": "",
        "kind": "binary"
      },
      "distribution": {
        "id": "",
        "did": "",
        "name": "",
        "version": "",
        "version_code_name": "",
        "version_id": "",
        "arch": "",
        "cpe": "",
        "pretty_name": ""
      },
      "repository": {
        "name": "Red Hat Container Catalog",
        "uri": "https://catalog.redhat.com/software/containers/explore"
      },
      "fixed_in_version": "v3.5.7-8"
    }
```