### PR TITLE
whiteout: Add back whiteout resolver

### DIFF
--- a/libindex/libindex.go
+++ b/libindex/libindex.go
@@ -154,6 +154,7 @@ func New(ctx context.Context, opts *Options, cl *http.Client) (*Libindex, error)
 		Vscnrs:        l.vscnrs,
 		Client:        l.client,
 		ScannerConfig: opts.ScannerConfig,
+		Resolvers:     opts.Resolvers,
 	}
 	l.indexerOptions.LayerScanner, err = indexer.NewLayerScanner(ctx, opts.LayerScanConcurrency, l.indexerOptions)
 	if err != nil {


### PR DESCRIPTION
I believe the new layerscanner construction work regressed this resolver being added to the indexer options.