### PR TITLE
jar: don't info-log every properties file

### DIFF
--- a/java/jar/jar.go
+++ b/java/jar/jar.go
@@ -180,7 +180,7 @@ func extractProperties(ctx context.Context, name string, z *zip.Reader) ([]Info,
 		// encoded in the file names.
 		p := normName(f.Name)
 		if path.Base(p) == filename {
-			zlog.Info(ctx).
+			zlog.Debug(ctx).
 				Str("path", p).
 				Msg("found properties file")
 			pf = append(pf, p)


### PR DESCRIPTION
This gets real chatty in a loaded production deployment.