### PR TITLE
chore: Only try building and pushing golang image when in quay

### DIFF
--- a/.github/workflows/golang-image.yml
+++ b/.github/workflows/golang-image.yml
@@ -20,6 +20,7 @@ env:
 
 jobs:
   golang-image:
+    if: ${{ github.repository == 'quay/claircore' }}
     name: Build and publish golang image
     runs-on: 'ubuntu-latest'
     strategy:


### PR DESCRIPTION
This change will only attempt to build and push the golang image when it's being run from quay/claircore, no other fork should attempt this as it's pushed to particular container repo requiring secrets. Something to keep in mind is this will silently not trigger if we migrate to a new namespace.