### PR TITLE
indexer: Add ability for package scanner to return a default repository

### DIFF
--- a/gobin/gobin.go
+++ b/gobin/gobin.go
@@ -29,7 +29,15 @@ const (
 	detectorKind    = `package`
 )
 
-var _ indexer.PackageScanner = Detector{}
+var (
+	_ indexer.PackageScanner     = Detector{}
+	_ indexer.DefaultRepoScanner = Detector{}
+
+	Repository = claircore.Repository{
+		Name: "go",
+		URI:  "https://pkg.go.dev/",
+	}
+)
 
 // Name implements [indexer.PackageScanner].
 func (Detector) Name() string { return detectorName }
@@ -142,6 +150,11 @@ func (Detector) Scan(ctx context.Context, l *claircore.Layer) ([]*claircore.Pack
 	}
 
 	return out, nil
+}
+
+// Scan implements [indexer.DefaultRepoScanner].
+func (Detector) DefaultRepository(ctx context.Context) *claircore.Repository {
+	return &Repository
 }
 
 type spoolfile struct {

--- a/indexer/controller/coalesce.go
+++ b/indexer/controller/coalesce.go
@@ -42,6 +42,13 @@ func coalesce(ctx context.Context, s *Controller) (State, error) {
 				return Terminal, fmt.Errorf("failed to retrieve packages for %v: %w", layer.Hash, err)
 			}
 			la.Pkgs = append(la.Pkgs, pkgs...)
+			// Get repos that have been created via the package scanners
+			pkgRepos, err := s.Store.RepositoriesByLayer(cctx, layer.Hash, vscnrs)
+			if err != nil {
+				return Terminal, fmt.Errorf("failed to retrieve repositories for %v: %w", layer.Hash, err)
+			}
+			la.Repos = append(la.Repos, pkgRepos...)
+
 			// get distributions from layer
 			vscnrs.DStoVS(distScanners) // method allocates new vscnr underlying array, clearing old contents
 			dists, err := s.Store.DistributionsByLayer(cctx, layer.Hash, vscnrs)

--- a/indexer/packagescanner.go
+++ b/indexer/packagescanner.go
@@ -44,3 +44,12 @@ func NewPackageScannerMock(name, version, kind string) PackageScanner {
 		kind:    kind,
 	}
 }
+
+// DefaultRepoScanner provides a DefaultRepository method to allow Package Scanners
+// to define what the default repository should be if the Scanner returned packages.
+// This is useful to avoid having a dedicated RepositoryScanner for an ecosystem that
+// largely duplicates the work of the PackageScanner and would always return the same
+// pre-defined repository.
+type DefaultRepoScanner interface {
+	DefaultRepository(context.Context) *claircore.Repository
+}


### PR DESCRIPTION
This has become an issue with more language support where the packages need to be associated to a repository but the repo scanner just ends up being a packagescanner-lite (repeating work). This change lets packageScanners implement an optional method to return a default Repository which will be created during indexing.