### PR TITLE
chore: Add filter version flag to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,12 @@ jobs:
       - name: ChangeLog
         run: |
           curl -o /tmp/git-chglog.tar.gz -fsSL\
-            https://github.com/git-chglog/git-chglog/releases/download/v0.14.0/git-chglog_0.14.0_linux_amd64.tar.gz
+            https://github.com/git-chglog/git-chglog/releases/download/v0.15.1/git-chglog_0.15.1_linux_amd64.tar.gz
           tar xvf /tmp/git-chglog.tar.gz --directory /tmp
           chmod u+x /tmp/git-chglog
           echo "creating change log for tag: $VERSION"
-          /tmp/git-chglog "${VERSION}" > "${{github.workspace}}/changelog"
+          filter_tag="--tag-filter-pattern=^v"
+          /tmp/git-chglog $filter_tag "${VERSION}" > "${{github.workspace}}/changelog"
       - name: Create Release
         uses: actions/create-release@latest
         env:


### PR DESCRIPTION
As we now have nested submodules the Changelog
generator chokes on path prefixed versions. This
change exclude tags that don't start with v. Also
bump the tool version.

Signed-off-by: crozzy <joseph.crosland@gmail.com>