### PR TITLE
ubuntu: use the pre-exisiting global vars

### DIFF
--- a/ubuntu/distributionscanner.go
+++ b/ubuntu/distributionscanner.go
@@ -76,13 +76,13 @@ func findDist(sys fs.FS) (*claircore.Distribution, error) {
 	var b []byte
 	var verKey, nameKey string
 
-	b, err = fs.ReadFile(sys, `etc/lsb-release`)
+	b, err = fs.ReadFile(sys, lsbReleasePath)
 	if errors.Is(err, nil) {
 		verKey = `DISTRIB_RELEASE`
 		nameKey = `DISTRIB_CODENAME`
 		goto Found
 	}
-	b, err = fs.ReadFile(sys, `etc/os-release`)
+	b, err = fs.ReadFile(sys, osReleasePath)
 	if errors.Is(err, nil) {
 		verKey = `VERSION_ID`
 		nameKey = `VERSION_CODENAME`


### PR DESCRIPTION
Noticed these variables were defined at the top of the file but never used, so I figured why not use them :)