### PR TITLE
indexer: Scope versioned scanners to controller

### DIFF
--- a/indexer/controller/controller.go
+++ b/indexer/controller/controller.go
@@ -28,6 +28,8 @@ type Controller struct {
 	currentState State
 	// Realizer is scoped to a single request
 	Realizer indexer.Realizer
+	// Vscnrs are the scanners that are used during indexing
+	Vscnrs indexer.VersionedScanners
 }
 
 // New constructs a controller given an Opts struct
@@ -46,6 +48,7 @@ func New(options *indexer.Options) *Controller {
 		currentState: CheckManifest,
 		report:       scanRes,
 		manifest:     &claircore.Manifest{},
+		Vscnrs:       options.Vscnrs,
 	}
 
 	return s


### PR DESCRIPTION
The indexer.Options are mostly shared objects that are instanciated during startup (i.e. Layerscanner, FetchArena etc) and this is the desired behaviour, however the `Vscnrs` can be modified during indexing (when re-evaluating which scanners need to used for a manifest that is partially up to date) so they should be scoped directly to the `Controller`. This situation is exacerbated when the same manifest is submitted at the same time.