### PR TITLE
Python: Account for fixed_in information that has no fixed version

### DIFF
--- a/python/matcher_test.go
+++ b/python/matcher_test.go
@@ -153,6 +153,54 @@ func TestMatcher(t *testing.T) {
 			Want:    false,
 			Matcher: &python.Matcher{},
 		},
+		{
+			Name: "test4",
+			R: claircore.IndexRecord{
+				Package: &claircore.Package{
+					Version: "1.0.0",
+				},
+			},
+			V: claircore.Vulnerability{
+				Package: &claircore.Package{
+					Name: "testPkg4",
+				},
+				FixedInVersion: "introduced=2.2.0&lastAffected=3.0.1",
+			},
+			Want:    false,
+			Matcher: &python.Matcher{},
+		},
+		{
+			Name: "test5",
+			R: claircore.IndexRecord{
+				Package: &claircore.Package{
+					Version: "3.0.1",
+				},
+			},
+			V: claircore.Vulnerability{
+				Package: &claircore.Package{
+					Name: "testPkg5",
+				},
+				FixedInVersion: "introduced=2.2.0&lastAffected=3.0.1",
+			},
+			Want:    true,
+			Matcher: &python.Matcher{},
+		},
+		{
+			Name: "test6",
+			R: claircore.IndexRecord{
+				Package: &claircore.Package{
+					Version: "3.0.2",
+				},
+			},
+			V: claircore.Vulnerability{
+				Package: &claircore.Package{
+					Name: "testPkg6",
+				},
+				FixedInVersion: "introduced=2.2.0&lastAffected=3.0.1",
+			},
+			Want:    false,
+			Matcher: &python.Matcher{},
+		},
 	}
 
 	for _, testcase := range testcases {


### PR DESCRIPTION
Currently we are assuming all python OSV url-encoded version strings have a fixed in version, but it appears like if a fixed version is not included the package is still vulnerable. We need to account for this behaviour.

Example warning:

```
WRN missing upper version component=internal/matcher/Controller.Match fixed in version=introduced=2.2.0&lastAffected=3.0.1 matcher=python package=pypdf2 request_id=999390f4cd1c7a56
```