### PR TITLE
debian:distroless dist parsing support and tests

### DIFF
--- a/debian/distributionscanner_test.go
+++ b/debian/distributionscanner_test.go
@@ -2,6 +2,7 @@ package debian
 
 import (
 	"context"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -17,24 +18,36 @@ func TestDistributionScanner(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, e := range ents {
-		t.Run(e.Name(), func(t *testing.T) {
-			sys := os.DirFS(filepath.Join(`testdata/dist`, e.Name()))
-			d, err := findDist(ctx, sys)
-			if err != nil {
-				t.Error(err)
-			}
-			if d == nil {
-				t.Fatalf("%s does not represent a Debian dist", e.Name())
-			}
-			got, want := d.VersionID, e.Name()
-			t.Logf("got: %q, want: %q", got, want)
-			if got != want {
-				t.Fail()
-			}
-			if !ver.MatchString(d.Version) {
-				t.Fatalf("weird version: %q", d.Version)
-			}
-		})
+	dEnts, err := os.ReadDir(`testdata/distroless_dist`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testCase := map[string][]fs.DirEntry{
+		"testdata/dist":            ents,
+		"testdata/distroless_dist": dEnts,
+	}
+
+	for tcDir, tcEnts := range testCase {
+		for _, e := range tcEnts {
+			t.Run(e.Name(), func(t *testing.T) {
+				sys := os.DirFS(filepath.Join(tcDir, e.Name()))
+				d, err := findDist(ctx, sys)
+				if err != nil {
+					t.Error(err)
+				}
+				if d == nil {
+					t.Fatalf("tc: %v | %s does not represent a Debian dist", tcDir, e.Name())
+				}
+				got, want := d.VersionID, e.Name()
+				t.Logf("tc: %v | got: %q, want: %q", tcDir, got, want)
+				if got != want {
+					t.Fail()
+				}
+				if !ver.MatchString(d.Version) {
+					t.Fatalf("tc: %v | weird version: %q", tcDir, d.Version)
+				}
+			})
+		}
 	}
 }

--- a/debian/testdata/distroless_dist/10/etc/os-release
+++ b/debian/testdata/distroless_dist/10/etc/os-release
@@ -1,0 +1,8 @@
+PRETTY_NAME="Distroless"
+NAME="Debian GNU/Linux"
+ID="debian"
+VERSION_ID="10"
+VERSION="Debian GNU/Linux 10 (buster)"
+HOME_URL="https://github.com/GoogleContainerTools/distroless"
+SUPPORT_URL="https://github.com/GoogleContainerTools/distroless/blob/master/README.md"
+BUG_REPORT_URL="https://github.com/GoogleContainerTools/distroless/issues/new"

--- a/debian/testdata/distroless_dist/11/etc/os-release
+++ b/debian/testdata/distroless_dist/11/etc/os-release
@@ -1,0 +1,8 @@
+PRETTY_NAME="Distroless"
+NAME="Debian GNU/Linux"
+ID="debian"
+VERSION_ID="11"
+VERSION="Debian GNU/Linux 11 (bullseye)"
+HOME_URL="https://github.com/GoogleContainerTools/distroless"
+SUPPORT_URL="https://github.com/GoogleContainerTools/distroless/blob/master/README.md"
+BUG_REPORT_URL="https://github.com/GoogleContainerTools/distroless/issues/new"

--- a/debian/testdata/distroless_dist/9/etc/os-release
+++ b/debian/testdata/distroless_dist/9/etc/os-release
@@ -1,0 +1,8 @@
+PRETTY_NAME="Distroless"
+NAME="Debian GNU/Linux"
+ID="debian"
+VERSION_ID="9"
+VERSION="Debian GNU/Linux 9 (stretch)"
+HOME_URL="https://github.com/GoogleContainerTools/distroless"
+SUPPORT_URL="https://github.com/GoogleContainerTools/distroless/blob/master/README.md"
+BUG_REPORT_URL="https://github.com/GoogleContainerTools/distroless/issues/new"

--- a/osrelease/scanner_test.go
+++ b/osrelease/scanner_test.go
@@ -122,6 +122,28 @@ func TestParse(t *testing.T) {
 				PrettyName: "Red Hat Enterprise Linux 8",
 			},
 		},
+		{
+			File: "distroless_corrupt_layer",
+			Want: claircore.Distribution{
+				DID:             "debian",
+				Name:            "Debian GNU/Linux",
+				Version:         "Debian GNU/Linux 12 (bookworm)",
+				VersionCodeName: "",
+				VersionID:       "12",
+				PrettyName:      "Distroless",
+			},
+		},
+		{
+			File: "distroless_valid_layer",
+			Want: claircore.Distribution{
+				DID:             "debian",
+				Name:            "Debian GNU/Linux",
+				Version:         "12 (bookworm)",
+				VersionCodeName: "bookworm",
+				VersionID:       "12",
+				PrettyName:      "Debian GNU/Linux 12 (bookworm)",
+			},
+		},
 	}
 	for _, tc := range tt {
 		t.Run(tc.File, tc.Test)

--- a/osrelease/testdata/distroless_corrupt_layer
+++ b/osrelease/testdata/distroless_corrupt_layer
@@ -1,0 +1,8 @@
+PRETTY_NAME="Distroless"
+NAME="Debian GNU/Linux"
+ID="debian"
+VERSION_ID="12"
+VERSION="Debian GNU/Linux 12 (bookworm)"
+HOME_URL="https://github.com/GoogleContainerTools/distroless"
+SUPPORT_URL="https://github.com/GoogleContainerTools/distroless/blob/master/README.md"
+BUG_REPORT_URL="https://github.com/GoogleContainerTools/distroless/issues/new"

--- a/osrelease/testdata/distroless_valid_layer
+++ b/osrelease/testdata/distroless_valid_layer
@@ -1,0 +1,9 @@
+PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
+NAME="Debian GNU/Linux"
+VERSION_ID="12"
+VERSION="12 (bookworm)"
+VERSION_CODENAME=bookworm
+ID=debian
+HOME_URL="https://www.debian.org/"
+SUPPORT_URL="https://www.debian.org/support"
+BUG_REPORT_URL="https://bugs.debian.org/"


### PR DESCRIPTION
Linked issue: https://github.com/quay/claircore/issues/1018

This PR aims to introduce support for distroless /etc/os-release file parsing in order to allow for vulnerability matching. Further details can be found in the linked issue.

This PR contains:

- Test files of example /etc/os-release files for distroless images
- An update to the distributionscanner_test.go which adds "test cases" for the dist and distroless_dist file paths containing test data.
- Use of a regex pattern to get the version name from the VERSION field wrapped in brackets, which is then unpicked as before.