### PR TITLE
updaters: Add vuln.cves column

### DIFF
--- a/alpine/parser.go
+++ b/alpine/parser.go
@@ -60,6 +60,7 @@ func unpackSecFixes(partial claircore.Vulnerability, secFixes map[string][]strin
 			v.Name = id
 			v.FixedInVersion = fixedIn
 			v.Links = fmt.Sprintf(nvdURLPrefix, id)
+			v.CVEs = []string{id}
 			out = append(out, &v)
 		}
 	}

--- a/datastore/postgres/migrations/migrations.go
+++ b/datastore/postgres/migrations/migrations.go
@@ -80,4 +80,8 @@ var MatcherMigrations = []migrate.Migration{
 		ID: 8,
 		Up: runFile("matcher/08-updater-status.sql"),
 	},
+	{
+		ID: 9,
+		Up: runFile("matcher/09-add-cves-column.sql"),
+	},
 }

--- a/datastore/postgres/updatevulnerabilities.go
+++ b/datastore/postgres/updatevulnerabilities.go
@@ -61,14 +61,14 @@ func updateVulnerabilites(ctx context.Context, pool *pgxpool.Pool, updater strin
 			package_name, package_version, package_module, package_arch, package_kind,
 			dist_id, dist_name, dist_version, dist_version_code_name, dist_version_id, dist_arch, dist_cpe, dist_pretty_name,
 			repo_name, repo_key, repo_uri,
-			fixed_in_version, arch_operation, version_kind, vulnerable_range
+			fixed_in_version, arch_operation, version_kind, vulnerable_range, cves
 		) VALUES (
 		  $1, $2,
 		  $3, $4, $5, $6, $7, $8, $9,
 		  $10, $11, $12, $13, $14,
 		  $15, $16, $17, $18, $19, $20, $21, $22,
 		  $23, $24, $25,
-		  $26, $27, $28, VersionRange($29, $30)
+		  $26, $27, $28, VersionRange($29, $30), $31
 		)
 		ON CONFLICT (hash_kind, hash) DO NOTHING;`
 		// Assoc associates an update operation and a vulnerability. It fails
@@ -133,7 +133,7 @@ func updateVulnerabilites(ctx context.Context, pool *pgxpool.Pool, updater strin
 			pkg.Name, pkg.Version, pkg.Module, pkg.Arch, pkg.Kind,
 			dist.DID, dist.Name, dist.Version, dist.VersionCodeName, dist.VersionID, dist.Arch, dist.CPE, dist.PrettyName,
 			repo.Name, repo.Key, repo.URI,
-			vuln.FixedInVersion, vuln.ArchOperation, vKind, vrLower, vrUpper,
+			vuln.FixedInVersion, vuln.ArchOperation, vKind, vrLower, vrUpper, vuln.CVEs,
 		)
 		if err != nil {
 			return uuid.Nil, fmt.Errorf("failed to queue vulnerability: %w", err)

--- a/pkg/ovalutil/dpkg.go
+++ b/pkg/ovalutil/dpkg.go
@@ -115,6 +115,7 @@ func DpkgDefsToVulns(ctx context.Context, root *oval.Root, protoVulns ProtoVulns
 							vuln.ArchOperation = mapArchOp(state.Arch.Operation)
 							vuln.Package.Arch = state.Arch.Body
 						}
+						vuln.CVEs = referencesBySource(def.References)["CVE"]
 					}
 					if pkg, ok := pkgcache[n]; !ok {
 						p := &claircore.Package{

--- a/pkg/ovalutil/rpm.go
+++ b/pkg/ovalutil/rpm.go
@@ -131,6 +131,7 @@ func RPMDefsToVulns(ctx context.Context, root *oval.Root, protoVulns ProtoVulnsF
 						Module: module,
 						Kind:   claircore.BINARY,
 					}
+					vuln.CVEs = referencesBySource(def.References)["CVE"]
 					if state != nil {
 						vuln.FixedInVersion = state.EVR.Body
 						if state.Arch != nil {

--- a/vulnerability.go
+++ b/vulnerability.go
@@ -38,6 +38,7 @@ type Vulnerability struct {
 	// ArchOperation indicates how the affected Package's "arch" should be
 	// compared.
 	ArchOperation ArchOp `json:"arch_op,omitempty"`
+	CVEs          []string
 }
 
 // CheckVulnernableFunc takes a vulnerability and an indexRecord and checks if the record is


### PR DESCRIPTION
Currently we have a very loose relationship between vulnerabilities
and CVEs. This somewhat prohibits us or an upstream client from being
able to do any CVE based filtering and it also could lead to false
positives (and false negatives) when looking up enrichment data. This
PR adds a CVEs array column to the vuln table.

TODO:

- [ ] Tests
- [ ] Modify updaters to save CVE data
- [ ] Change enrichment query to use `cves` column

Signed-off-by: crozzy <joseph.crosland@gmail.com>