### PR TITLE
gobin: fix unit test when run on ARM64

### DIFF
--- a/gobin/gobin_test.go
+++ b/gobin/gobin_test.go
@@ -72,6 +72,7 @@ func TestScanner(t *testing.T) {
 	// Build a go binary.
 	outname := filepath.Join(tmpdir, "bisect")
 	cmd := exec.CommandContext(ctx, "go", "build", "-o", outname, "github.com/quay/claircore/test/bisect")
+	cmd.Env = append(cmd.Environ(), "GOOS=linux", "GOARCH=amd64") // build a Linux amd64 ELF exe, supported by clair. Unit tests may be running on another architecture
 	out, err := cmd.CombinedOutput()
 	if len(out) != 0 {
 		t.Logf("%q", string(out))


### PR DESCRIPTION
Unit test `TestScanner` builds and scans a layer containing a go executable. Clair doesn't recognise eg. Mac ARM64 go executables, so this test fails when run on an ARM Mac.

Fix: always (cross-)compile a Linux AMD64 executable, regardless of the host platform.

Alternatively it's simple to get gobin's `Detector.Scan(...)` to recognise the Mac ARM64 Mach-O executable header, but I don't whether other changes would be needed to fully support Mac ARM go binaries in Clair.