### PR TITLE
Indexer: handle SetIndexReport() errors

### DIFF
--- a/indexer/controller/state.go
+++ b/indexer/controller/state.go
@@ -19,10 +19,10 @@ const (
 	CheckManifest
 	// FetchLayers retrieves all the layers in a manifest and stacks them the same obtain the file image contents.
 	// creates the "image" layer
-	// Transitions: LayerScan
+	// Transitions: ScanLayers
 	FetchLayers
 	// ScanLayers scans each image including the image layer and indexes the contents
-	// Transitions: BuildLayerResult
+	// Transitions: Coalesce
 	ScanLayers
 	// Coalesce runs each provided ecosystem's coalescer and merges their scan results
 	// Transitions: IndexManifest


### PR DESCRIPTION
In the indexer controller's state machine, inside `run()`, errors from `SetIndexReport()` were logged but otherwise unhandled. 
If an error occurred, a correct index report could be returned in the HTTP response, but an incomplete one from a previous state would exist in the database.
