### PR TITLE
rpm: add support for NDB backend

### DIFF
--- a/rpm/bdb.go
+++ b/rpm/bdb.go
@@ -137,6 +137,9 @@ func checkMagic(ctx context.Context, r io.Reader) bool {
 		BTree = 0x00053162
 		Queue = 0x00042253
 		Log   = 0x00040988
+		// https://github.com/rpm-software-management/rpm/blob/be64821b908fdb1ff3c12530430d1cf046839e60/lib/backend/ndb/rpmpkg.c#L98
+		// fmt.Printf("%08x", 'R'|'p'<<8|'m'<<16|'P'<<24)
+		Ndb = 0x506d7052
 	)
 	// Most hosts are still x86, try LE first.
 	be := []binary.ByteOrder{binary.LittleEndian, binary.BigEndian}
@@ -154,7 +157,7 @@ func checkMagic(ctx context.Context, r io.Reader) bool {
 		}
 		for _, o := range be {
 			n := o.Uint32(b)
-			if n == Hash || n == BTree || n == Queue || n == Log {
+			if n == Hash || n == BTree || n == Queue || n == Log || n == Ndb {
 				return true
 			}
 		}

--- a/rpm/dbkind_string.go
+++ b/rpm/dbkind_string.go
@@ -10,11 +10,12 @@ func _() {
 	var x [1]struct{}
 	_ = x[kindBDB-1]
 	_ = x[kindSQLite-2]
+	_ = x[kindNDB-3]
 }
 
-const _dbKind_name = "bdbsqlite"
+const _dbKind_name = "bdbsqlitendb"
 
-var _dbKind_index = [...]uint8{0, 3, 9}
+var _dbKind_index = [...]uint8{0, 3, 9, 12}
 
 func (i dbKind) String() string {
 	i -= 1


### PR DESCRIPTION
RHEL has move to sqlite but NDB is also getting
some traction. This adds support for NDB which is
pretty close to BDB so shares a lot of code.

Signed-off-by: crozzy <joseph.crosland@gmail.com>

TODO
- [ ] Add support for registry.suse.com to the test Fetcher