### PR TITLE
aws: include epoch in FixedInVersion

### DIFF
--- a/aws/updater.go
+++ b/aws/updater.go
@@ -113,6 +113,8 @@ func (u *Updater) Parse(ctx context.Context, contents io.ReadCloser) ([]*clairco
 // provided alas.Package
 func (u *Updater) unpack(partial *claircore.Vulnerability, packages []alas.Package) []*claircore.Vulnerability {
 	out := []*claircore.Vulnerability{}
+
+	var b strings.Builder
 	for _, alasPKG := range packages {
 		// make copy
 		v := *partial
@@ -121,12 +123,27 @@ func (u *Updater) unpack(partial *claircore.Vulnerability, packages []alas.Packa
 			Name: alasPKG.Name,
 			Kind: claircore.BINARY,
 		}
-		v.FixedInVersion = fmt.Sprintf("%s-%s", alasPKG.Version, alasPKG.Release)
+		v.FixedInVersion = versionString(&b, alasPKG)
 
 		out = append(out, &v)
 	}
 
+	b.Reset()
 	return out
+}
+
+func versionString(b *strings.Builder, p alas.Package) string {
+	b.Reset()
+
+	if p.Epoch != "" && p.Epoch != "0" {
+		b.WriteString(p.Epoch)
+		b.WriteByte(':')
+	}
+	b.WriteString(p.Version)
+	b.WriteByte('-')
+	b.WriteString(p.Release)
+
+	return b.String()
 }
 
 // refsToLinks takes an alas.Update and creates a string with all the href links

--- a/aws/updater_test.go
+++ b/aws/updater_test.go
@@ -1,0 +1,50 @@
+package aws
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/quay/alas"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestVersionString(t *testing.T) {
+	testcases := []struct {
+		pkg      alas.Package
+		expected string
+	}{
+		{
+			pkg: alas.Package{
+				Epoch:   "",
+				Version: "3.3.10",
+				Release: "26.amzn2",
+			},
+			expected: "3.3.10-26.amzn2",
+		},
+		{
+			pkg: alas.Package{
+				Epoch:   "0",
+				Version: "3.3.10",
+				Release: "26.amzn2",
+			},
+			expected: "3.3.10-26.amzn2",
+		},
+		{
+			pkg: alas.Package{
+				Epoch:   "10",
+				Version: "3.1.0",
+				Release: "8.amzn2.0.8",
+			},
+			expected: "10:3.1.0-8.amzn2.0.8",
+		},
+	}
+
+	var b strings.Builder
+	for _, testcase := range testcases {
+		v := versionString(&b, testcase.pkg)
+		if !cmp.Equal(v, testcase.expected) {
+			t.Errorf(cmp.Diff(v, testcase.expected))
+		}
+	}
+}


### PR DESCRIPTION
We are missing the epoch for the Amazon Linux vulnerability `FixedInVersion`. The `rpm` package scanner accounts for it, so it's possible we have been missing a bunch of Amazon Linux vulnerabilities.