### PR TITLE
matcher: Use materialized view to speed up queries to update_operations

### DIFF
--- a/datastore/postgres/get.go
+++ b/datastore/postgres/get.go
@@ -44,7 +44,7 @@ func (s *MatcherStore) Get(ctx context.Context, records []*claircore.IndexRecord
 		return nil, err
 	}
 	defer tx.Rollback(ctx)
-	latestUpdatesQuery := "SELECT DISTINCT ON (updater) id FROM update_operation ORDER BY updater, id DESC"
+	latestUpdatesQuery := "SELECT id FROM latest_update_operations WHERE kind = 'vulnerability';"
 	rows, err := tx.Query(ctx, latestUpdatesQuery)
 	if err != nil {
 		return nil, err

--- a/datastore/postgres/migrations/matcher/11-add-update_operation-mv.sql
+++ b/datastore/postgres/migrations/matcher/11-add-update_operation-mv.sql
@@ -1,0 +1,3 @@
+-- Create materialized view that maintains the lastest update_operation id per updater.
+CREATE MATERIALIZED VIEW IF NOT exists latest_update_operations AS
+SELECT DISTINCT ON (updater) id, kind, updater FROM update_operation ORDER BY updater, id DESC;

--- a/datastore/postgres/migrations/migrations.go
+++ b/datastore/postgres/migrations/migrations.go
@@ -100,4 +100,8 @@ var MatcherMigrations = []migrate.Migration{
 		ID: 10,
 		Up: runFile("matcher/10-delete-osv.sql"),
 	},
+	{
+		ID: 11,
+		Up: runFile("matcher/11-add-update_operation-mv.sql"),
+	},
 }

--- a/datastore/postgres/querybuilder.go
+++ b/datastore/postgres/querybuilder.go
@@ -19,6 +19,11 @@ func buildGetQuery(record *claircore.IndexRecord, opts *datastore.GetOpts, uos [
 	psql := goqu.Dialect("postgres")
 	exps := []goqu.Expression{}
 
+	// Check that uos isn't empty, if it is it will result in a query error
+	if len(uos) == 0 {
+		return "", fmt.Errorf("cannot query without update_operation IDs")
+	}
+
 	// Add package name as first condition in query.
 	if record.Package.Name == "" {
 		return "", fmt.Errorf("IndexRecord must provide a Package.Name")


### PR DESCRIPTION
Querying the update_operations table for the latest operations creates a lot of CPU load on the DB. When the data is pulled into a materialized view we can take the CPU hit when the update_operation is being created as opposed to every time we receive a vulnerability report request.