### PR TITLE
indexer: Cache scanner table

### DIFF
--- a/datastore/postgres/distributionsbylayer.go
+++ b/datastore/postgres/distributionsbylayer.go
@@ -39,13 +39,6 @@ var (
 
 func (s *IndexerStore) DistributionsByLayer(ctx context.Context, hash claircore.Digest, scnrs indexer.VersionedScanners) ([]*claircore.Distribution, error) {
 	const (
-		selectScanner = `
-		SELECT id
-		FROM scanner
-		WHERE name = $1
-		  AND version = $2
-		  AND kind = $3;
-		`
 		query = `
 		SELECT dist.id,
 			   dist.name,
@@ -68,17 +61,9 @@ func (s *IndexerStore) DistributionsByLayer(ctx context.Context, hash claircore.
 		return []*claircore.Distribution{}, nil
 	}
 
-	// get scanner ids
-	scannerIDs := make([]int64, len(scnrs))
-	for i, scnr := range scnrs {
-		start := time.Now()
-		err := s.pool.QueryRow(ctx, selectScanner, scnr.Name(), scnr.Version(), scnr.Kind()).
-			Scan(&scannerIDs[i])
-		if err != nil {
-			return nil, fmt.Errorf("failed to retrieve distribution ids for scanner %q: %w", scnr, err)
-		}
-		distributionByLayerCounter.WithLabelValues("selectScanner").Add(1)
-		distributionByLayerDuration.WithLabelValues("selectScanner").Observe(time.Since(start).Seconds())
+	scannerIDs, err := s.selectScanners(ctx, scnrs)
+	if err != nil {
+		return nil, err
 	}
 
 	start := time.Now()

--- a/datastore/postgres/filesbylayer.go
+++ b/datastore/postgres/filesbylayer.go
@@ -38,13 +38,6 @@ var (
 
 func (s *IndexerStore) FilesByLayer(ctx context.Context, hash claircore.Digest, scnrs indexer.VersionedScanners) ([]claircore.File, error) {
 	const (
-		selectScanner = `
-		SELECT id
-		FROM scanner
-		WHERE name = $1
-		  AND version = $2
-		  AND kind = $3;
-		`
 		query = `
 		SELECT file.path, file.kind
 		FROM file_scanartifact
@@ -59,17 +52,9 @@ func (s *IndexerStore) FilesByLayer(ctx context.Context, hash claircore.Digest, 
 		return []claircore.File{}, nil
 	}
 
-	// get scanner ids
-	scannerIDs := make([]int64, len(scnrs))
-	for i, scnr := range scnrs {
-		start := time.Now()
-		err := s.pool.QueryRow(ctx, selectScanner, scnr.Name(), scnr.Version(), scnr.Kind()).
-			Scan(&scannerIDs[i])
-		filesByLayerCounter.WithLabelValues("selectScanner").Add(1)
-		filesByLayerDuration.WithLabelValues("selectScanner").Observe(time.Since(start).Seconds())
-		if err != nil {
-			return nil, fmt.Errorf("failed to retrieve file ids for scanner %q: %w", scnr, err)
-		}
+	scannerIDs, err := s.selectScanners(ctx, scnrs)
+	if err != nil {
+		return nil, err
 	}
 
 	start := time.Now()

--- a/datastore/postgres/index_e2e_test.go
+++ b/datastore/postgres/index_e2e_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/indexer"
@@ -49,157 +50,23 @@ func TestIndexE2E(t *testing.T) {
 	integration.NeedDB(t)
 	ctx := context.Background()
 
-	e2es := []indexE2e{
-		{
-			name: "3 scanners gen small",
-			scnrs: indexer.VersionedScanners{
-				mockScnr{
-					name:    "test-scanner",
-					kind:    "test",
-					version: "v0.0.1",
-				},
-				mockScnr{
-					name:    "test-scanner1",
-					kind:    "test",
-					version: "v0.0.11",
-				},
-				mockScnr{
-					name:    "test-scanner2",
-					kind:    "test",
-					version: "v0.0.8",
-				},
-			},
-			packageGen: 100,
-			distGen:    150,
-			repoGen:    50,
-		},
-		{
-			name: "6 scanners gen small",
-			scnrs: indexer.VersionedScanners{
-				mockScnr{
-					name:    "test-scanner",
-					kind:    "test",
-					version: "v0.0.1",
-				},
-				mockScnr{
-					name:    "test-scanner1",
-					kind:    "test",
-					version: "v0.0.11",
-				},
-				mockScnr{
-					name:    "test-scanner2",
-					kind:    "test",
-					version: "v0.0.8",
-				},
-				mockScnr{
-					name:    "test-scanner3",
-					kind:    "test",
-					version: "v0.0.8",
-				},
-				mockScnr{
-					name:    "test-scanner4",
-					kind:    "test",
-					version: "v0.0.8",
-				},
-				mockScnr{
-					name:    "test-scanner5",
-					kind:    "test",
-					version: "v0.0.8",
-				},
-			},
-			packageGen: 100,
-			distGen:    150,
-			repoGen:    50,
-		},
-		{
-			name: "3 scanners gen large",
-			scnrs: indexer.VersionedScanners{
-				mockScnr{
-					name:    "test-scanner",
-					kind:    "test",
-					version: "v0.0.1",
-				},
-				mockScnr{
-					name:    "test-scanner1",
-					kind:    "test",
-					version: "v0.0.11",
-				},
-				mockScnr{
-					name:    "test-scanner2",
-					kind:    "test",
-					version: "v0.0.8",
-				},
-			},
-			packageGen: 1000,
-			distGen:    1500,
-			repoGen:    500,
-		},
-		{
-			name: "6 scanners gen large",
-			scnrs: indexer.VersionedScanners{
-				mockScnr{
-					name:    "test-scanner",
-					kind:    "test",
-					version: "v0.0.1",
-				},
-				mockScnr{
-					name:    "test-scanner1",
-					kind:    "test",
-					version: "v0.0.11",
-				},
-				mockScnr{
-					name:    "test-scanner2",
-					kind:    "test",
-					version: "v0.0.8",
-				},
-				mockScnr{
-					name:    "test-scanner3",
-					kind:    "test",
-					version: "v0.0.8",
-				},
-				mockScnr{
-					name:    "test-scanner4",
-					kind:    "test",
-					version: "v0.0.8",
-				},
-				mockScnr{
-					name:    "test-scanner5",
-					kind:    "test",
-					version: "v0.0.8",
-				},
-			},
-			packageGen: 1000,
-			distGen:    1500,
-			repoGen:    500,
-		},
-	}
+	for _, scenario := range testScenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			pool := pgtest.TestIndexerDB(ctx, t)
+			defer pool.Close()
 
-	for _, e := range e2es {
-		pool := pgtest.TestIndexerDB(ctx, t)
-		store := NewIndexerStore(pool)
-
-		layer := &claircore.Layer{
-			Hash: claircore.MustParseDigest(`sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef`),
-		}
-		manifest := claircore.Manifest{
-			Hash:   claircore.MustParseDigest(`sha256:fc92eec5cac70b0c324cec2933cd7db1c0eae7c9e2649e42d02e77eb6da0d15f`),
-			Layers: []*claircore.Layer{layer},
-		}
-
-		e.store = store
-		e.ctx = ctx
-		e.manifest = manifest
-
-		t.Run(e.name, e.Run)
+			e := setupIndexE2E(ctx, pool, scenario, t)
+			e.RunAll(t)
+		})
 	}
 }
 
-func (e *indexE2e) Run(t *testing.T) {
-	type subtest struct {
+// RunAll executes all test steps in sequence
+func (e *indexE2e) RunAll(t testing.TB) {
+	steps := []struct {
 		name string
-		do   func(t *testing.T)
-	}
-	subtests := [...]subtest{
+		fn   func(testing.TB)
+	}{
 		{"RegisterScanner", e.RegisterScanner},
 		{"PersistManifest", e.PersistManifest},
 		{"IndexAndRetrievePackages", e.IndexAndRetrievePackages},
@@ -210,9 +77,19 @@ func (e *indexE2e) Run(t *testing.T) {
 		{"LayerScannedFalse", e.LayerScannedFalse},
 		{"IndexReport", e.IndexReport},
 	}
-	for _, subtest := range subtests {
-		if !t.Run(subtest.name, subtest.do) {
-			t.FailNow()
+	if _, isBenchmark := t.(*testing.B); isBenchmark {
+		for _, step := range steps {
+			step.fn(t)
+		}
+		return
+	}
+	tt, ok := t.(*testing.T)
+	if !ok {
+		t.Fatal("RunAll requires *testing.T or *testing.B")
+	}
+	for _, step := range steps {
+		if !tt.Run(step.name, func(t *testing.T) { step.fn(t) }) {
+			tt.FailNow()
 		}
 	}
 }
@@ -220,7 +97,7 @@ func (e *indexE2e) Run(t *testing.T) {
 // PersistManifest confirms we create the necessary
 // Manifest and Layer identities so layer code
 // foreign key references do not fail.
-func (e *indexE2e) PersistManifest(t *testing.T) {
+func (e *indexE2e) PersistManifest(t testing.TB) {
 	ctx := test.Logging(t, e.ctx)
 	err := e.store.PersistManifest(ctx, e.manifest)
 	if err != nil {
@@ -230,7 +107,7 @@ func (e *indexE2e) PersistManifest(t *testing.T) {
 
 // RegisterScanner confirms a scanner can be registered
 // and provides this scanner for other subtests to use
-func (e *indexE2e) RegisterScanner(t *testing.T) {
+func (e *indexE2e) RegisterScanner(t testing.TB) {
 	ctx := test.Logging(t, e.ctx)
 	err := e.store.RegisterScanners(ctx, e.scnrs)
 	if err != nil {
@@ -241,7 +118,7 @@ func (e *indexE2e) RegisterScanner(t *testing.T) {
 // IndexAndRetrievePackages confirms inserting and
 // selecting packages associated with a layer works
 // correctly.
-func (e *indexE2e) IndexAndRetrievePackages(t *testing.T) {
+func (e *indexE2e) IndexAndRetrievePackages(t testing.TB) {
 	ctx := test.Logging(t, e.ctx)
 	A := test.GenUniquePackages(e.packageGen)
 
@@ -265,7 +142,7 @@ func (e *indexE2e) IndexAndRetrievePackages(t *testing.T) {
 // IndexAndRetrieveDistributions confirms inserting and
 // selecting distributions associated with a layer works
 // correctly.
-func (e *indexE2e) IndexAndRetrieveDistributions(t *testing.T) {
+func (e *indexE2e) IndexAndRetrieveDistributions(t testing.TB) {
 	ctx := test.Logging(t, e.ctx)
 	A := test.GenUniqueDistributions(e.distGen)
 
@@ -289,7 +166,7 @@ func (e *indexE2e) IndexAndRetrieveDistributions(t *testing.T) {
 // IndexAndRetrieveRepos confirms inserting and
 // selecting repositories associated with a layer works
 // correctly.
-func (e *indexE2e) IndexAndRetrieveRepos(t *testing.T) {
+func (e *indexE2e) IndexAndRetrieveRepos(t testing.TB) {
 	ctx := test.Logging(t, e.ctx)
 	A := test.GenUniqueRepositories(e.repoGen)
 
@@ -312,7 +189,7 @@ func (e *indexE2e) IndexAndRetrieveRepos(t *testing.T) {
 
 // LayerScanned confirms the book keeping involved in marking a layer
 // scanned works correctly.
-func (e *indexE2e) LayerScanned(t *testing.T) {
+func (e *indexE2e) LayerScanned(t testing.TB) {
 	ctx := test.Logging(t, e.ctx)
 	for _, scnr := range e.scnrs {
 		err := e.store.SetLayerScanned(ctx, e.manifest.Layers[0].Hash, scnr)
@@ -332,7 +209,7 @@ func (e *indexE2e) LayerScanned(t *testing.T) {
 
 // LayerScannedNotExists confirms an error is returned when attempting
 // to obtain if a layer was scanned by a non-existent scanner.
-func (e *indexE2e) LayerScannedNotExists(t *testing.T) {
+func (e *indexE2e) LayerScannedNotExists(t testing.TB) {
 	ctx := test.Logging(t, e.ctx)
 	scnr := mockScnr{
 		name:    "invalid",
@@ -348,7 +225,7 @@ func (e *indexE2e) LayerScannedNotExists(t *testing.T) {
 
 // LayerScannedFalse confirms a false boolean is returned when attempting
 // to obtain if a non-existent layer was scanned by a valid scanner
-func (e *indexE2e) LayerScannedFalse(t *testing.T) {
+func (e *indexE2e) LayerScannedFalse(t testing.TB) {
 	ctx := test.Logging(t, e.ctx)
 
 	// create a layer that has not been persisted to the store
@@ -367,7 +244,7 @@ func (e *indexE2e) LayerScannedFalse(t *testing.T) {
 
 // IndexReport confirms the book keeping around index reports works
 // correctly.
-func (e *indexE2e) IndexReport(t *testing.T) {
+func (e *indexE2e) IndexReport(t testing.TB) {
 	ctx := test.Logging(t, e.ctx)
 
 	A := &claircore.IndexReport{
@@ -439,5 +316,105 @@ func (e *indexE2e) IndexReport(t *testing.T) {
 	}
 	if C != nil {
 		t.Fatalf("non-existent index report should be nil")
+	}
+}
+
+func BenchmarkIndexE2E(b *testing.B) {
+	integration.NeedDB(b)
+	ctx := context.Background()
+
+	for _, scenario := range testScenarios {
+		b.Run(scenario.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				pool := pgtest.TestIndexerDB(ctx, b)
+				e := setupIndexE2E(ctx, pool, scenario, b)
+				b.StartTimer()
+
+				e.RunAll(b)
+
+				b.StopTimer()
+				pool.Close()
+				b.StartTimer()
+			}
+		})
+	}
+}
+
+// testScenarios defines shared test scenarios for both tests and benchmarks
+var testScenarios = []indexE2e{
+	{
+		name: "3_scanners_small",
+		scnrs: indexer.VersionedScanners{
+			mockScnr{name: "test-scanner", kind: "test", version: "v0.0.1"},
+			mockScnr{name: "test-scanner1", kind: "test", version: "v0.0.11"},
+			mockScnr{name: "test-scanner2", kind: "test", version: "v0.0.8"},
+		},
+		packageGen: 100,
+		distGen:    150,
+		repoGen:    50,
+	},
+	{
+		name: "6_scanners_small",
+		scnrs: indexer.VersionedScanners{
+			mockScnr{name: "test-scanner", kind: "test", version: "v0.0.1"},
+			mockScnr{name: "test-scanner1", kind: "test", version: "v0.0.11"},
+			mockScnr{name: "test-scanner2", kind: "test", version: "v0.0.8"},
+			mockScnr{name: "test-scanner3", kind: "test", version: "v0.0.8"},
+			mockScnr{name: "test-scanner4", kind: "test", version: "v0.0.8"},
+			mockScnr{name: "test-scanner5", kind: "test", version: "v0.0.8"},
+		},
+		packageGen: 100,
+		distGen:    150,
+		repoGen:    50,
+	},
+	{
+		name: "3_scanners_large",
+		scnrs: indexer.VersionedScanners{
+			mockScnr{name: "test-scanner", kind: "test", version: "v0.0.1"},
+			mockScnr{name: "test-scanner1", kind: "test", version: "v0.0.11"},
+			mockScnr{name: "test-scanner2", kind: "test", version: "v0.0.8"},
+		},
+		packageGen: 1000,
+		distGen:    1500,
+		repoGen:    500,
+	},
+	{
+		name: "6_scanners_large",
+		scnrs: indexer.VersionedScanners{
+			mockScnr{name: "test-scanner", kind: "test", version: "v0.0.1"},
+			mockScnr{name: "test-scanner1", kind: "test", version: "v0.0.11"},
+			mockScnr{name: "test-scanner2", kind: "test", version: "v0.0.8"},
+			mockScnr{name: "test-scanner3", kind: "test", version: "v0.0.8"},
+			mockScnr{name: "test-scanner4", kind: "test", version: "v0.0.8"},
+			mockScnr{name: "test-scanner5", kind: "test", version: "v0.0.8"},
+		},
+		packageGen: 1000,
+		distGen:    1500,
+		repoGen:    500,
+	},
+}
+
+// setupIndexE2E creates and configures an indexE2e instance
+func setupIndexE2E(ctx context.Context, pool *pgxpool.Pool, scenario indexE2e, t testing.TB) *indexE2e {
+	store := NewIndexerStore(pool)
+
+	layer := &claircore.Layer{
+		Hash: test.RandomSHA256Digest(t),
+	}
+	manifest := claircore.Manifest{
+		Hash:   test.RandomSHA256Digest(t),
+		Layers: []*claircore.Layer{layer},
+	}
+
+	return &indexE2e{
+		name:       scenario.name,
+		store:      store,
+		ctx:        ctx,
+		manifest:   manifest,
+		scnrs:      scenario.scnrs,
+		packageGen: scenario.packageGen,
+		distGen:    scenario.distGen,
+		repoGen:    scenario.repoGen,
 	}
 }

--- a/datastore/postgres/indexer_store.go
+++ b/datastore/postgres/indexer_store.go
@@ -2,7 +2,7 @@ package postgres
 
 import (
 	"context"
-	"fmt"
+	"sync"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -23,8 +23,7 @@ func InitPostgresIndexerStore(ctx context.Context, pool *pgxpool.Pool, doMigrati
 		pool.Reset()
 	}
 
-	store := NewIndexerStore(pool)
-	return store, nil
+	return NewIndexerStore(pool), nil
 }
 
 var _ indexer.Store = (*IndexerStore)(nil)
@@ -33,7 +32,9 @@ var _ indexer.Store = (*IndexerStore)(nil)
 //
 // All the other exported methods live in their own files.
 type IndexerStore struct {
-	pool *pgxpool.Pool
+	pool         *pgxpool.Pool
+	scanners     map[string]int64
+	scannersOnce sync.Once
 }
 
 func NewIndexerStore(pool *pgxpool.Pool) *IndexerStore {
@@ -45,28 +46,6 @@ func NewIndexerStore(pool *pgxpool.Pool) *IndexerStore {
 func (s *IndexerStore) Close(_ context.Context) error {
 	s.pool.Close()
 	return nil
-}
-
-const selectScanner = `
-SELECT
-	id
-FROM
-	scanner
-WHERE
-	name = $1 AND version = $2 AND kind = $3;
-`
-
-func (s *IndexerStore) selectScanners(ctx context.Context, vs indexer.VersionedScanners) ([]int64, error) {
-	ids := make([]int64, len(vs))
-	for i, v := range vs {
-		err := s.pool.QueryRow(ctx, selectScanner, v.Name(), v.Version(), v.Kind()).
-			Scan(&ids[i])
-		if err != nil {
-			return nil, fmt.Errorf("failed to retrieve id for scanner %q: %w", v.Name(), err)
-		}
-	}
-
-	return ids, nil
 }
 
 func promTimer(h *prometheus.HistogramVec, name string, err *error) func() time.Duration {

--- a/datastore/postgres/layerscanned.go
+++ b/datastore/postgres/layerscanned.go
@@ -2,11 +2,8 @@ package postgres
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"time"
 
-	"github.com/jackc/pgx/v5"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
@@ -40,14 +37,6 @@ func (s *IndexerStore) LayerScanned(ctx context.Context, hash claircore.Digest, 
 	// TODO(hank) Could this be written as a single query that reports NULL if
 	// the scanner isn't present?
 	const (
-		selectScanner = `
-SELECT
-	id
-FROM
-	scanner
-WHERE
-	name = $1 AND version = $2 AND kind = $3;
-`
 		selectScanned = `
 SELECT
 	EXISTS(
@@ -64,23 +53,14 @@ SELECT
 `
 	)
 
-	start := time.Now()
-	var scannerID int64
-	err := s.pool.QueryRow(ctx, selectScanner, scnr.Name(), scnr.Version(), scnr.Kind()).
-		Scan(&scannerID)
-	switch {
-	case errors.Is(err, nil):
-	case errors.Is(err, pgx.ErrNoRows):
-		return false, fmt.Errorf("scanner %s not found", scnr.Name())
-	default:
+	scannerID, err := s.selectScanner(ctx, scnr)
+	if err != nil {
 		return false, err
 	}
-	layerScannedCounter.WithLabelValues("selectScanner").Add(1)
-	layerScannedDuration.WithLabelValues("selectScanner").Observe(time.Since(start).Seconds())
 
 	var ok bool
 
-	start = time.Now()
+	start := time.Now()
 	err = s.pool.QueryRow(ctx, selectScanned, hash.String(), scannerID).
 		Scan(&ok)
 	if err != nil {

--- a/datastore/postgres/packagesbylayer.go
+++ b/datastore/postgres/packagesbylayer.go
@@ -39,14 +39,6 @@ var (
 
 func (s *IndexerStore) PackagesByLayer(ctx context.Context, hash claircore.Digest, scnrs indexer.VersionedScanners) ([]*claircore.Package, error) {
 	const (
-		selectScanner = `
-SELECT
-	id
-FROM
-	scanner
-WHERE
-	name = $1 AND version = $2 AND kind = $3;
-`
 		query = `
 SELECT
 	package.id,
@@ -88,16 +80,9 @@ WHERE
 		return []*claircore.Package{}, nil
 	}
 	// get scanner ids
-	scannerIDs := make([]int64, len(scnrs))
-	for i, scnr := range scnrs {
-		start := time.Now()
-		err := s.pool.QueryRow(ctx, selectScanner, scnr.Name(), scnr.Version(), scnr.Kind()).
-			Scan(&scannerIDs[i])
-		if err != nil {
-			return nil, fmt.Errorf("failed to retrieve scanner ids: %w", err)
-		}
-		packagesByLayerCounter.WithLabelValues("selectScanner").Add(1)
-		packagesByLayerDuration.WithLabelValues("selectScanner").Observe(time.Since(start).Seconds())
+	scannerIDs, err := s.selectScanners(ctx, scnrs)
+	if err != nil {
+		return nil, err
 	}
 
 	start := time.Now()

--- a/datastore/postgres/registerscanners.go
+++ b/datastore/postgres/registerscanners.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
 	"github.com/quay/claircore/indexer"
 )
 
@@ -16,7 +17,7 @@ var (
 			Namespace: "claircore",
 			Subsystem: "indexer",
 			Name:      "registerscanners_total",
-			Help:      "Total number of database queries issued in the RegiterScanners method.",
+			Help:      "Total number of database queries issued in the RegisterScanners method.",
 		},
 		[]string{"query"},
 	)
@@ -26,7 +27,7 @@ var (
 			Namespace: "claircore",
 			Subsystem: "indexer",
 			Name:      "registerscanners_duration_seconds",
-			Help:      "The duration of all queries issued in the RegiterScanners method",
+			Help:      "The duration of all queries issued in the RegisterScanners method",
 		},
 		[]string{"query"},
 	)
@@ -82,5 +83,83 @@ SELECT
 		registerScannerDuration.WithLabelValues("insert").Observe(time.Since(start).Seconds())
 	}
 
+	s.scannersOnce.Do(func() {
+		err = s.populateScanners(ctx)
+	})
+	return err
+}
+
+const selectAllScanner = `
+SELECT
+	id, name, version, kind
+FROM
+	scanner;
+`
+
+func (s *IndexerStore) populateScanners(ctx context.Context) error {
+	rows, err := s.pool.Query(ctx, selectAllScanner)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve scanners: %w", err)
+	}
+	defer rows.Close()
+	s.scanners = make(map[string]int64)
+	for rows.Next() {
+		var id int64
+		var name, version, kind string
+		err := rows.Scan(
+			&id,
+			&name,
+			&version,
+			&kind,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to scan scanners: %w", err)
+		}
+		s.scanners[makeScannerKey(name, version, kind)] = id
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("error iterating scanners: %w", err)
+	}
 	return nil
+}
+
+func (s *IndexerStore) selectScanners(ctx context.Context, vs indexer.VersionedScanners) ([]int64, error) {
+	var err error
+	s.scannersOnce.Do(func() {
+		err = s.populateScanners(ctx)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	ids := make([]int64, len(vs))
+	for i, v := range vs {
+		id, ok := s.scanners[makeScannerKey(v.Name(), v.Version(), v.Kind())]
+		if !ok {
+			return nil, fmt.Errorf("failed to retrieve id for scanner %q", v.Name())
+		}
+		ids[i] = id
+	}
+
+	return ids, nil
+}
+
+func (s *IndexerStore) selectScanner(ctx context.Context, v indexer.VersionedScanner) (int64, error) {
+	var err error
+	s.scannersOnce.Do(func() {
+		err = s.populateScanners(ctx)
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	id, ok := s.scanners[makeScannerKey(v.Name(), v.Version(), v.Kind())]
+	if !ok {
+		return 0, fmt.Errorf("failed to retrieve id for scanner %q", v.Name())
+	}
+	return id, nil
+}
+
+func makeScannerKey(name, version, kind string) string {
+	return name + "_" + version + "_" + kind
 }

--- a/datastore/postgres/repositoriesbylayer.go
+++ b/datastore/postgres/repositoriesbylayer.go
@@ -55,7 +55,7 @@ WHERE
 	}
 	scannerIDs, err := s.selectScanners(ctx, scnrs)
 	if err != nil {
-		return nil, fmt.Errorf("unable to select scanners: %w", err)
+		return nil, err
 	}
 
 	start := time.Now()

--- a/datastore/postgres/setindexfinished.go
+++ b/datastore/postgres/setindexfinished.go
@@ -78,7 +78,7 @@ DO
 
 	scannerIDs, err := s.selectScanners(ctx, scnrs)
 	if err != nil {
-		return fmt.Errorf("failed to select package scanner id: %w", err)
+		return err
 	}
 
 	tx, err := s.pool.Begin(ctx)

--- a/datastore/postgres/setlayerscanned.go
+++ b/datastore/postgres/setlayerscanned.go
@@ -37,15 +37,6 @@ var (
 func (s *IndexerStore) SetLayerScanned(ctx context.Context, hash claircore.Digest, vs indexer.VersionedScanner) error {
 	const query = `
 WITH
-	scanner
-		AS (
-			SELECT
-				id
-			FROM
-				scanner
-			WHERE
-				name = $2 AND version = $3 AND kind = $4
-		),
 	layer AS (SELECT id FROM layer WHERE hash = $1)
 INSERT
 INTO
@@ -53,7 +44,7 @@ INTO
 VALUES
 	(
 		(SELECT id AS layer_id FROM layer),
-		(SELECT id AS scanner_id FROM scanner)
+		$2
 	)
 ON CONFLICT
 	(layer_id, scanner_id)
@@ -61,9 +52,12 @@ DO
 	NOTHING;
 `
 
-	start := time.Now()
-	_, err := s.pool.Exec(ctx, query, hash, vs.Name(), vs.Version(), vs.Kind())
+	scannerID, err := s.selectScanner(ctx, vs)
 	if err != nil {
+		return err
+	}
+	start := time.Now()
+	if _, err = s.pool.Exec(ctx, query, hash, scannerID); err != nil {
 		return fmt.Errorf("error setting layer scanned: %w", err)
 	}
 	setLayerScannedCounter.WithLabelValues("query").Add(1)


### PR DESCRIPTION
During the indexing cycle many operations try to read information from the scanner table, this can occasionally lead to resource contention depending on the DB. This reads the table into memory when the indexer store is instanciated and uses when asked for scanner info.