### PR TITLE
rpm: remove rpm packageScanner from rpm ecosystem

### DIFF
--- a/rpm/ecosystem.go
+++ b/rpm/ecosystem.go
@@ -15,7 +15,7 @@ import (
 func NewEcosystem(ctx context.Context) *indexer.Ecosystem {
 	return &indexer.Ecosystem{
 		PackageScanners: func(ctx context.Context) ([]indexer.PackageScanner, error) {
-			return []indexer.PackageScanner{&Scanner{}}, nil
+			return []indexer.PackageScanner{}, nil
 		},
 		DistributionScanners: func(ctx context.Context) ([]indexer.DistributionScanner, error) {
 			return []indexer.DistributionScanner{


### PR DESCRIPTION
Currently the rpm packageScanner is a part of the rpm Ecosystem
and and the rhel Ecosystem, this cause a multiple environments to
be returned for the same package_db. This change could be strange
with regards to defaults as a user would need the rhel Ecosystem to
be required in order to find packages in a suse distro.

Signed-off-by: crozzy <joseph.crosland@gmail.com>