### PR TITLE
tarfs: support traversing intermediate hard links

### DIFF
--- a/pkg/tarfs/tarfs.go
+++ b/pkg/tarfs/tarfs.go
@@ -187,6 +187,9 @@ AddEnt:
 		switch parent.h.Typeflag {
 		case tar.TypeDir:
 			// OK
+		case tar.TypeLink:
+			// This is annoying -- hard linking to directories is weird
+			fallthrough
 		case tar.TypeSymlink:
 			dir = parent.h.Linkname
 			goto AddEnt


### PR DESCRIPTION
Hard linking to directories isn't _technically_ disallowed, but not a common occurrence. This change adds support for it.

Closes: #737
Signed-off-by: Hank Donnay <hdonnay@redhat.com>