### PR TITLE
ndb: handle noncontiguous package slots

### DIFF
--- a/rpm/ndb/package_test.go
+++ b/rpm/ndb/package_test.go
@@ -1,42 +1,63 @@
 package ndb
 
 import (
+	"bytes"
 	"context"
+	"io/fs"
 	"os"
 	"testing"
+
+	"github.com/quay/zlog"
 
 	"github.com/quay/claircore/rpm/internal/rpm"
 )
 
 func TestLoadPackage(t *testing.T) {
 	ctx := context.Background()
-	pkgf, err := os.Open("testdata/Packages.db")
-	if err != nil {
-		t.Fatal(err)
+
+	dir := os.DirFS("testdata")
+	ms, err := fs.Glob(dir, "Packages*.db")
+	if err != nil || len(ms) == 0 {
+		t.Fatalf("error or not enough matches: %v/%d", err, len(ms))
 	}
-	defer pkgf.Close()
-	var pkg PackageDB
-	if err := pkg.Parse(pkgf); err != nil {
-		t.Fatal(err)
-	}
-	rds, err := pkg.AllHeaders(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	for _, rd := range rds {
-		var h rpm.Header
-		if err := h.Parse(ctx, rd); err != nil {
-			t.Fatal(err)
-		}
-		var found bool
-		for i := range h.Infos {
-			if h.Infos[i].Tag == rpm.TagName {
-				found = true
-				break
+	for _, n := range ms {
+		t.Run(n, func(t *testing.T) {
+			ctx := zlog.Test(ctx, t)
+			b, err := fs.ReadFile(dir, n)
+			if err != nil {
+				t.Fatal(err)
 			}
-		}
-		if !found {
-			t.Error(`missing "name" tag`)
-		}
+			pkgf := bytes.NewReader(b)
+			var pkg PackageDB
+			if err := pkg.Parse(pkgf); err != nil {
+				t.Fatal(err)
+			}
+			rds, err := pkg.AllHeaders(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, rd := range rds {
+				var h rpm.Header
+				if err := h.Parse(ctx, rd); err != nil {
+					t.Fatal(err)
+				}
+				var found bool
+				for i := range h.Infos {
+					if h.Infos[i].Tag == rpm.TagName {
+						v, err := h.ReadData(ctx, &h.Infos[i])
+						if err != nil {
+							t.Error(err)
+							continue
+						}
+						t.Logf("package: %q", v)
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Error(`missing "name" tag`)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
This should handle the case where the RPM DB has unpopulated slots. My previous reads of the RPM C code had me thinking that the DB was recompacted after transactions, but this seems to no be the case. This implements a sanity check that exists in the C slot reading code.

Closes: quay/clair#1645
Signed-off-by: Hank Donnay <hdonnay@redhat.com>