### PR TITLE
datastore: Revert lastest_vuln view usage

### DIFF
--- a/datastore/postgres/querybuilder.go
+++ b/datastore/postgres/querybuilder.go
@@ -121,7 +121,7 @@ func buildGetQuery(record *claircore.IndexRecord, opts *datastore.GetOpts) (stri
 		"repo_uri",
 		"fixed_in_version",
 		"updater",
-	).From("latest_vuln").Where(exps...)
+	).From("vuln").Where(exps...)
 
 	sql, _, err := query.ToSQL()
 	if err != nil {


### PR DESCRIPTION
Currently the latest_vuln view is too resource intensive and needs to be reverted.