### PR TITLE
tarfs: format error

### DIFF
--- a/libindex/fetcher.go
+++ b/libindex/fetcher.go
@@ -23,6 +23,7 @@ import (
 	"golang.org/x/sync/singleflight"
 
 	"github.com/quay/claircore"
+	"github.com/quay/claircore/pkg/tarfs"
 )
 
 // Arena does coordination and global refcounting.
@@ -302,6 +303,17 @@ func (a *RemoteFetchArena) realizeLayer(ctx context.Context, l *claircore.Layer)
 		err := fmt.Errorf("fetcher: validation failed: got %q, expected %q",
 			hex.EncodeToString(got),
 			hex.EncodeToString(want))
+		return "", err
+	}
+
+	zlog.Debug(ctx).
+		Msg("checking if layer is a valid tar")
+	// TODO(hank) Need media types somewhere in here.
+	switch _, err := tarfs.New(fd); {
+	case errors.Is(err, nil):
+	case errors.Is(err, tarfs.ErrFormat):
+		fallthrough
+	default:
 		return "", err
 	}
 


### PR DESCRIPTION
This change adds a dedicated error for when an invalid tarball is detected, and then adds a validation step to the fetcher.