### PR TITLE
gobin: Make matching use VersionFilter for db side filtering

### DIFF
--- a/gobin/gobin.go
+++ b/gobin/gobin.go
@@ -25,7 +25,7 @@ type Detector struct{}
 
 const (
 	detectorName    = `gobin`
-	detectorVersion = `2`
+	detectorVersion = `3`
 	detectorKind    = `package`
 )
 

--- a/gobin/matcher.go
+++ b/gobin/matcher.go
@@ -3,14 +3,14 @@ package gobin
 import (
 	"context"
 
-	"github.com/Masterminds/semver"
-
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/libvuln/driver"
-	"github.com/quay/claircore/updater/osv"
 )
 
-var _ driver.Matcher = (*Matcher)(nil)
+var (
+	_ driver.Matcher       = (*Matcher)(nil)
+	_ driver.VersionFilter = (*Matcher)(nil)
+)
 
 // Matcher matches discovered go packages against advisories provided via OSV.
 type Matcher struct{}
@@ -26,15 +26,14 @@ func (matcher *Matcher) Filter(record *claircore.IndexRecord) bool {
 
 // Query implements driver.Matcher.
 func (matcher *Matcher) Query() []driver.MatchConstraint {
-	return []driver.MatchConstraint{driver.RepositoryName, driver.PackageName}
+	return []driver.MatchConstraint{driver.RepositoryName}
 }
 
 // Vulnerable implements driver.Matcher.
 func (matcher *Matcher) Vulnerable(ctx context.Context, record *claircore.IndexRecord, vuln *claircore.Vulnerability) (bool, error) {
-	sv, err := semver.NewVersion(record.Package.Version)
-	if err != nil {
-		return false, err
-	}
-	v := osv.FromSemver(sv)
-	return vuln.Range.Contains(&v), nil
+	// no-op
+	return false, nil
 }
+
+func (matcher *Matcher) VersionFilter()             {}
+func (matcher *Matcher) VersionAuthoritative() bool { return true }

--- a/updater/osv/osv.go
+++ b/updater/osv/osv.go
@@ -613,13 +613,13 @@ func (e *ecs) Insert(ctx context.Context, skipped *stats, name string, a *adviso
 			}
 			pkgName := af.Package.PURL
 			switch af.Package.Ecosystem {
-			case ecosystemMaven, ecosystemPyPI:
+			case ecosystemMaven, ecosystemPyPI, ecosystemGo:
 				pkgName = af.Package.Name
 			}
 			pkg, novel := e.LookupPackage(pkgName, vs)
 			v.Package = pkg
 			switch af.Package.Ecosystem {
-			case ecosystemMaven, ecosystemPyPI:
+			case ecosystemMaven, ecosystemPyPI, ecosystemGo:
 				v.Package.Kind = claircore.BINARY
 			}
 			if novel {


### PR DESCRIPTION
In order to use the db for version filtering, the package created with the gobin package detector needs to add normalized versions. The detector also needs implement VersionFilter and VersionAuthoritative, then Vulnerable() becomes a no-op.