### PR TITLE
all: rewrite uses of `ioutil`

### DIFF
--- a/aws/client.go
+++ b/aws/client.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path"
@@ -194,7 +193,7 @@ func (c *Client) getMirrors(ctx context.Context, list string) error {
 		return err
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("failed to read http body: %v", err)
 	}

--- a/crda/remotematcher_test.go
+++ b/crda/remotematcher_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -93,7 +93,7 @@ func TestRemoteMatcher(t *testing.T) {
 			}
 			testLocalPath := fmt.Sprintf("testdata/%s/%s/%s.json", vulnRequest.Ecosystem, p.Name, p.Version)
 			t.Logf("serving request for %v", testLocalPath)
-			jsonOut, err := ioutil.ReadFile(testLocalPath)
+			jsonOut, err := os.ReadFile(testLocalPath)
 			if err != nil {
 				t.Log(err)
 				continue

--- a/debian/sourcemapper_test.go
+++ b/debian/sourcemapper_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -24,7 +23,7 @@ func NewTestClient() (*http.Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	b, err := ioutil.ReadAll(f)
+	b, err := io.ReadAll(f)
 	if err != nil {
 		return nil, err
 	}

--- a/libvuln/jsonblob/jsonblob_test.go
+++ b/libvuln/jsonblob/jsonblob_test.go
@@ -3,7 +3,6 @@ package jsonblob
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -27,7 +26,7 @@ func TestStore(t *testing.T) {
 	}
 	t.Logf("ref: %v", ref)
 
-	if err := s.Store(ioutil.Discard); err != nil {
+	if err := s.Store(io.Discard); err != nil {
 		t.Error(err)
 	}
 }

--- a/pkg/tmp/file.go
+++ b/pkg/tmp/file.go
@@ -1,7 +1,6 @@
 package tmp
 
 import (
-	"io/ioutil"
 	"os"
 )
 
@@ -12,7 +11,7 @@ type File struct {
 }
 
 func NewFile(dir, pattern string) (*File, error) {
-	f, err := ioutil.TempFile(dir, pattern)
+	f, err := os.CreateTemp(dir, pattern)
 	if err != nil {
 		return nil, err
 	}

--- a/rhel/fetch_test.go
+++ b/rhel/fetch_test.go
@@ -3,7 +3,6 @@ package rhel
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -37,7 +36,7 @@ func TestFetch(t *testing.T) {
 		}
 		t.Logf("got fingerprint: %+v", hint)
 		defer rd.Close()
-		n, err := io.Copy(ioutil.Discard, rd)
+		n, err := io.Copy(io.Discard, rd)
 		switch {
 		case err != nil:
 			t.Fatalf("unable to read returned data: %v", err)
@@ -70,7 +69,7 @@ func TestFetch(t *testing.T) {
 		}
 		t.Logf("got fingerprint: %+v", hint)
 		defer rd.Close()
-		n, err := io.Copy(ioutil.Discard, rd)
+		n, err := io.Copy(io.Discard, rd)
 		switch {
 		case err != nil:
 			t.Fatalf("unable to read returned data: %v", err)

--- a/rhel/matcher_test.go
+++ b/rhel/matcher_test.go
@@ -3,7 +3,7 @@ package rhel
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -81,7 +81,7 @@ func TestMatcherIntegration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := json.NewEncoder(ioutil.Discard).Encode(&vr); err != nil {
+	if err := json.NewEncoder(io.Discard).Encode(&vr); err != nil {
 		t.Fatalf("failed to marshal VR: %v", err)
 	}
 }

--- a/rhel/rhcc/matcher_integration_test.go
+++ b/rhel/rhcc/matcher_integration_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -128,7 +128,7 @@ func TestMatcherIntegration(t *testing.T) {
 			if found != tt.match {
 				t.Fatalf("Expected to find %s in vulnerability report", tt.cveID)
 			}
-			if err := json.NewEncoder(ioutil.Discard).Encode(&vr); err != nil {
+			if err := json.NewEncoder(io.Discard).Encode(&vr); err != nil {
 				t.Fatalf("failed to marshal VR: %v", err)
 			}
 		})

--- a/rpm/extract.go
+++ b/rpm/extract.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,7 +14,7 @@ import (
 )
 
 func extractTar(ctx context.Context, rd io.ReadSeeker) (string, error) {
-	root, err := ioutil.TempDir("", "rpmscanner.")
+	root, err := os.MkdirTemp("", "rpmscanner.")
 	if err != nil {
 		return "", err
 	}

--- a/test/integration/engine.go
+++ b/test/integration/engine.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -53,10 +52,10 @@ func (e *Engine) init(t testing.TB) {
 	}
 	t.Logf("using data directory %q", e.dataDir)
 	pwfile := filepath.Join(t.TempDir(), "passwd")
-	if err := ioutil.WriteFile(pwfile, []byte(`securepassword`), 0644); err != nil {
+	if err := os.WriteFile(pwfile, []byte(`securepassword`), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	os.MkdirAll("testdata", 0755)
+	os.MkdirAll("testdata", 0o755)
 	log, err := os.Create(filepath.Join("testdata", "pg"+dbVersion+".initdb"))
 	if err != nil {
 		t.Fatal(err)
@@ -112,7 +111,7 @@ func (e *Engine) Stop() error {
 func fetchArchive(t testing.TB) {
 	p, err := cachedDir()
 	if errors.Is(err, os.ErrNotExist) {
-		os.MkdirAll(p, 0755)
+		os.MkdirAll(p, 0o755)
 	}
 	if !lockDir(t, p) {
 		return
@@ -130,7 +129,7 @@ func fetchArchive(t testing.TB) {
 		t.Fatalf("unexpected response: %v", res.Status)
 	}
 	t.Log("fetch OK")
-	jf, err := ioutil.TempFile(t.TempDir(), "embedded-postgres.")
+	jf, err := os.CreateTemp(t.TempDir(), "embedded-postgres.")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -163,7 +162,7 @@ func fetchArchive(t testing.TB) {
 
 	// Extract the tarball to the target directory.
 	t.Logf("extracting %q to %q", zf.Name, p)
-	if err := os.MkdirAll(p, 0755); err != nil {
+	if err := os.MkdirAll(p, 0o755); err != nil {
 		t.Error(err)
 	}
 	rd, err := zf.Open()
@@ -188,14 +187,14 @@ func fetchArchive(t testing.TB) {
 		// This also plays fast and loose with permissions around directories.
 		switch h.Typeflag {
 		case tar.TypeDir:
-			if err := os.MkdirAll(outName, 0755); err != nil {
+			if err := os.MkdirAll(outName, 0o755); err != nil {
 				t.Error(err)
 			}
 			if err := os.Chmod(outName, h.FileInfo().Mode()); err != nil {
 				t.Error(err)
 			}
 		case tar.TypeReg:
-			if err := os.MkdirAll(filepath.Dir(outName), 0755); err != nil {
+			if err := os.MkdirAll(filepath.Dir(outName), 0o755); err != nil {
 				t.Error(err)
 			}
 			f, err := os.Create(outName)
@@ -214,7 +213,7 @@ func fetchArchive(t testing.TB) {
 				t.Error(err)
 			}
 		case tar.TypeSymlink:
-			if err := os.MkdirAll(filepath.Dir(outName), 0755); err != nil {
+			if err := os.MkdirAll(filepath.Dir(outName), 0o755); err != nil {
 				t.Error(err)
 			}
 			if err := os.Symlink(h.Linkname, outName); err != nil {


### PR DESCRIPTION
Used a script to fix up all the call sites:

    git grep -l ioutil -- :/**.go |
    while read f; do
	    for rule in \
		    'ioutil.Discard -> io.Discard'\
		    'ioutil.NopCloser -> io.NopCloser'\
		    'ioutil.ReadAll -> io.ReadAll'\
		    'ioutil.ReadFile -> os.ReadFile'\
		    'ioutil.TempDir -> os.MkdirTemp'\
		    'ioutil.TempFile -> os.CreateTemp'\
		    'ioutil.WriteFile -> os.WriteFile'\
	    ; do
		    gofmt -w -r "$rule" "$f"
	    done
	    goimports -l -w "$f"
	    gofumpt -l -w "$f"
    done

Running this on the previous commit should produce the same results.

Signed-off-by: Hank Donnay <hdonnay@redhat.com>