### PR TITLE
logging: Expose error from SetLayerScanned in the logs

### DIFF
--- a/indexer/layerscanner/layerscanner.go
+++ b/indexer/layerscanner/layerscanner.go
@@ -209,7 +209,7 @@ func (ls *layerScanner) scanLayer(ctx context.Context, l *claircore.Layer, s ind
 	}
 
 	if err = ls.store.SetLayerScanned(ctx, l.Hash, s); err != nil {
-		return fmt.Errorf("could not set layer scanned: %v", l)
+		return fmt.Errorf("could not set layer scanned: %w", err)
 	}
 
 	return result.Store(ctx, ls.store, s, l)


### PR DESCRIPTION
Currently we just log that there was an error and the layer object. This change removes the layer object and adds the error.

Signed-off-by: crozzy <joseph.crosland@gmail.com>