### PR TITLE
ovalutil:check-cve-href-for-links

### DIFF
--- a/pkg/ovalutil/links.go
+++ b/pkg/ovalutil/links.go
@@ -21,6 +21,10 @@ func Links(def oval.Definition) string {
 		links = append(links, bug.URL)
 	}
 
+	for _, cve := range def.Advisory.Cves {
+		links = append(links, cve.Href)
+	}
+
 	s := strings.Join(links, " ")
 	return s
 }


### PR DESCRIPTION
Linked Issue: https://github.com/quay/claircore/issues/1022

This PR adds an additional for loop to /pkg/links.go which will loop through advisory CVEs and pull the link from the href. This is with the aim to collect more links.