### PR TITLE
bisect tool update

### DIFF
--- a/libvuln/libvuln.go
+++ b/libvuln/libvuln.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/quay/zlog"
 	"github.com/rs/zerolog"
 
@@ -29,7 +28,6 @@ import (
 type Libvuln struct {
 	store           datastore.MatcherStore
 	locker          LockSource
-	pool            *pgxpool.Pool
 	matchers        []driver.Matcher
 	enrichers       []driver.Enricher
 	updateRetention int
@@ -130,7 +128,6 @@ func New(ctx context.Context, opts *Options) (*Libvuln, error) {
 
 func (l *Libvuln) Close(ctx context.Context) error {
 	l.locker.Close(ctx)
-	l.pool.Close()
 	return nil
 }
 

--- a/test/bisect/main.go
+++ b/test/bisect/main.go
@@ -1,7 +1,4 @@
 // Bisect is a git bisect helper.
-//
-// It relies on some makefile targets to spin up and down all services and wraps
-// calls to cctool.
 package main
 
 import (
@@ -15,6 +12,11 @@ import (
 	"os/signal"
 	"path/filepath"
 )
+
+/*
+This tool is significantly weird in that it makes heavy use of test harnesses for automatic setup,
+so the "normal" binary here is mostly setup around correctly building and invoking the test binary.
+*/
 
 func main() {
 	var exit int


### PR DESCRIPTION
This updates the bisect tool to actually work enough to make `go generate github.com/quay/claircore/datastore/postgres` work.