### PR TITLE
java: discount Red Hat patched packages from matching

### DIFF
--- a/java/matcher.go
+++ b/java/matcher.go
@@ -3,9 +3,11 @@ package java
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"strings"
+
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/libvuln/driver"
-	"net/url"
 )
 
 // Matcher matches discovered Java Maven packages against advisories provided via OSV.
@@ -31,6 +33,13 @@ func (*Matcher) Query() []driver.MatchConstraint {
 func (*Matcher) Vulnerable(ctx context.Context, record *claircore.IndexRecord, vuln *claircore.Vulnerability) (bool, error) {
 	if vuln.FixedInVersion == "" {
 		return true, nil
+	}
+
+	if strings.Contains(record.Package.Version, "redhat") {
+		// This is a Red Hat patched jar, it's version can
+		// no longer be relied on. Deferring any vuln matching
+		// to the native RH components (rhel, rhcc).
+		return false, nil
 	}
 
 	decodedVersions, err := url.ParseQuery(vuln.FixedInVersion)

--- a/java/matcher_test.go
+++ b/java/matcher_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/quay/claircore"
 )
 
@@ -161,6 +162,27 @@ func TestVulnerable(t *testing.T) {
 					RepositoryHint: "Maven",
 				},
 				FixedInVersion: "lastAffected=3.3.0&introduced=3.2.0",
+			},
+			want: false,
+		},
+		{
+			name: "pkg7",
+			record: &claircore.IndexRecord{
+				Package: &claircore.Package{
+					Name:    "org.apache.logging.log4j:log4j-core",
+					Version: "2.11.1.redhat-00001",
+					Kind:    "binary",
+				},
+			},
+			vuln: &claircore.Vulnerability{
+				Updater:     "osv",
+				Name:        "GHSA-7rjr-3q55-vv33",
+				Description: "Incomplete fix for Apache Log4j vulnerability",
+				Package: &claircore.Package{
+					Name:           "org.apache.logging.log4j:log4j-core",
+					RepositoryHint: "Maven",
+				},
+				FixedInVersion: "fixed=2.12.2",
 			},
 			want: false,
 		},


### PR DESCRIPTION
Once RH has patched a package, the version it reports is no longer reliable to use for vulnerability matching. If the package is truely vulnerable it should be picked up on a container level by the rhcc matcher.