### PR TITLE
cicd: enable dependabot for go modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,19 @@
+---
 version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "gomod"
+    directory: "/toolkit"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "gomod"
+    directory: "/updater/driver"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Signed-off-by: Hank Donnay <hdonnay@redhat.com>