### PR TITLE
chore: delete airgap options

### DIFF
--- a/indexer/opts.go
+++ b/indexer/opts.go
@@ -15,6 +15,4 @@ type Opts struct {
 	Realizer     Realizer
 	Ecosystems   []*Ecosystem
 	Vscnrs       VersionedScanners
-	// Deprecated: the airgap functionality should be encapsulated in the client passed to libindex.New()
-	Airgap bool
 }

--- a/libindex/options.go
+++ b/libindex/options.go
@@ -39,11 +39,6 @@ type Options struct {
 	ControllerFactory ControllerFactory
 	// Ecosystems a list of ecosystems to use which define which package databases and coalescing methods we use
 	Ecosystems []*indexer.Ecosystem
-	// Airgap should be set to disallow any scanners that mark themselves as
-	// making network calls.
-	//
-	// Deprecated: the airgap functionality should be encapsulated in the client passed to libindex.New()
-	Airgap bool
 	// ScannerConfig holds functions that can be passed into configurable
 	// scanners. They're broken out by kind, and only used if a scanner
 	// implements the appropriate interface.


### PR DESCRIPTION
At this point, these options are no longer used anywhere, so might as well remove them to ensure nobody uses them.