### PR TITLE
chore: skip 'none' rhel vulnerability definition type

### DIFF
--- a/pkg/ovalutil/rpm.go
+++ b/pkg/ovalutil/rpm.go
@@ -12,12 +12,15 @@ import (
 	"github.com/quay/claircore"
 )
 
+type DefinitionType string
+
 const (
-	CVEDefinition        = "cve"
-	RHBADefinition       = "rhba"
-	RHEADefinition       = "rhea"
-	RHSADefinition       = "rhsa"
-	UnaffectedDefinition = "unaffected"
+	CVEDefinition        DefinitionType = "cve"
+	RHBADefinition       DefinitionType = "rhba"
+	RHEADefinition       DefinitionType = "rhea"
+	RHSADefinition       DefinitionType = "rhsa"
+	UnaffectedDefinition DefinitionType = "unaffected"
+	NoneDefinition       DefinitionType = "none"
 )
 
 var moduleCommentRegex, definitionTypeRegex *regexp.Regexp
@@ -211,10 +214,10 @@ func rpmStateLookup(root *oval.Root, ref string) (*oval.RPMInfoState, error) {
 }
 
 // GetDefinitionType parses an OVAL definition and extracts its type from ID.
-func GetDefinitionType(def oval.Definition) (string, error) {
+func GetDefinitionType(def oval.Definition) (DefinitionType, error) {
 	match := definitionTypeRegex.FindStringSubmatch(def.ID)
 	if len(match) != 2 { // we should have match of the whole string and one submatch
 		return "", errors.New("cannot parse definition ID for its type")
 	}
-	return match[1], nil
+	return DefinitionType(match[1]), nil
 }

--- a/pkg/ovalutil/rpm_test.go
+++ b/pkg/ovalutil/rpm_test.go
@@ -7,9 +7,10 @@ import (
 )
 
 type definitionTypeTestCase struct {
-	want, name string
-	def        oval.Definition
-	err        bool
+	name string
+	want DefinitionType
+	def  oval.Definition
+	err  bool
 }
 
 func TestGetDefinitionType(t *testing.T) {

--- a/rhel/parser.go
+++ b/rhel/parser.go
@@ -43,9 +43,7 @@ func (u *Updater) Parse(ctx context.Context, r io.ReadCloser) ([]*claircore.Vuln
 		// Red Hat OVAL data include information about vulnerabilities,
 		// that actually don't affect the package in any way. Storing them
 		// would increase number of records in DB without adding any value.
-		// TODO: Delete second part of the condition when all work related
-		// to new OVAL data is done.
-		if defType == ovalutil.UnaffectedDefinition || defType == ovalutil.CVEDefinition {
+		if isSkippableDefinitionType(defType) {
 			return vs, nil
 		}
 
@@ -85,4 +83,12 @@ func (u *Updater) Parse(ctx context.Context, r io.ReadCloser) ([]*claircore.Vuln
 		return nil, err
 	}
 	return vulns, nil
+}
+
+func isSkippableDefinitionType(defType ovalutil.DefinitionType) bool {
+	// TODO: Delete CVEDefinition of the condition when all work related
+	// to new OVAL data is done.
+	return defType == ovalutil.UnaffectedDefinition ||
+		defType == ovalutil.NoneDefinition ||
+		defType == ovalutil.CVEDefinition
 }


### PR DESCRIPTION
The 'none' type appears in "empty" OVAL v2 files (look for any 567 byte file like this one: https://access.redhat.com/security/data/oval/v2/RHEL8/openshift-service-mesh-2.3-including-unpatched.oval.xml.bz2).

We already ignore these because `def.Advisory.AffectedCPEList` is empty/`nil`, but this PR makes the code more defensive.