### PR TITLE
rhel: Check that after casting to mappingFile we have a usable mapper

### DIFF
--- a/rhel/repositoryscanner.go
+++ b/rhel/repositoryscanner.go
@@ -186,11 +186,15 @@ func (r *RepositoryScanner) Scan(ctx context.Context, l *claircore.Layer) (repos
 
 	tctx, done := context.WithTimeout(ctx, r.cfg.Timeout)
 	defer done()
-	cm, err := r.upd.Get(tctx, r.client)
-	if err != nil && cm == nil {
+	cmi, err := r.upd.Get(tctx, r.client)
+	if err != nil && cmi == nil {
 		return []*claircore.Repository{}, err
 	}
-	CPEs, err := mapContentSets(ctx, sys, cm.(*mappingFile))
+	cm, ok := cmi.(*mappingFile)
+	if !ok || cm == nil {
+		return []*claircore.Repository{}, fmt.Errorf("rhel: unable to create a mappingFile object")
+	}
+	CPEs, err := mapContentSets(ctx, sys, cm)
 	if err != nil {
 		return []*claircore.Repository{}, err
 	}

--- a/rhel/rhcc/scanner.go
+++ b/rhel/rhcc/scanner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/fs"
 	"net/http"
 	"os"
@@ -165,11 +166,15 @@ func (s *scanner) Scan(ctx context.Context, l *claircore.Layer) ([]*claircore.Pa
 
 	tctx, done := context.WithTimeout(ctx, s.cfg.Timeout)
 	defer done()
-	v, err := s.upd.Get(tctx, s.client)
-	if err != nil && v == nil {
+	vi, err := s.upd.Get(tctx, s.client)
+	if err != nil && vi == nil {
 		return nil, err
 	}
-	repos, ok := v.(*mappingFile).Data[name]
+	v, ok := vi.(*mappingFile)
+	if !ok || v == nil {
+		return nil, fmt.Errorf("rhcc: unable to create a mappingFile object")
+	}
+	repos, ok := v.Data[name]
 	if ok {
 		zlog.Debug(ctx).Str("name", name).
 			Msg("name present in mapping file")


### PR DESCRIPTION
Currently it is possible that if the repo2cpe_mapping_url or the repo2cpe_mapping_file (or indeed if the endpoint is down) that we will panic as the mappingFile will cast to a nil. This will check for a nil mapper before it gets accessed and error out.

Signed-off-by: crozzy <joseph.crosland@gmail.com>