### PR TITLE
updater: Extend default updater time to 6 hours

### DIFF
--- a/libvuln/libvuln.go
+++ b/libvuln/libvuln.go
@@ -59,7 +59,7 @@ func New(ctx context.Context, opts *Options) (*Libvuln, error) {
 
 	// optional
 	if opts.UpdateInterval == 0 || opts.UpdateInterval < time.Minute {
-		opts.UpdateInterval = DefaultUpdateInterval
+		opts.UpdateInterval = updates.DefaultInterval
 	}
 	// This gives us a ±60 second range, rounded to the nearest tenth of a
 	// second.

--- a/libvuln/options.go
+++ b/libvuln/options.go
@@ -9,7 +9,6 @@ import (
 )
 
 const (
-	DefaultUpdateInterval  = 30 * time.Minute
 	DefaultUpdateWorkers   = 10
 	DefaultMaxConnPool     = 50
 	DefaultUpdateRetention = 2

--- a/libvuln/updates/manager.go
+++ b/libvuln/updates/manager.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	DefaultInterval = time.Duration(30 * time.Minute)
+	DefaultInterval = time.Duration(6 * time.Hour)
 )
 
 var DefaultBatchSize = runtime.GOMAXPROCS(0)


### PR DESCRIPTION
Given the expense of updating and the lack of value to such a high frequency this change extends the default update period from 30 mins to 6 hours.