### PR TITLE
dpkg: consider `Status` field

### DIFF
--- a/dpkg/distroless_scanner.go
+++ b/dpkg/distroless_scanner.go
@@ -101,6 +101,8 @@ func (ps *DistrolessScanner) Scan(ctx context.Context, layer *claircore.Layer) (
 			Restart:
 				hdr, err := tp.ReadMIMEHeader()
 				for ; (err == nil || errors.Is(err, io.EOF)) && len(hdr) > 0; hdr, err = tp.ReadMIMEHeader() {
+					// NB The "Status" header is not considered here. It seems
+					// to not be populated in the "distroless" scheme.
 					name := hdr.Get("Package")
 					v := hdr.Get("Version")
 					p := &claircore.Package{

--- a/dpkg/scanner.go
+++ b/dpkg/scanner.go
@@ -25,7 +25,7 @@ import (
 const (
 	name    = "dpkg"
 	kind    = "package"
-	version = "4"
+	version = "5"
 )
 
 var (
@@ -134,6 +134,18 @@ func (ps *Scanner) Scan(ctx context.Context, layer *claircore.Layer) ([]*clairco
 	Restart:
 		hdr, err := tp.ReadMIMEHeader()
 		for ; err == nil && len(hdr) > 0; hdr, err = tp.ReadMIMEHeader() {
+			var ok, installed bool
+			for _, s := range strings.Fields(hdr.Get("Status")) {
+				switch s {
+				case "installed":
+					installed = true
+				case "ok":
+					ok = true
+				}
+			}
+			if !ok || !installed {
+				continue
+			}
 			name := hdr.Get("Package")
 			v := hdr.Get("Version")
 			p := &claircore.Package{


### PR DESCRIPTION
This change makes the dpkg indexer consider the `Status` field. This can be set a few different ways depending on if dpkg-managed files are left after a removal operation or not.