### PR TITLE
all: audit `tmp.NewFile` use

### DIFF
--- a/enricher/cvss/cvss.go
+++ b/enricher/cvss/cvss.go
@@ -172,6 +172,14 @@ func (e *Enricher) FetchEnrichment(ctx context.Context, hint driver.Fingerprint)
 	if err != nil {
 		return nil, hint, err
 	}
+	var success bool
+	defer func() {
+		if !success {
+			if err := out.Close(); err != nil {
+				zlog.Warn(ctx).Err(err).Msg("unable to close spool")
+			}
+		}
+	}()
 	// Doing this serially is slower, but much less complicated than using an
 	// ErrGroup or the like.
 	//
@@ -211,6 +219,7 @@ func (e *Enricher) FetchEnrichment(ctx context.Context, hint driver.Fingerprint)
 	if _, err := out.Seek(0, io.SeekStart); err != nil {
 		return nil, hint, fmt.Errorf("unable to reset item feed: %w", err)
 	}
+	success = true
 
 	nh, err := json.Marshal(cur)
 	if err != nil {

--- a/rhel/rhcc/updater.go
+++ b/rhel/rhcc/updater.go
@@ -141,6 +141,14 @@ func (u *updater) Fetch(ctx context.Context, hint driver.Fingerprint) (io.ReadCl
 	zlog.Debug(ctx).
 		Str("name", tf.Name()).
 		Msg("created tempfile")
+	var success bool
+	defer func() {
+		if !success {
+			if err := tf.Close(); err != nil {
+				zlog.Warn(ctx).Err(err).Msg("unable to close spool")
+			}
+		}
+	}()
 
 	var r io.Reader = res.Body
 	if u.bzipped {
@@ -148,15 +156,14 @@ func (u *updater) Fetch(ctx context.Context, hint driver.Fingerprint) (io.ReadCl
 		r = bzip2.NewReader(res.Body)
 	}
 	if _, err := io.Copy(tf, r); err != nil {
-		tf.Close()
 		return nil, hint, fmt.Errorf("rhcc: unable to copy resp body to tempfile: %w", err)
 	}
 	if n, err := tf.Seek(0, io.SeekStart); err != nil || n != 0 {
-		tf.Close()
 		return nil, hint, fmt.Errorf("rhcc: unable to seek database to start: %w", err)
 	}
 	zlog.Debug(ctx).Msg("decompressed and buffered database")
 
+	success = true
 	hint = driver.Fingerprint(res.Header.Get("etag"))
 	zlog.Debug(ctx).
 		Str("hint", string(hint)).


### PR DESCRIPTION
The fact that this idiom was applied unevenly means the interface is in need of retooling, IMO.

See-also: PROJQUAY-5165