### PR TITLE
periodic: attempt to follow API-created links

### DIFF
--- a/test/periodic/rpm_test.go
+++ b/test/periodic/rpm_test.go
@@ -1,8 +1,10 @@
 package periodic
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -26,11 +28,12 @@ func TestRPMSpotCheck(t *testing.T) {
 		RawQuery: url.Values{
 			"redhat_client": {"claircore-tests"},
 			"fq": {
-				"documentKind:ContainerRepository",
+				`documentKind:"ContainerRepository"`,
+				`-release_catagories:"Deprecated"`,
 				"repository:ubi?/ubi*",
 			},
-			"fl":   {"container_image_id,repository,registry,parsed_data_layers"},
-			"rows": {"20"},
+			"fl":   {"id,repository,registry,parsed_data_layers"},
+			"rows": {"500"},
 			"q":    {"ubi"},
 		}.Encode(),
 	}
@@ -49,10 +52,11 @@ func TestRPMSpotCheck(t *testing.T) {
 	}
 	t.Logf("%s: %s", query.String(), res.Status)
 	var searchRes hydraResponse
-	if err := json.NewDecoder(res.Body).Decode(&searchRes); err != nil {
+	var buf bytes.Buffer
+	if err := json.NewDecoder(io.TeeReader(res.Body, &buf)).Decode(&searchRes); err != nil {
 		t.Error(err)
 	}
-	//t.Log(searchRes)
+	t.Logf("search response:\t%q", buf.String())
 	dir := t.TempDir()
 	for _, d := range searchRes.Response.Docs {
 		t.Run(d.Repository, d.Run(dir))
@@ -66,21 +70,50 @@ type hydraResponse struct {
 }
 
 type hydraDoc struct {
-	ID         string             `json:"container_image_id"`
+	ID         string             `json:"id"`
 	Repository string             `json:"repository"`
 	Registry   string             `json:"registry"`
 	Layers     []claircore.Digest `json:"parsed_data_layers"`
 }
 
+type imageInfo struct {
+	Links imageInfoLinks `json:"_links"`
+}
+
+type imageInfoLinks struct {
+	Images      link `json:"images"`
+	RpmManifest link `json:"rpm_manifest"`
+}
+
+type link struct {
+	Href string `json:"href"`
+}
+
+type imagesResponse struct {
+	Data []struct {
+		ID     string         `json:"_id"`
+		Links  imageInfoLinks `json:"_links"`
+		Parsed struct {
+			Layers []claircore.Digest `json:"layers"`
+		} `json:"parsed_data"`
+	} `json:"data"`
+}
+
 func (doc hydraDoc) Run(dir string) func(*testing.T) {
-	manifestURL := url.URL{
+	root := url.URL{
 		Scheme: "https",
 		Host:   "catalog.redhat.com",
-		Path:   path.Join("/api/containers/v1/images/id", doc.ID, "rpm-manifest"),
+		Path:   "/api/containers/",
 	}
+	var buf bytes.Buffer
 	return func(t *testing.T) {
 		ctx := zlog.Test(context.Background(), t)
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, manifestURL.String(), nil)
+
+		fetchURL, err := root.Parse(path.Join("/api/containers/", "v1/repositories/id/", doc.ID))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, fetchURL.String(), nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -91,14 +124,72 @@ func (doc hydraDoc) Run(dir string) func(*testing.T) {
 		}
 		defer res.Body.Close()
 		if res.StatusCode != http.StatusOK {
+			t.Fatalf("unexpected response to %q: %s", fetchURL.String(), res.Status)
+		}
+		buf.Reset()
+		var info imageInfo
+		if err := json.NewDecoder(io.TeeReader(res.Body, &buf)).Decode(&info); err != nil {
+			t.Fatalf("%s: %v", fetchURL.String(), err)
+		}
+		t.Logf("%s response:\t%q", res.Request.URL.Path, buf.String())
+
+		imageURL, err := root.Parse(path.Join("/api/containers/", info.Links.Images.Href))
+		if err != nil {
+			t.Fatal(err)
+		}
+		imageURL.RawQuery = (url.Values{
+			"page_size": {"1"},
+			"page":      {"0"},
+			"exclude":   {"data.repositories.comparison.advisory_rpm_mapping,data.brew,data.cpe_ids,data.top_layer_id"},
+			"filter":    {"deleted!=true"},
+		}).Encode()
+		req, err = http.NewRequestWithContext(ctx, http.MethodGet, imageURL.String(), nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("accept", "application/json")
+		res, err = pkgClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer res.Body.Close()
+		if res.StatusCode != http.StatusOK {
+			t.Fatalf("unexpected response to %q: %s", imageURL.String(), res.Status)
+		}
+		buf.Reset()
+		var image imagesResponse
+		if err := json.NewDecoder(io.TeeReader(res.Body, &buf)).Decode(&image); err != nil {
+			t.Fatalf("%s: %v", imageURL.String(), err)
+		}
+		t.Logf("%s response:\t%q", res.Request.URL.Path, buf.String())
+
+		t.Log(image.Data[0])
+		manifestURL, err := fetchURL.Parse(path.Join("/api/containers/", image.Data[0].Links.RpmManifest.Href))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req, err = http.NewRequestWithContext(ctx, http.MethodGet, manifestURL.String(), nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("accept", "application/json")
+		res, err = pkgClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer res.Body.Close()
+		if res.StatusCode != http.StatusOK {
 			t.Fatalf("unexpected response to %q: %s", manifestURL.String(), res.Status)
 		}
-		want := rpmtest.PackagesFromRPMManifest(t, res.Body)
+
+		buf.Reset()
+		want := rpmtest.PackagesFromRPMManifest(t, io.TeeReader(res.Body, &buf))
+		t.Logf("%s response:\t%q", res.Request.URL.Path, buf.String())
 
 		s := &rpm.Scanner{}
 		var got []*claircore.Package
 		var which claircore.Digest
-		for _, ld := range doc.Layers {
+		for _, ld := range image.Data[0].Parsed.Layers {
 			n, err := fetch.Layer(ctx, t, pkgClient, doc.Registry, doc.Repository, ld, fetch.IgnoreIntegration)
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
A few constructed APIs started 404/403-ing. This change attempts to only use links returned by the API. This is all reverse-engineered, so I can only be so annoyed at having to do some additional reversing.

Signed-off-by: Hank Donnay <hdonnay@redhat.com>