### PR TITLE
indexer: Add index to manifest_index table to aid deletions

### DIFF
--- a/datastore/postgres/migrations/indexer/07-index-manifest_index.sql
+++ b/datastore/postgres/migrations/indexer/07-index-manifest_index.sql
@@ -1,0 +1,4 @@
+-- This index is needed when deleting manifests, the cascade will want
+-- to delete rows from manifest_index based on the manifest.id. Without
+-- this index things get slow.
+CREATE INDEX IF NOT EXISTS idx_manifest_index_manifest_id ON manifest_index(manifest_id);

--- a/datastore/postgres/migrations/migrations.go
+++ b/datastore/postgres/migrations/migrations.go
@@ -53,6 +53,10 @@ var IndexerMigrations = []migrate.Migration{
 		ID: 6,
 		Up: runFile("indexer/06-file-artifacts.sql"),
 	},
+	{
+		ID: 7,
+		Up: runFile("indexer/07-index-manifest_index.sql"),
+	},
 }
 
 var MatcherMigrations = []migrate.Migration{

--- a/test/integration/engine.go
+++ b/test/integration/engine.go
@@ -102,6 +102,8 @@ func (e *Engine) Start(t testing.TB) error {
 			"-o", "-c auto_explain.log_analyze=true",
 			"-o", "-c auto_explain.log_buffers=true",
 			"-o", "-c auto_explain.log_wal=true",
+			"-o", "-c auto_explain.log_verbose=true",
+			"-o", "-c auto_explain.log_nested_statements=true",
 		)
 		if f := os.Getenv("PGEXPLAIN_FORMAT"); f != "" {
 			opts = append(opts, "-o", fmt.Sprintf("-c auto_explain.log_format=%s", f))


### PR DESCRIPTION
By deleting a broad index for space reasons (
https://github.com/quay/claircore/commit/d9abe3db42bb533962ff163b3521587fc4b3f0cc) I inadvertantly slowed the delete manifests query due to a delete cascading to the manifest_index table and having to do a seq scan. This change adds a dedicated index for queries involving manifest_id.