### PR TITLE
debian:distroless dist parsing support and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+<a name="v1.5.13"></a>
+## [v1.5.13] - 2023-07-26
+[v1.5.13]: https://github.com/quay/claircore/compare/v1.5.12...v1.5.13
+
+Nothing interesting happened this release.
+
 <a name="v1.5.12"></a>
 ## [v1.5.12] - 2023-07-24
 [v1.5.12]: https://github.com/quay/claircore/compare/v1.5.11...v1.5.12

--- a/debian/distributionscanner.go
+++ b/debian/distributionscanner.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"regexp"
 	"runtime/trace"
 	"strconv"
 	"strings"
@@ -85,10 +86,13 @@ func findDist(ctx context.Context, sys fs.FS) (*claircore.Distribution, error) {
 		return nil, nil
 	}
 
+	// Regex pattern matches item within string that appear as so: (bookworm), (buster), (bullseye)
+	ver := regexp.MustCompile(`\(\w+\)$`)
+
 	name, nameok := kv[`VERSION_CODENAME`]
 	idstr := kv[`VERSION_ID`]
 	if !nameok {
-		name = strings.TrimFunc(kv[`VERSION`], func(r rune) bool { return !unicode.IsLetter(r) })
+		name = strings.TrimFunc(ver.FindString(kv[`VERSION`]), func(r rune) bool { return !unicode.IsLetter(r) })
 	}
 	if name == "" || idstr == "" {
 		zlog.Info(ctx).

--- a/debian/testdata/distroless_dist/10/etc/os-release
+++ b/debian/testdata/distroless_dist/10/etc/os-release
@@ -1,0 +1,8 @@
+PRETTY_NAME="Distroless"
+NAME="Debian GNU/Linux"
+ID="debian"
+VERSION_ID="10"
+VERSION="Debian GNU/Linux 10 (buster)"
+HOME_URL="https://github.com/GoogleContainerTools/distroless"
+SUPPORT_URL="https://github.com/GoogleContainerTools/distroless/blob/master/README.md"
+BUG_REPORT_URL="https://github.com/GoogleContainerTools/distroless/issues/new"

--- a/debian/testdata/distroless_dist/11/etc/os-release
+++ b/debian/testdata/distroless_dist/11/etc/os-release
@@ -1,0 +1,8 @@
+PRETTY_NAME="Distroless"
+NAME="Debian GNU/Linux"
+ID="debian"
+VERSION_ID="11"
+VERSION="Debian GNU/Linux 11 (bullseye)"
+HOME_URL="https://github.com/GoogleContainerTools/distroless"
+SUPPORT_URL="https://github.com/GoogleContainerTools/distroless/blob/master/README.md"
+BUG_REPORT_URL="https://github.com/GoogleContainerTools/distroless/issues/new"

--- a/debian/testdata/distroless_dist/9/etc/os-release
+++ b/debian/testdata/distroless_dist/9/etc/os-release
@@ -1,0 +1,8 @@
+PRETTY_NAME="Distroless"
+NAME="Debian GNU/Linux"
+ID="debian"
+VERSION_ID="9"
+VERSION="Debian GNU/Linux 9 (stretch)"
+HOME_URL="https://github.com/GoogleContainerTools/distroless"
+SUPPORT_URL="https://github.com/GoogleContainerTools/distroless/blob/master/README.md"
+BUG_REPORT_URL="https://github.com/GoogleContainerTools/distroless/issues/new"


### PR DESCRIPTION
Linked issue: https://github.com/quay/claircore/issues/1018

This PR aims to introduce support for distroless `/etc/os-release` file parsing in order to allow for vulnerability matching. Further details can be found in the linked issue.

This PR contains:
- Test files of example `/etc/os-release` files for distroless images
- An update to the `distributionscanner_test.go` which adds "test cases" for the `dist` and `distroless_dist` file paths containing test data.
- Use of a regex pattern to get the version name from the VERSION field wrapped in brackets, which is then unpicked as before.