### PR TITLE
osv: remove package-level Factory instance

### DIFF
--- a/.github/workflows/updater-check.yml
+++ b/.github/workflows/updater-check.yml
@@ -1,4 +1,5 @@
 ---
+name: Updater Check
 on:
   workflow_dispatch: {}
   schedule:
@@ -8,11 +9,10 @@ on:
 jobs:
   test_schedule:
     runs-on: ubuntu-latest
-    container: quay.io/projectquay/golang:1.20
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
           check-latest: true
           go-version: '>=1.20'
-      - uses: actions/checkout@v3
       - run: go test ./test/periodic -enable

--- a/java/matcher_integration_test.go
+++ b/java/matcher_integration_test.go
@@ -56,7 +56,7 @@ func TestMatcherIntegration(t *testing.T) {
 	}
 
 	facs := map[string]driver.UpdaterSetFactory{
-		"osv": osv.Factory,
+		"osv": new(osv.Factory),
 	}
 	mgr, err := updates.NewManager(ctx, store, locks, srv.Client(),
 		updates.WithFactories(facs), updates.WithConfigs(cfg))

--- a/python/matcher_integration_test.go
+++ b/python/matcher_integration_test.go
@@ -56,7 +56,7 @@ func TestMatcherIntegration(t *testing.T) {
 	}
 
 	facs := map[string]driver.UpdaterSetFactory{
-		"osv": osv.Factory,
+		"osv": new(osv.Factory),
 	}
 	mgr, err := updates.NewManager(ctx, store, locks, srv.Client(),
 		updates.WithFactories(facs), updates.WithConfigs(cfg))

--- a/ruby/matcher_integration_test.go
+++ b/ruby/matcher_integration_test.go
@@ -56,7 +56,7 @@ func TestMatcherIntegration(t *testing.T) {
 	}
 
 	facs := map[string]driver.UpdaterSetFactory{
-		"osv": osv.Factory,
+		"osv": new(osv.Factory),
 	}
 	mgr, err := updates.NewManager(ctx, store, locks, srv.Client(),
 		updates.WithFactories(facs), updates.WithConfigs(cfg))

--- a/test/periodic/updater_test.go
+++ b/test/periodic/updater_test.go
@@ -20,6 +20,11 @@ import (
 	"github.com/quay/claircore/updater/osv"
 )
 
+// Helper for keeping the default configuration.
+func noopConfigure(_ interface{}) error {
+	return nil
+}
+
 func TestAWS(t *testing.T) {
 	ctx := zlog.Test(context.Background(), t)
 	set, err := aws.UpdaterSet(ctx)
@@ -35,7 +40,7 @@ func TestAlpine(t *testing.T) {
 	if err != nil {
 		t.Fatal()
 	}
-	err = fac.Configure(ctx, func(interface{}) error { return nil }, pkgClient)
+	err = fac.Configure(ctx, noopConfigure, pkgClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,7 +57,7 @@ func TestDebian(t *testing.T) {
 	if err != nil {
 		t.Fatal()
 	}
-	err = fac.Configure(ctx, func(interface{}) error { return nil }, pkgClient)
+	err = fac.Configure(ctx, noopConfigure, pkgClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -87,7 +92,7 @@ func TestRHEL(t *testing.T) {
 	if err != nil {
 		t.Fatal()
 	}
-	err = fac.Configure(ctx, func(interface{}) error { return nil }, pkgClient)
+	err = fac.Configure(ctx, noopConfigure, pkgClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -113,7 +118,7 @@ func TestUbuntu(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = fac.Configure(ctx, func(interface{}) error { return nil }, pkgClient)
+	err = fac.Configure(ctx, noopConfigure, pkgClient)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -139,7 +144,7 @@ func runUpdaterSet(ctx context.Context, t *testing.T, set driver.UpdaterSet) {
 		t.Run(u.Name(), func(t *testing.T) {
 			ctx := zlog.Test(ctx, t)
 			if cfg, ok := u.(driver.Configurable); ok {
-				err := cfg.Configure(ctx, func(interface{}) error { return nil }, pkgClient)
+				err := cfg.Configure(ctx, noopConfigure, pkgClient)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/test/periodic/updater_test.go
+++ b/test/periodic/updater_test.go
@@ -131,7 +131,11 @@ func TestUbuntu(t *testing.T) {
 
 func TestOSV(t *testing.T) {
 	ctx := zlog.Test(context.Background(), t)
-	us, err := osv.Factory.UpdaterSet(ctx)
+	fac := &osv.Factory{}
+	if err := fac.Configure(ctx, noopConfigure, pkgClient); err != nil {
+		t.Fatal(err)
+	}
+	us, err := fac.UpdaterSet(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/updater/defaults/defaults.go
+++ b/updater/defaults/defaults.go
@@ -62,7 +62,7 @@ func inner(ctx context.Context) error {
 	}
 	updater.Register("debian", df)
 
-	updater.Register("osv", osv.Factory)
+	updater.Register("osv", new(osv.Factory))
 	updater.Register("aws", driver.UpdaterSetFactoryFunc(aws.UpdaterSet))
 	updater.Register("oracle", driver.UpdaterSetFactoryFunc(oracle.UpdaterSet))
 	updater.Register("photon", driver.UpdaterSetFactoryFunc(photon.UpdaterSet))

--- a/updater/osv/osv_test.go
+++ b/updater/osv/osv_test.go
@@ -28,7 +28,7 @@ func TestFetch(t *testing.T) {
 	defer srv.Close()
 	ctx := zlog.Test(context.Background(), t)
 
-	f := factory{}
+	f := Factory{}
 	cfgFunc := func(v interface{}) error {
 		cfg := v.(*FactoryConfig)
 		cfg.URL = srv.URL
@@ -109,7 +109,7 @@ func TestParse(t *testing.T) {
 	defer srv.Close()
 	ctx := zlog.Test(context.Background(), t)
 
-	f := factory{}
+	f := Factory{}
 	cfgFunc := func(v interface{}) error {
 		cfg := v.(*FactoryConfig)
 		cfg.URL = srv.URL


### PR DESCRIPTION
This corrects an oversight when the change to splitting out ecosystems was done: the factory requires a `Configure` call, which is unsafe to do on a global variable. This was causing the `updater-check` CI to fail. With the change, this is no longer the case:
![image](https://github.com/quay/claircore/assets/242672/b2142854-c4dd-47e8-9a3c-c1389b3ad202)
