### PR TITLE
java: expose matcher

### DIFF
--- a/java/matcher.go
+++ b/java/matcher.go
@@ -8,26 +8,27 @@ import (
 	"net/url"
 )
 
-type matcher struct{}
+// Matcher matches discovered Java Maven packages against advisories provided via OSV.
+type Matcher struct{}
 
 var (
-	_ driver.Matcher = (*matcher)(nil)
+	_ driver.Matcher = (*Matcher)(nil)
 )
 
 // Name implements driver.Matcher.
-func (*matcher) Name() string { return "java-maven" }
+func (*Matcher) Name() string { return "java-maven" }
 
-func (*matcher) Filter(r *claircore.IndexRecord) bool {
+func (*Matcher) Filter(r *claircore.IndexRecord) bool {
 	return r.Repository != nil &&
 		r.Repository.Name == Repository.Name
 }
 
 // Query implements driver.Matcher.
-func (*matcher) Query() []driver.MatchConstraint {
+func (*Matcher) Query() []driver.MatchConstraint {
 	return []driver.MatchConstraint{driver.RepositoryName}
 }
 
-func (*matcher) Vulnerable(ctx context.Context, record *claircore.IndexRecord, vuln *claircore.Vulnerability) (bool, error) {
+func (*Matcher) Vulnerable(ctx context.Context, record *claircore.IndexRecord, vuln *claircore.Vulnerability) (bool, error) {
 	if vuln.FixedInVersion == "" {
 		return true, nil
 	}

--- a/java/matcher_integration_test.go
+++ b/java/matcher_integration_test.go
@@ -40,7 +40,7 @@ func TestMatcherIntegration(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	m := &matcher{}
+	m := &Matcher{}
 	locks, err := ctxlock.New(ctx, pool)
 	if err != nil {
 		t.Fatalf("%v", err)
@@ -84,7 +84,7 @@ func TestMatcherIntegration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected error to be nil but got %v", err)
 	}
-	
+
 	vulns := vr.Vulnerabilities
 	t.Logf("Number of Vulnerabilities found: %d", len(vulns))
 

--- a/java/matcher_test.go
+++ b/java/matcher_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestVulnerable(t *testing.T) {
-	matcher := &matcher{}
+	matcher := &Matcher{}
 
 	testcases := []struct {
 		name   string


### PR DESCRIPTION
This is so other users of this library may use the matcher, as necessary.