### PR TITLE
tarfs: lookup path bug

### DIFF
--- a/pkg/tarfs/tarfs.go
+++ b/pkg/tarfs/tarfs.go
@@ -153,9 +153,7 @@ Again:
 			hardlink[tgt] = append(hardlink[tgt], name)
 		}
 	}
-	if _, ok := hardlink[name]; ok {
-		delete(hardlink, name)
-	}
+	delete(hardlink, name)
 	i := len(f.inode)
 	f.inode = append(f.inode, ino)
 	f.lookup[name] = i
@@ -302,11 +300,12 @@ func (f *FS) walkTo(p string, create bool) (*inode, error) {
 		case found && create, found && !create:
 			// OK
 		case !found && create:
-			f.add(n, newDir(n), nil)
-			ci := f.lookup[n]
+			fp := b.String() // Make sure to use the full path and not just the member name.
+			f.add(fp, newDir(n), nil)
+			ci := f.lookup[fp]
 			child = &f.inode[ci]
 		case !found && !create:
-			return nil, fmt.Errorf("tarfs: walk to %q, but missing segment %q", p, n)
+			return nil, fmt.Errorf("tarfs: walk to %q, but missing segment %q", p, b.String())
 		}
 		cur = child
 	}

--- a/rpm/packagescanner_test.go
+++ b/rpm/packagescanner_test.go
@@ -1706,3 +1706,29 @@ func TestRelPath(t *testing.T) {
 		}
 	}
 }
+
+func TestLayer(t *testing.T) {
+	ctx := context.Background()
+	ents, err := os.ReadDir(`testdata/layers`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, e := range ents {
+		ctx := zlog.Test(ctx, t)
+		n := e.Name()
+		if n == ".gitignore" {
+			continue
+		}
+		t.Run(n, func(t *testing.T) {
+			var l claircore.Layer
+			l.SetLocal(filepath.Join(`testdata/layers`, n))
+			var s Scanner
+			got, err := s.Scan(ctx, &l)
+			if err != nil {
+				t.Error(err)
+			}
+			t.Logf("found %d packages", len(got))
+		})
+	}
+}

--- a/rpm/testdata/layers/.gitignore
+++ b/rpm/testdata/layers/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
This fixes the `tarfs` code to use the full path where appropriate, instead of just the file name.

Closes #736