### PR TITLE
chore: make dependabot harass a specific team

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,15 +5,35 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    reviewers:
+      - "quay/babysitters"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "weekly"
+    reviewers:
+      - "quay/babysitters"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
   - package-ecosystem: "gomod"
     directory: "/toolkit"
     schedule:
       interval: "weekly"
+    reviewers:
+      - "quay/babysitters"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
   - package-ecosystem: "gomod"
     directory: "/updater/driver"
     schedule:
       interval: "weekly"
+    reviewers:
+      - "quay/babysitters"
+    commit-message:
+      prefix: "chore"
+      include: "scope"


### PR DESCRIPTION
Also tweaks the commit format a little bit to fit the style of human-authored commits in the repo.