### PR TITLE
suse: change security tracker URL

### DIFF
--- a/suse/distributionscanner.go
+++ b/suse/distributionscanner.go
@@ -49,6 +49,18 @@ var suseRegexes = []suseRegex{
 		regexp:  regexp.MustCompile(`(?i)SUSE Linux Enterprise Server 11`),
 	},
 	{
+		release: Leap154,
+		regexp:  regexp.MustCompile(`(?i)openSUSE Leap 15.4`),
+	},
+	{
+		release: Leap153,
+		regexp:  regexp.MustCompile(`(?i)openSUSE Leap 15.3`),
+	},
+	{
+		release: Leap152,
+		regexp:  regexp.MustCompile(`(?i)openSUSE Leap 15.2`),
+	},
+	{
 		release: Leap151,
 		regexp:  regexp.MustCompile(`(?i)openSUSE Leap 15.1`),
 	},

--- a/suse/distributionscanner_test.go
+++ b/suse/distributionscanner_test.go
@@ -8,13 +8,13 @@ import (
 )
 
 var enterpriseServer15OSRelease []byte = []byte(`NAME="SLES"
-VERSION="15-SP1"
+VERSION="15-SP4"
 VERSION_ID="15.1"
-PRETTY_NAME="SUSE Linux Enterprise Server 15 SP1"
+PRETTY_NAME="SUSE Linux Enterprise Server 15 SP4"
 ID="sles"
 ID_LIKE="suse"
 ANSI_COLOR="0;32"
-CPE_NAME="cpe:/o:suse:sles:15:sp1"`)
+CPE_NAME="cpe:/o:suse:sles:15:sp4"`)
 
 var enterpriseServer12OSRelase []byte = []byte(`NAME="SLES"
 VERSION="12-SP5"
@@ -32,6 +32,39 @@ ID="sles"
 ANSI_COLOR="0;32"
 CPE_NAME="cpe:/o:suse:sles:12:sp5"`)
 
+var leap154OSRelease []byte = []byte(`NAME="openSUSE Leap"
+VERSION="15.4"
+ID="opensuse-leap"
+ID_LIKE="suse opensuse"
+VERSION_ID="15.4"
+PRETTY_NAME="openSUSE Leap 15.4"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:opensuse:leap:15.4"
+BUG_REPORT_URL="https://bugzilla.opensuse.org"
+HOME_URL="https://www.opensuse.org/"`)
+
+var leap153OSRelease []byte = []byte(`NAME="openSUSE Leap"
+VERSION="15.3"
+ID="opensuse-leap"
+ID_LIKE="suse opensuse"
+VERSION_ID="15.3"
+PRETTY_NAME="openSUSE Leap 15.3"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:opensuse:leap:15.3"
+BUG_REPORT_URL="https://bugzilla.opensuse.org"
+HOME_URL="https://www.opensuse.org/"`)
+
+var leap152OSRelease []byte = []byte(`NAME="openSUSE Leap"
+VERSION="15.2"
+ID="opensuse-leap"
+ID_LIKE="suse opensuse"
+VERSION_ID="15.2"
+PRETTY_NAME="openSUSE Leap 15.2"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:opensuse:leap:15.2"
+BUG_REPORT_URL="https://bugzilla.opensuse.org"
+HOME_URL="https://www.opensuse.org/"`)
+
 var leap151OSRelease []byte = []byte(`NAME="openSUSE Leap"
 VERSION="15.1"
 ID="opensuse-leap"
@@ -40,7 +73,7 @@ VERSION_ID="15.1"
 PRETTY_NAME="openSUSE Leap 15.1"
 ANSI_COLOR="0;32"
 CPE_NAME="cpe:/o:opensuse:leap:15.1"
-BUG_REPORT_URL="https://bugs.opensuse.org"
+BUG_REPORT_URL="https://bugzilla.opensuse.org"
 HOME_URL="https://www.opensuse.org/"`)
 
 var leap15OSRelease []byte = []byte(`NAME="openSUSE Leap"
@@ -51,7 +84,7 @@ VERSION_ID="15.0"
 PRETTY_NAME="openSUSE Leap 15.0"
 ANSI_COLOR="0;32"
 CPE_NAME="cpe:/o:opensuse:leap:15.0"
-BUG_REPORT_URL="https://bugs.opensuse.org"
+BUG_REPORT_URL="https://bugzilla.opensuse.org"
 HOME_URL="https://www.opensuse.org/"`)
 
 var leap423OSRelease []byte = []byte(`NAME="openSUSE Leap"
@@ -62,7 +95,7 @@ VERSION_ID="42.3"
 PRETTY_NAME="openSUSE Leap 42.3"
 ANSI_COLOR="0;32"
 CPE_NAME="cpe:/o:opensuse:leap:42.3"
