### PR TITLE
jar: skip corrupt jar files

### DIFF
--- a/java/jar/jar_test.go
+++ b/java/jar/jar_test.go
@@ -259,6 +259,100 @@ func TestJARBadManifest(t *testing.T) {
 	}
 }
 
+// TestMalformed creates a malformed zip, then makes sure the package handles it
+// gracefully.
+func TestMalformed(t *testing.T) {
+	const (
+		jarName  = `malformed_zip.jar`
+		manifest = `testdata/malformed_zip.MF`
+	)
+	t.Parallel()
+	ctx := zlog.Test(context.Background(), t)
+	dir := integration.PackageCacheDir(t)
+	fn := filepath.Join(dir, jarName)
+Open:
+	f, err := os.Open(fn)
+	switch {
+	case errors.Is(err, nil):
+	case errors.Is(err, os.ErrNotExist):
+		// Create the jar-like.
+		mk, err := os.Create(fn)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			if err := mk.Close(); err != nil {
+				t.Logf("non-failing error: %v", err)
+			}
+			if t.Failed() {
+				if err := os.Remove(fn); err != nil {
+					t.Error(err)
+				}
+			}
+		}()
+		w := zip.NewWriter(mk)
+		if _, err := w.Create(`META-INF/`); err != nil {
+			t.Fatal(err)
+		}
+		fw, err := w.Create(`META-INF/MANIFEST.MF`)
+		if err != nil {
+			t.Fatal(err)
+		}
+		mf, err := os.ReadFile(manifest)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := io.Copy(fw, bytes.NewReader(mf)); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		// Then, corrupt it.
+		// Seek to the central directory footer:
+		pos, err := mk.Seek(-0x16+0x10 /* sizeof(footer) + offset(dir_offset)*/, io.SeekEnd)
+		if err != nil {
+			t.Fatal(err)
+		}
+		b := make([]byte, 4)
+		if _, err := io.ReadFull(mk, b); err != nil {
+			t.Fatal(err)
+		}
+		// Offset everything so the reader slowly descends into madness.
+		b[0] -= 7
+		if _, err := mk.WriteAt(b, pos); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := mk.Sync(); err != nil {
+			t.Error(err)
+		}
+		goto Open
+	default:
+		t.Fatal(err)
+	}
+	defer f.Close()
+	fi, err := f.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	z, err := zip.NewReader(f, fi.Size())
+	if err != nil {
+		t.Fatal(err)
+	}
+	infos, err := Parse(ctx, jarName, z)
+	t.Logf("returned error: %v", err)
+	switch {
+	case errors.Is(err, ErrNotAJar):
+	default:
+		t.Fail()
+	}
+	if len(infos) != 0 {
+		t.Errorf("returned infos: %#v", infos)
+	}
+}
+
 func TestManifestSectionReader(t *testing.T) {
 	var ms []string
 	d := os.DirFS("testdata")

--- a/java/jar/testdata/malformed_zip.MF
+++ b/java/jar/testdata/malformed_zip.MF
@@ -1,0 +1,5 @@
+Manifest-Version: 1.0
+Created-By: 666 (claircore testing)
+
+Name: foo
+Other-Key: blah


### PR DESCRIPTION
Some types of jar file corruption don't cause errors as soon as the file is opened with `archive/zip`, but only later when the scanner looks for specific zip entries. Currently the error causes the indexing to fail completely.

So: Log and skip any jar files where `archive/zip` errors with "not a zip file"

---

Example of a weirdly corrupt jar: 
https://github.com/IBM/db2-samples/blob/master/repl/xmlpubtk/loadqueue/LoadQueue.jar

```
# file /tmp/LoadQueue.jar
/tmp/LoadQueue.jar: Java archive data (JAR)
```
```
# jar tf /tmp/LoadQueue.jar
java.util.zip.ZipException: invalid END header (bad central directory offset)
	at java.util.zip.ZipFile.open(Native Method)
	at java.util.zip.ZipFile.<init>(ZipFile.java:247)
	at java.util.zip.ZipFile.<init>(ZipFile.java:172)
	at java.util.zip.ZipFile.<init>(ZipFile.java:143)
	at sun.tools.jar.Main.list(Main.java:1127)
	at sun.tools.jar.Main.run(Main.java:305)
	at sun.tools.jar.Main.main(Main.java:1300)
```