### PR TITLE
gobin: Add noop Coalescer

### DIFF
--- a/gobin/coalescer.go
+++ b/gobin/coalescer.go
@@ -1,0 +1,19 @@
+package gobin
+
+import (
+	"context"
+
+	"github.com/quay/claircore"
+	"github.com/quay/claircore/indexer"
+)
+
+type coalescer struct {
+}
+
+func (c *coalescer) Coalesce(ctx context.Context, ls []*indexer.LayerArtifacts) (*claircore.IndexReport, error) {
+	return &claircore.IndexReport{
+		Environments: map[string][]*claircore.Environment{},
+		Packages:     map[string]*claircore.Package{},
+		Repositories: map[string]*claircore.Repository{},
+	}, nil
+}

--- a/gobin/ecosystem.go
+++ b/gobin/ecosystem.go
@@ -14,7 +14,6 @@ func NewEcosystem(ctx context.Context) *indexer.Ecosystem {
 		},
 		DistributionScanners: func(context.Context) ([]indexer.DistributionScanner, error) { return nil, nil },
 		RepositoryScanners:   func(context.Context) ([]indexer.RepositoryScanner, error) { return nil, nil },
-		// BUG(hank) The Ecosystem needs a coalescer that understands whiteouts.
-		Coalescer: func(context.Context) (indexer.Coalescer, error) { return nil, nil },
+		Coalescer:            func(context.Context) (indexer.Coalescer, error) { return &coalescer{}, nil },
 	}
 }


### PR DESCRIPTION
The coalesce function requires each ecosystem to have a coalescer, this change add a vanilla one.

Signed-off-by: crozzy <joseph.crosland@gmail.com>