### PR TITLE
gobin: Disable gobin Ecosystem until coalescer is written

### DIFF
--- a/libindex/libindex.go
+++ b/libindex/libindex.go
@@ -18,7 +18,6 @@ import (
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/alpine"
 	"github.com/quay/claircore/dpkg"
-	"github.com/quay/claircore/gobin"
 	"github.com/quay/claircore/indexer"
 	"github.com/quay/claircore/java"
 	"github.com/quay/claircore/pkg/omnimatcher"
@@ -96,7 +95,7 @@ func New(ctx context.Context, opts *Options, cl *http.Client) (*Libindex, error)
 			python.NewEcosystem(ctx),
 			java.NewEcosystem(ctx),
 			rhcc.NewEcosystem(ctx),
-			gobin.NewEcosystem(ctx),
+			//gobin.NewEcosystem(ctx),
 		}
 	}
 


### PR DESCRIPTION
Currently all ecosystems are required to have a non-nil coalescer, this causes a panic.

Signed-off-by: crozzy <joseph.crosland@gmail.com>