### PR TITLE
chore: fix `git fetch` in release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
       - name: Changelog
         run: |
-          git fetch --tags origin refs/notes/changelog:refs/notes/changelog
+          git fetch origin refs/notes/changelog:refs/notes/changelog
           .github/scripts/changelog-render "${VERSION}" > "${{github.workspace}}/changelog"
       - name: Create Release
         uses: actions/create-release@latest


### PR DESCRIPTION
The switch to a `fetch-depth` of "0" means the `--tags` option errors out.

Signed-off-by: Hank Donnay <hdonnay@redhat.com>