### PR TITLE
python: account for just introduced key in OSV data

### DIFF
--- a/python/matcher.go
+++ b/python/matcher.go
@@ -2,7 +2,6 @@ package python
 
 import (
 	"context"
-	"fmt"
 	"net/url"
 
 	"github.com/quay/zlog"
@@ -79,8 +78,6 @@ func (*Matcher) Vulnerable(ctx context.Context, record *claircore.IndexRecord, v
 		if rv.Compare(&la) > 0 {
 			return false, nil
 		}
-	default:
-		return false, fmt.Errorf("could not find fixed or last_affected: %s", vuln.FixedInVersion)
 	}
 
 	if decodedVersions.Has("introduced") {

--- a/python/matcher_test.go
+++ b/python/matcher_test.go
@@ -201,6 +201,38 @@ func TestMatcher(t *testing.T) {
 			Want:    false,
 			Matcher: &python.Matcher{},
 		},
+		{
+			Name: "test7",
+			R: claircore.IndexRecord{
+				Package: &claircore.Package{
+					Version: "3.0.2",
+				},
+			},
+			V: claircore.Vulnerability{
+				Package: &claircore.Package{
+					Name: "testPkg7",
+				},
+				FixedInVersion: "introduced=2.2.0",
+			},
+			Want:    true,
+			Matcher: &python.Matcher{},
+		},
+		{
+			Name: "test8",
+			R: claircore.IndexRecord{
+				Package: &claircore.Package{
+					Version: "3.0.2",
+				},
+			},
+			V: claircore.Vulnerability{
+				Package: &claircore.Package{
+					Name: "testPkg8",
+				},
+				FixedInVersion: "introduced=3.2.0",
+			},
+			Want:    false,
+			Matcher: &python.Matcher{},
+		},
 	}
 
 	for _, testcase := range testcases {


### PR DESCRIPTION
We weren't (I wasn't) accounting for the valid scenario when the vulnerability was open-ended defined by the "introduced" key and the absence of any other valid keys.