### PR TITLE
common: increase update interval

### DIFF
--- a/rhel/internal/common/updater.go
+++ b/rhel/internal/common/updater.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Interval is how often we attempt to update the mapping file.
-var interval = rate.Every(10 * time.Minute)
+var interval = rate.Every(24 * time.Hour)
 
 // Updater returns a value that's periodically updated.
 type Updater struct {


### PR DESCRIPTION
The Red Hat Product Security team tells us that these files won't update more than once a day. This changes the interval in the updater to 24 hours (the most common length of a day).

Closes: PROJQUAY-5069
Signed-off-by: Hank Donnay <hdonnay@redhat.com>