### PR TITLE
migrations: Make manifest_index.manifest_id index concurrent

### DIFF
--- a/datastore/postgres/migrations/indexer/07-index-manifest_index.sql
+++ b/datastore/postgres/migrations/indexer/07-index-manifest_index.sql
@@ -1,4 +1,4 @@
 -- This index is needed when deleting manifests, the cascade will want
 -- to delete rows from manifest_index based on the manifest.id. Without
 -- this index things get slow.
-CREATE INDEX IF NOT EXISTS idx_manifest_index_manifest_id ON manifest_index(manifest_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_manifest_index_manifest_id ON manifest_index(manifest_id);


### PR DESCRIPTION
This table has the potential to be large and normal indexing operations will need to be running concurrrently during this index creation. This will slow the index creation time but ensure the application can function during the creation.