### PR TITLE
rhel: correct config location for ignoring unpatched vulns

### DIFF
--- a/rhel/fetch_test.go
+++ b/rhel/fetch_test.go
@@ -23,7 +23,7 @@ func TestFetch(t *testing.T) {
 
 	t.Run("FetchContext", func(t *testing.T) {
 		ctx := zlog.Test(ctx, t)
-		u, err := NewUpdater(`rhel-3-updater`, 3, srv.URL)
+		u, err := NewUpdater(`rhel-3-updater`, 3, srv.URL, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -56,7 +56,7 @@ func TestFetch(t *testing.T) {
 
 	t.Run("Fetch", func(t *testing.T) {
 		ctx := zlog.Test(ctx, t)
-		u, err := NewUpdater(`rhel-3-updater`, 3, srv.URL)
+		u, err := NewUpdater(`rhel-3-updater`, 3, srv.URL, false)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/rhel/matcher_test.go
+++ b/rhel/matcher_test.go
@@ -60,6 +60,7 @@ func TestMatcherIntegration(t *testing.T) {
 			fmt.Sprintf("test-updater-%s", filepath.Base(fn)),
 			1,
 			root+"/"+filepath.Base(fn),
+			false,
 		)
 		if err != nil {
 			t.Error(err)

--- a/rhel/parse_test.go
+++ b/rhel/parse_test.go
@@ -21,6 +21,7 @@ func TestCVEDefFromUnpatched(t *testing.T) {
 		fileName          string
 		configFunc        driver.ConfigUnmarshaler
 		expectedVulnCount int
+		ignoreUnpatched   bool
 	}{
 		{
 			name:              "default path",
@@ -29,15 +30,10 @@ func TestCVEDefFromUnpatched(t *testing.T) {
 			expectedVulnCount: 192,
 		},
 		{
-			name:     "ignore unpatched path",
-			fileName: "testdata/rhel-8-rpm-unpatched.xml",
-			configFunc: func(c interface{}) error {
-				cfg, ok := c.(*UpdaterConfig)
-				if ok {
-					cfg.IgnoreUnpatched = true
-				}
-				return nil
-			},
+			name:              "ignore unpatched path",
+			fileName:          "testdata/rhel-8-rpm-unpatched.xml",
+			configFunc:        func(c interface{}) error { return nil },
+			ignoreUnpatched:   true,
 			expectedVulnCount: 0,
 		},
 	}
@@ -51,7 +47,7 @@ func TestCVEDefFromUnpatched(t *testing.T) {
 				t.Fatal(err)
 			}
 			defer f.Close()
-			u, err := NewUpdater("rhel-8-unpatched-updater", 8, "file:///dev/null")
+			u, err := NewUpdater("rhel-8-unpatched-updater", 8, "file:///dev/null", test.ignoreUnpatched)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -73,7 +69,7 @@ func TestParse(t *testing.T) {
 	t.Parallel()
 	ctx := zlog.Test(context.Background(), t)
 
-	u, err := NewUpdater(`rhel-3-updater`, 3, "file:///dev/null")
+	u, err := NewUpdater(`rhel-3-updater`, 3, "file:///dev/null", false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/rhel/rhel.go
+++ b/rhel/rhel.go
@@ -37,15 +37,15 @@ type Updater struct {
 // See also [ovalutil.FetcherConfig].
 type UpdaterConfig struct {
 	ovalutil.FetcherConfig
-	Release         int64 `json:"release" yaml:"release"`
-	IgnoreUnpatched bool  `json:"ignore_unpatched" yaml:"ignore_unpatched"`
+	Release int64 `json:"release" yaml:"release"`
 }
 
 // NewUpdater returns an Updater.
-func NewUpdater(name string, release int, uri string) (*Updater, error) {
+func NewUpdater(name string, release int, uri string, ignoreUnpatched bool) (*Updater, error) {
 	u := &Updater{
-		name: name,
-		dist: mkRelease(int64(release)),
+		name:            name,
+		dist:            mkRelease(int64(release)),
+		ignoreUnpatched: ignoreUnpatched,
 	}
 	var err error
 	u.Fetcher.URL, err = url.Parse(uri)
@@ -65,7 +65,7 @@ func (u *Updater) Configure(ctx context.Context, cf driver.ConfigUnmarshaler, c 
 	if cfg.Release != 0 {
 		u.dist = mkRelease(cfg.Release)
 	}
-	u.ignoreUnpatched = cfg.IgnoreUnpatched
+
 	return u.Fetcher.Configure(ctx, cf, c)
 }
 

--- a/test/ovaldebug/main.go
+++ b/test/ovaldebug/main.go
@@ -63,7 +63,7 @@ func main() {
 		switch *flavor {
 		case "rpm":
 			var u driver.Updater
-			u, err = rhel.NewUpdater("rhel-test", 8, "file:///dev/null")
+			u, err = rhel.NewUpdater("rhel-test", 8, "file:///dev/null", false)
 			if err != nil {
 				log.Fatal().Err(err).Send()
 			}


### PR DESCRIPTION
This needs to be configurable at the factory level instead of the updater level as the user is unlikely to know the rhel updater names nor should they have to.