-BUG_REPORT_URL="https://bugs.opensuse.org"
+BUG_REPORT_URL="https://bugzilla.opensuse.org"
 HOME_URL="https://www.opensuse.org/"`)
 
 func TestDistributionScanner(t *testing.T) {
@@ -87,14 +120,29 @@ func TestDistributionScanner(t *testing.T) {
 			osRelease: enterpriseServer11OSRelease,
 		},
 		{
-			name:      "leap 15.0",
-			release:   Leap150,
-			osRelease: leap15OSRelease,
+			name:      "leap 15.4",
+			release:   Leap154,
+			osRelease: leap154OSRelease,
+		},
+		{
+			name:      "leap 15.3",
+			release:   Leap153,
+			osRelease: leap153OSRelease,
+		},
+		{
+			name:      "leap 15.2",
+			release:   Leap152,
+			osRelease: leap152OSRelease,
 		},
 		{
 			name:      "leap 15.1",
 			release:   Leap151,
 			osRelease: leap151OSRelease,
+		},
+		{
+			name:      "leap 15.0",
+			release:   Leap150,
+			osRelease: leap15OSRelease,
 		},
 		{
 			name:      "leap 42.3",

--- a/suse/releases.go
+++ b/suse/releases.go
@@ -14,6 +14,9 @@ const (
 	EnterpriseServer15 Release = `suse.linux.enterprise.server.15`
 	EnterpriseServer12 Release = `suse.linux.enterprise.server.12`
 	EnterpriseServer11 Release = `suse.linux.enterprise.server.11`
+	Leap154            Release = `opensuse.leap.15.4`
+	Leap153            Release = `opensuse.leap.15.3`
+	Leap152            Release = `opensuse.leap.15.2`
 	Leap151            Release = `opensuse.leap.15.1`
 	Leap150            Release = `opensuse.leap.15.0`
 	Leap423            Release = `opensuse.leap.42.3`
@@ -43,6 +46,30 @@ var enterpriseServer11Dist = &claircore.Distribution{
 	DID:        "sles",
 }
 
+var leap154Dist = &claircore.Distribution{
+    Name:       "openSUSE Leap",
+    Version:    "15.4",
+    DID:        "opensuse-leap",
+    VersionID:  "15.4",
+    PrettyName: "openSUSE Leap 15.4",
+}
+
+var leap153Dist = &claircore.Distribution{
+    Name:       "openSUSE Leap",
+    Version:    "15.3",
+    DID:        "opensuse-leap",
+    VersionID:  "15.3",
+    PrettyName: "openSUSE Leap 15.3",
+}
+
+var leap152Dist = &claircore.Distribution{
+    Name:       "openSUSE Leap",
+    Version:    "15.2",
+    DID:        "opensuse-leap",
+    VersionID:  "15.2",
+    PrettyName: "openSUSE Leap 15.2",
+}
+
 var leap151Dist = &claircore.Distribution{
 	Name:       "openSUSE Leap",
 	Version:    "15.1",
@@ -51,7 +78,7 @@ var leap151Dist = &claircore.Distribution{
 	PrettyName: "openSUSE Leap 15.1",
 }
 
-var leap15Dist = &claircore.Distribution{
+var leap150Dist = &claircore.Distribution{
 	Name:       "openSUSE Leap",
 	Version:    "15.0",
 	DID:        "opensuse-leap",
@@ -75,10 +102,16 @@ func releaseToDist(r Release) *claircore.Distribution {
 		return enterpriseServer12Dist
 	case EnterpriseServer11:
 		return enterpriseServer11Dist
-	case Leap150:
-		return leap15Dist
+	case Leap154:
+		return leap154Dist
+	case Leap153:
+		return leap153Dist
+	case Leap152:
+		return leap152Dist
 	case Leap151:
 		return leap151Dist
+	case Leap150:
+		return leap150Dist
 	case Leap423:
 		return leap423Dist
 	default:

--- a/suse/suse.go
+++ b/suse/suse.go
@@ -12,7 +12,7 @@ import (
 var upstreamBase *url.URL
 
 func init() {
-	const base = `https://support.novell.com/security/oval/`
+	const base = `https://ftp.suse.com/pub/projects/security/oval/`
 	var err error
 	upstreamBase, err = url.Parse(base)
 	if err != nil {

--- a/suse/updaterset.go
+++ b/suse/updaterset.go
@@ -11,8 +11,11 @@ var suseReleases = []Release{
 	EnterpriseServer15,
 	EnterpriseServer12,
 	EnterpriseServer11,
-	Leap150,
+	Leap154,
+	Leap153,
+	Leap152,
 	Leap151,
+	Leap150,
 }
 
 func UpdaterSet(_ context.Context) (driver.UpdaterSet, error) {


### PR DESCRIPTION
The current link lacks relevant CVE statistics compared to the SUSE upstream.
Moreover, it doesn't include some of the SUSE distributions (e.g. Opensuse Leap 15.3, Opensuse Leap 15.4, etc.).