### PR TITLE
cicd: fix test invocation, print postgres logs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,8 +98,17 @@ jobs:
             **/testdata/*.tar
             **/testdata/*.tar.gz
       - name: Tests
-        run: >
-          find .
-          -name .git -prune -o
-          -name testdata -prune -o
-          -name go.mod -execdir go test -race -tags integration ./... \;
+        run: |
+          find . -name .git -prune -o -name testdata -prune -o -name go.mod -printf '%h\n' |
+          while read -r dir; do (
+            cd "$dir";
+            go list -m;
+            go mod download;
+            go test -race -tags integration ./...;
+          ); done
+      - name: Database Logs
+        if: failure()
+        run: |
+          sudo journalctl --unit postgresql.service --boot -0
+          ls /var/log/postgresql/postgresql-*.log
+          sudo cat /var/log/postgresql/postgresql-*.log

--- a/go.sum
+++ b/go.sum
@@ -39,7 +39,6 @@ github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/pprof v0.0.0-20221118152302-e6195bd50e26 h1:Xim43kblpZXfIBQsbuBVKCudVG457BR2GZFIz3uw3hQ=

--- a/toolkit/go.mod
+++ b/toolkit/go.mod
@@ -2,4 +2,4 @@ module github.com/quay/claircore/toolkit
 
 go 1.16
 
-require github.com/google/go-cmp v0.5.7
+require github.com/google/go-cmp v0.5.9

--- a/toolkit/go.sum
+++ b/toolkit/go.sum
@@ -1,4 +1,2 @@
-github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
-github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=


### PR DESCRIPTION
This should make the tests fail if the tests for any module fails and print the postgres logs in that case.