### PR TITLE
ovalutil:check-cve-href-for-links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+<a name="v1.5.13"></a>
+## [v1.5.13] - 2023-07-26
+[v1.5.13]: https://github.com/quay/claircore/compare/v1.5.12...v1.5.13
+
+Nothing interesting happened this release.
+
 <a name="v1.5.12"></a>
 ## [v1.5.12] - 2023-07-24
 [v1.5.12]: https://github.com/quay/claircore/compare/v1.5.11...v1.5.12

--- a/pkg/ovalutil/links.go
+++ b/pkg/ovalutil/links.go
@@ -21,6 +21,10 @@ func Links(def oval.Definition) string {
 		links = append(links, bug.URL)
 	}
 
+	for _, cve := range def.Advisory.Cves {
+		links = append(links, cve.Href)
+	}
+
 	s := strings.Join(links, " ")
 	return s
 }


### PR DESCRIPTION
Linked Issue: https://github.com/quay/claircore/issues/1022

This PR adds an additional for loop to `/pkg/links.go` which will loop through advisory CVEs and pull the link from the href. This is with the aim to collect more links.