### PR TITLE
java: Add java.Matcher to defaults

### DIFF
--- a/crda/matcherfactory.go
+++ b/crda/matcherfactory.go
@@ -106,6 +106,8 @@ func (f *Factory) Configure(ctx context.Context, cfg driver.MatcherConfigUnmarsh
 		zlog.Info(ctx).
 			Str("key", f.key).
 			Msg("configured API key")
+		zlog.Warn(ctx).
+			Msg("CRDA remote matcher is deprecated and will be removed in upcoming versions")
 	}
 
 	f.ecosystems = fc.Ecosystems

--- a/matchers/defaults/defaults.go
+++ b/matchers/defaults/defaults.go
@@ -11,6 +11,7 @@ import (
 	"github.com/quay/claircore/crda"
 	"github.com/quay/claircore/debian"
 	"github.com/quay/claircore/gobin"
+	"github.com/quay/claircore/java"
 	"github.com/quay/claircore/libvuln/driver"
 	"github.com/quay/claircore/matchers/registry"
 	"github.com/quay/claircore/oracle"
@@ -47,6 +48,7 @@ var defaultMatchers = []driver.Matcher{
 	&aws.Matcher{},
 	&debian.Matcher{},
 	&gobin.Matcher{},
+	&java.Matcher{},
 	&oracle.Matcher{},
 	&photon.Matcher{},
 	&python.Matcher{},


### PR DESCRIPTION
As we now have a native java matcher we should add it to the defaults, it will be doing similar work to the CRDA matcher so people will most likely want to disable the CRDA matcher (by removing its config). The CRDA matcher will be removed in later versions.