### PR TITLE
fetcher: Wrap error to surface error type to external caller

### DIFF
--- a/libindex/fetcher.go
+++ b/libindex/fetcher.go
@@ -344,7 +344,7 @@ func (p *FetchProxy) Realize(ctx context.Context, ls []*claircore.Layer) error {
 		g.Go(p.a.fetchOne(ctx, l))
 	}
 	if err := g.Wait(); err != nil {
-		return fmt.Errorf("encountered error while fetching a layer: %v", err)
+		return fmt.Errorf("encountered error while fetching a layer: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Currently the error type gets lost in the stack, this
allows certain errors (particularly at the tarfs level) to
be surfaced to external callers of Index().

Signed-off-by: crozzy <joseph.crosland@gmail.com>