### PR TITLE
osv: Split osv updater into updaterset and updater

### DIFF
--- a/datastore/postgres/migrations/matcher/10-delete-osv.sql
+++ b/datastore/postgres/migrations/matcher/10-delete-osv.sql
@@ -1,0 +1,10 @@
+-- Delete all update_operations for osv updater and vulns
+DELETE FROM update_operation WHERE updater = 'osv';
+
+DELETE FROM vuln v1 USING
+	vuln v2
+	LEFT JOIN uo_vuln uvl
+		ON v2.id = uvl.vuln
+	WHERE uvl.vuln IS NULL
+	AND v2.updater = 'osv'
+AND v1.id = v2.id;

--- a/datastore/postgres/migrations/migrations.go
+++ b/datastore/postgres/migrations/migrations.go
@@ -96,4 +96,8 @@ var MatcherMigrations = []migrate.Migration{
 		ID: 9,
 		Up: runFile("matcher/09-delete-pyupio.sql"),
 	},
+	{
+		ID: 10,
+		Up: runFile("matcher/10-delete-osv.sql"),
+	},
 }

--- a/java/matcher_integration_test.go
+++ b/java/matcher_integration_test.go
@@ -49,7 +49,7 @@ func TestMatcherIntegration(t *testing.T) {
 
 	cfg := map[string]driver.ConfigUnmarshaler{
 		"osv": func(v interface{}) error {
-			cfg := v.(*osv.Config)
+			cfg := v.(*osv.FactoryConfig)
 			cfg.URL = osv.DefaultURL
 			return nil
 		},

--- a/python/matcher_integration_test.go
+++ b/python/matcher_integration_test.go
@@ -49,7 +49,7 @@ func TestMatcherIntegration(t *testing.T) {
 
 	cfg := map[string]driver.ConfigUnmarshaler{
 		"osv": func(v interface{}) error {
-			cfg := v.(*osv.Config)
+			cfg := v.(*osv.FactoryConfig)
 			cfg.URL = osv.DefaultURL
 			return nil
 		},

--- a/ruby/matcher_integration_test.go
+++ b/ruby/matcher_integration_test.go
@@ -49,7 +49,7 @@ func TestMatcherIntegration(t *testing.T) {
 
 	cfg := map[string]driver.ConfigUnmarshaler{
 		"osv": func(v interface{}) error {
-			cfg := v.(*osv.Config)
+			cfg := v.(*osv.FactoryConfig)
 			cfg.URL = osv.DefaultURL
 			return nil
 		},


### PR DESCRIPTION
Having one generic updater has issues when not all ecosystems have
updates. The osv updater will associate the new vulns from the updated
ecosystem with a new osv update_operation and the unchanged vulns will
be associated to an old update_operation. This throws up 3 potential
issues: 1) as we now use the latest_vuln view only the vulns from the
updated ecosytems are available to query 2) The GC can potentially
delete those un-updated vulns 3) when the notification system tries to
calculate the delta between previous and current update_operations it
will receive unexpected results. This pushes the updater creation to
the osv.factory which creates an updater per ecosystem (i.e. osv/go).
The fetching/parsing logic remains largely unchanged.