### PR TITLE
python: Delete pyupio vulns

### DIFF
--- a/datastore/postgres/migrations/matcher/09-delete-pyupio.sql
+++ b/datastore/postgres/migrations/matcher/09-delete-pyupio.sql
@@ -1,0 +1,10 @@
+-- Delete all update_operations for pyupio to trigger pyupio vuln deletion
+DELETE FROM update_operation WHERE updater = 'pyupio';
+
+DELETE FROM vuln v1 USING
+	vuln v2
+	LEFT JOIN uo_vuln uvl
+		ON v2.id = uvl.vuln
+	WHERE uvl.vuln IS NULL
+	AND v2.updater = 'pyupio'
+AND v1.id = v2.id;

--- a/datastore/postgres/migrations/migrations.go
+++ b/datastore/postgres/migrations/migrations.go
@@ -92,4 +92,8 @@ var MatcherMigrations = []migrate.Migration{
 		ID: 8,
 		Up: runFile("matcher/08-updater-status.sql"),
 	},
+	{
+		ID: 9,
+		Up: runFile("matcher/09-delete-pyupio.sql"),
+	},
 }


### PR DESCRIPTION
Because no more update_operations are being created for pyupio the current vulns will not be GCed. This is a manual intervention to clear them up and avoid double reporting.