### PR TITLE
chore: restrict CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,13 @@
 ---
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - "**"
 
 jobs:
   config:


### PR DESCRIPTION
Only run CI on push if going to main, keep PR branches open in case we have a situation where we're merging into a non-main branch.

Signed-off-by: crozzy <joseph.crosland@gmail.com>