### PR TITLE
airgapped: Remove airgapped logic from the core in lieu of the client being passed being airgap aware

### DIFF
--- a/datastore/postgres/layerscanned.go
+++ b/datastore/postgres/layerscanned.go
@@ -73,7 +73,7 @@ SELECT
 	switch {
 	case errors.Is(err, nil):
 	case errors.Is(err, pgx.ErrNoRows):
-		return false, fmt.Errorf("scanner %q not found", scnr)
+		return false, fmt.Errorf("scanner %s not found", scnr.Name())
 	default:
 		return false, err
 	}

--- a/indexer/ecosystem.go
+++ b/indexer/ecosystem.go
@@ -24,7 +24,7 @@ type Ecosystem struct {
 
 // EcosystemsToScanners extracts and dedupes multiple ecosystems and returns
 // their discrete scanners.
-func EcosystemsToScanners(ctx context.Context, ecosystems []*Ecosystem, disallowRemote bool) ([]PackageScanner, []DistributionScanner, []RepositoryScanner, error) {
+func EcosystemsToScanners(ctx context.Context, ecosystems []*Ecosystem) ([]PackageScanner, []DistributionScanner, []RepositoryScanner, error) {
 	ctx = zlog.ContextWithValues(ctx, "component", "indexer/EcosystemsToScanners")
 	ps := []PackageScanner{}
 	ds := []DistributionScanner{}
@@ -46,12 +46,6 @@ func EcosystemsToScanners(ctx context.Context, ecosystems []*Ecosystem, disallow
 				continue
 			}
 			seen.pkg[n] = struct{}{}
-			if _, ok := s.(RPCScanner); ok && disallowRemote {
-				zlog.Info(ctx).
-					Str("scanner", n).
-					Msg("disallowed by configuration")
-				continue
-			}
 			ps = append(ps, s)
 		}
 
@@ -65,12 +59,6 @@ func EcosystemsToScanners(ctx context.Context, ecosystems []*Ecosystem, disallow
 				continue
 			}
 			seen.dist[n] = struct{}{}
-			if _, ok := s.(RPCScanner); ok && disallowRemote {
-				zlog.Info(ctx).
-					Str("scanner", n).
-					Msg("disallowed by configuration")
-				continue
-			}
 			ds = append(ds, s)
 		}
 
@@ -84,12 +72,6 @@ func EcosystemsToScanners(ctx context.Context, ecosystems []*Ecosystem, disallow
 				continue
 			}
 			seen.repo[n] = struct{}{}
-			if _, ok := s.(RPCScanner); ok && disallowRemote {
-				zlog.Info(ctx).
-					Str("scanner", n).
-					Msg("disallowed by configuration")
-				continue
-			}
 			rs = append(rs, s)
 		}
 	}

--- a/indexer/opts.go
+++ b/indexer/opts.go
@@ -15,5 +15,6 @@ type Opts struct {
 	Realizer     Realizer
 	Ecosystems   []*Ecosystem
 	Vscnrs       VersionedScanners
-	Airgap       bool
+	// Deprecated: the airgap functionality should be encapsulated in the client passed to libindex.New()
+	Airgap bool
 }

--- a/libindex/libindex.go
+++ b/libindex/libindex.go
@@ -100,9 +100,6 @@ func New(ctx context.Context, opts *Options, cl *http.Client) (*Libindex, error)
 		}
 	}
 
-	// TODO(hank) If "airgap" is set, we should wrap the client and return
-	// errors on non-RFC1918 and non-RFC4193 addresses. As of go1.17, the net.IP
-	// type has a method for this purpose.
 	if cl == nil {
 		return nil, errors.New("invalid *http.Client")
 	}
@@ -116,7 +113,7 @@ func New(ctx context.Context, opts *Options, cl *http.Client) (*Libindex, error)
 	}
 
 	// register any new scanners.
-	pscnrs, dscnrs, rscnrs, err := indexer.EcosystemsToScanners(ctx, opts.Ecosystems, opts.Airgap)
+	pscnrs, dscnrs, rscnrs, err := indexer.EcosystemsToScanners(ctx, opts.Ecosystems)
 	if err != nil {
 		return nil, err
 	}

--- a/libindex/options.go
+++ b/libindex/options.go
@@ -41,6 +41,8 @@ type Options struct {
 	Ecosystems []*indexer.Ecosystem
 	// Airgap should be set to disallow any scanners that mark themselves as
 	// making network calls.
+	//
+	// Deprecated: the airgap functionality should be encapsulated in the client passed to libindex.New()
 	Airgap bool
 	// ScannerConfig holds functions that can be passed into configurable
 	// scanners. They're broken out by kind, and only used if a scanner


### PR DESCRIPTION
This change removes the code that disables RPC scanners when airgap
is true allowing hybrid implementations to be configured with local
resources. It assumes that the client passed will be airgap aware.

Signed-off-by: crozzy <joseph.crosland@gmail.com>

TODO

- [x] Check for the error in the RHEL and the RHCC scanners once https://github.com/quay/claircore/pull/762 is merged
- [x] Add error check in the layerscanner to see if the error comes from the client being airgapped