### PR TITLE
cicd: specify branch in codecov arguments

### DIFF
--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -2,6 +2,12 @@ ignore:
 - "test"  # Our test helpers largely do not have tests themselves.
 - "**/*_string.go"  # Ignore generated string implementations.
 
+coverage:
+  status:
+    project:
+      default:
+        threshold: 0.5%
+
 component_management:
   default_rules: {}
   individual_components:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -124,6 +124,7 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           directory: ${{ runner.temp }}
+          override_branch: ${{ github.ref_name }}
       - name: Database Logs
         if: failure() || env.RUNNER_DEBUG == 1
         run: |


### PR DESCRIPTION
I _think_ this is the reason that commits are not getting associated with the `main` branch when merged.