### PR TITLE
rhel: handle malformed build metadata

### DIFF
--- a/rhel/repositoryscanner.go
+++ b/rhel/repositoryscanner.go
@@ -245,6 +245,11 @@ func (r *RepositoryScanner) getCPEsUsingEmbeddedContentSets(ctx context.Context,
 	if err := json.Unmarshal(b, &m); err != nil {
 		return nil, err
 	}
+	// If the JSON file is malformed and has a 0-length list of content sets,
+	// report nil so that the API can be consulted.
+	if len(m.ContentSets) == 0 {
+		return nil, nil
+	}
 	return r.mapper.Get(ctx, m.ContentSets)
 }
 


### PR DESCRIPTION
When the embedded build metadata indicates there are no content-sets associated with the container, fall through to the API call. This shouldn't happen, but does in some early RHEL 9 based containers.

Signed-off-by: Hank Donnay <hdonnay@redhat.com>