### PR TITLE
chore: update go versions

### DIFF
--- a/.github/workflows/golang-image.yml
+++ b/.github/workflows/golang-image.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.17', '1.18', '1.19']
+        go: ['1.18', '1.19', '1.20']
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - id: config
         run: |
-          echo 'go_versions=["1.18","1.19"]' >> $GITHUB_OUTPUT
+          echo 'go_versions=["1.18","1.19","1.20"]' >> $GITHUB_OUTPUT
 
   commit-check:
     name: Commit Check

--- a/etc/Dockerfile
+++ b/etc/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:experimental
-FROM registry.access.redhat.com/ubi8/ubi:8.1 AS install
+FROM registry.access.redhat.com/ubi8/ubi:8.7 AS install
 RUN dnf install -q -y \
 	gcc \
 	make \
@@ -9,7 +9,7 @@ RUN dnf install -q -y \
 ARG GO_VERSION
 ARG GO_CHECKSUM
 RUN arch=$(case "$(uname -m)" in\
-                ppc64le) echo ppc64le ;;\
+		ppc64le) echo ppc64le ;;\
 		aarch64) echo arm64 ;;\
 		x86_64) echo amd64 ;;\
 		*) exit 99 ;; esac);\


### PR DESCRIPTION
Start building the 1.20 container -- this is needed to pick up a fix in the `debug/elf` package.

Signed-off-by: Hank Donnay <hdonnay@redhat.com>