### PR TITLE
pep440: add leading zeroes tests

### DIFF
--- a/pkg/pep440/range_test.go
+++ b/pkg/pep440/range_test.go
@@ -70,6 +70,32 @@ var rangeCases = []rangeTestcase{
 		},
 	},
 	{
+		Name: "SimpleLT",
+		In:   "<2022.12.07",
+		Want: Range{
+			criterion{Op: opLT, V: Version{Release: []int{2022, 12, 7}}},
+		},
+		Match: []matchTestcase{
+			{In: "2022.12.07", Match: false},
+			{In: "2022.12.7", Match: false},
+			{In: "2022.12.08", Match: false},
+			{In: "2022.12.06", Match: true},
+		},
+	},
+	{
+		Name: "SimpleLTE",
+		In:   "<=2022.12.07",
+		Want: Range{
+			criterion{Op: opLTE, V: Version{Release: []int{2022, 12, 7}}},
+		},
+		Match: []matchTestcase{
+			{In: "2022.12.07", Match: true},
+			{In: "2022.12.7", Match: true},
+			{In: "2022.12.08", Match: false},
+			{In: "2022.12.8", Match: false},
+		},
+	},
+	{
 		Name: "Compatible",
 		In:   "~=1.1",
 		Want: Range{

--- a/pkg/pep440/version_test.go
+++ b/pkg/pep440/version_test.go
@@ -58,6 +58,12 @@ func TestSimple(t *testing.T) {
 			Err:  false,
 			Want: Version{Release: []int{2019, 3}},
 		},
+		{
+			Name: "Date Leading Zero",
+			In:   "2022.12.07",
+			Err:  false,
+			Want: Version{Release: []int{2022, 12, 7}},
+		},
 	}
 
 	for _, tc := range tt {


### PR DESCRIPTION
This came up in a chat, so I decided to add some tests to confirm ClairCore can handle this scenario. This popped up when determining if Clair can find https://github.com/certifi/python-certifi/security/advisories/GHSA-43fp-rhv2-5gv8 when the metadata says the version is `2022.12.7`. See https://github.com/pypa/setuptools/issues/302 and https://peps.python.org/pep-0440/ for more information about how `setuptools` removes leading zeroes and `pep440` specifies date-versions have leading zeroes removed.