### PR TITLE
gobin: reduce debug verbosity

### DIFF
--- a/gobin/gobin.go
+++ b/gobin/gobin.go
@@ -79,6 +79,8 @@ func (Detector) Scan(ctx context.Context, l *claircore.Layer) ([]*claircore.Pack
 			return err
 		case d.IsDir():
 			return nil
+		case ctx.Err() != nil:
+			return ctx.Err()
 		}
 		fi, err := d.Info()
 		if err != nil {


### PR DESCRIPTION
This change reaches into the `debug/buildinfo` package to determine when the returned errors aren't worth reporting.

Signed-off-by: Hank Donnay <hdonnay@redhat.com>