### PR TITLE
datastore: refresh materialized view concurrently

### DIFF
--- a/datastore/postgres/enrichment.go
+++ b/datastore/postgres/enrichment.go
@@ -106,7 +106,7 @@ VALUES
 ON CONFLICT
 DO
 	NOTHING;`
-		refreshView = `REFRESH MATERIALIZED VIEW latest_update_operations;`
+		refreshView = `REFRESH MATERIALIZED VIEW CONCURRENTLY latest_update_operations;`
 	)
 	ctx = zlog.ContextWithValues(ctx, "component", "datastore/postgres/UpdateEnrichments")
 

--- a/datastore/postgres/migrations/matcher/12-add-latest_update_operation-index.sql
+++ b/datastore/postgres/migrations/matcher/12-add-latest_update_operation-index.sql
@@ -1,0 +1,2 @@
+-- A unique index is needed on the materialized view to facilitate CONCURRENT refreshing.
+CREATE UNIQUE INDEX idx_updater_uniq ON latest_update_operations(updater);

--- a/datastore/postgres/migrations/migrations.go
+++ b/datastore/postgres/migrations/migrations.go
@@ -104,4 +104,8 @@ var MatcherMigrations = []migrate.Migration{
 		ID: 11,
 		Up: runFile("matcher/11-add-update_operation-mv.sql"),
 	},
+	{
+		ID: 12,
+		Up: runFile("matcher/12-add-latest_update_operation-index.sql"),
+	},
 }

--- a/datastore/postgres/updatevulnerabilities.go
+++ b/datastore/postgres/updatevulnerabilities.go
@@ -80,7 +80,7 @@ func (s *MatcherStore) UpdateVulnerabilities(ctx context.Context, updater string
 			(SELECT id FROM vuln WHERE hash_kind = $1 AND hash = $2))
 		ON CONFLICT DO NOTHING;`
 		undo        = `DELETE FROM update_operation WHERE id = $1;`
-		refreshView = `REFRESH MATERIALIZED VIEW latest_update_operations;`
+		refreshView = `REFRESH MATERIALIZED VIEW CONCURRENTLY latest_update_operations;`
 	)
 	ctx = zlog.ContextWithValues(ctx, "component", "internal/vulnstore/postgres/updateVulnerabilities")
 


### PR DESCRIPTION
Without concurrency we are seeing heavy locking on the production DB. This option will mean data is slightly latent but will not lock the materialized view for reading.