### PR TITLE
gobin: Reduce log level for non-go binaries

### DIFF
--- a/gobin/exe.go
+++ b/gobin/exe.go
@@ -13,7 +13,7 @@ import (
 func toPackages(ctx context.Context, out *[]*claircore.Package, p string, r io.ReaderAt) error {
 	bi, err := buildinfo.Read(r)
 	if err != nil {
-		zlog.Info(ctx).
+		zlog.Debug(ctx).
 			Err(err).
 			Msg("unable to open executable")
 		return nil


### PR DESCRIPTION
Currently the logs get spammed with
`unable to open executable error="not a Go executable"`, this reduces the level of these logs from Info to Debug.

Signed-off-by: crozzy <joseph.crosland@gmail.com>