### PR TITLE
rpm: handle bdb header weirdness

### DIFF
--- a/rpm/packagescanner.go
+++ b/rpm/packagescanner.go
@@ -22,7 +22,7 @@ import (
 const (
 	pkgName    = "rpm"
 	pkgKind    = "package"
-	pkgVersion = "8"
+	pkgVersion = "9"
 )
 
 var (


### PR DESCRIPTION
It seems like headers in bdb databases don't always have the same sorting applied to the tags. This change catches when a header region is less orderly and falls back to a lax verification mode.

Closes: #885