### PR TITLE
chore: do not assume challenge endpoint called token

### DIFF
--- a/test/fetch/layer.go
+++ b/test/fetch/layer.go
@@ -154,10 +154,6 @@ func (d *client) doAuth(ctx context.Context, c *http.Client, name, h string) err
 	if err != nil {
 		return err
 	}
-	u, err = u.Parse("token")
-	if err != nil {
-		return err
-	}
 	v := url.Values{
 		"service": {attrs["service"]},
 		"scope":   {attrs["scope"]},


### PR DESCRIPTION
I ran into this when I was testing out images pulled from quay.io. The returned `realm` for that was `https://quay.io/v2/auth`