### PR TITLE
rhcc: add a resolver to discount non-rhcc packages

### DIFF
--- a/rhel/rhcc/resolver.go
+++ b/rhel/rhcc/resolver.go
@@ -1,0 +1,59 @@
+package rhcc
+
+import (
+	"context"
+
+	"github.com/quay/claircore"
+	"github.com/quay/claircore/indexer"
+)
+
+var (
+	_ indexer.Resolver = (*Resolver)(nil)
+)
+
+type Resolver struct{}
+
+func (r *Resolver) Resolve(ctx context.Context, ir *claircore.IndexReport, layers []*claircore.Layer) *claircore.IndexReport {
+	rhLayers := []claircore.Digest{}
+	// TODO: Should we look at repos here? Nicer to find but harder to use.
+	for id, p := range ir.Packages {
+		if p.RepositoryHint == "rhcc" {
+			// Grab the layers where rhcc packages exist.
+			for _, e := range ir.Environments[id] {
+				rhLayers = append(rhLayers, e.IntroducedIn)
+			}
+		}
+	}
+	problematicPkgIDs := []string{}
+	// Check which packages come from those layers.
+	for pkgID, es := range ir.Environments {
+		for _, e := range es {
+			for _, rhl := range rhLayers {
+				if e.IntroducedIn.String() == rhl.String() {
+					problematicPkgIDs = append(problematicPkgIDs, pkgID)
+				}
+			}
+		}
+	}
+	finalPackages := map[string]*claircore.Package{}
+	finalEnvironments := map[string][]*claircore.Environment{}
+	for pkgID, pkg := range ir.Packages {
+		packageDelete := false
+		for _, ppkgID := range problematicPkgIDs {
+			if ppkgID == pkgID && (pkg.RepositoryHint != "rhcc") {
+				// TODO: Do we actually want to delete this package or make it unmatchable?
+				// TODO: Do we want to delete every other package or just ones from
+				// certain ecosystems, if so, how do we identify them?
+				// TODO: Do we add rpm packages here?
+				packageDelete = true
+			}
+		}
+		if !packageDelete {
+			finalPackages[pkgID] = pkg
+			finalEnvironments[pkgID] = ir.Environments[pkgID]
+		}
+	}
+	ir.Packages = finalPackages
+	ir.Environments = finalEnvironments
+	return ir
+}

--- a/rhel/rhcc/resolver_test.go
+++ b/rhel/rhcc/resolver_test.go
@@ -1,0 +1,195 @@
+package rhcc
+
+import (
+	"context"
+	"crypto/sha256"
+	"io"
+	"testing"
+
+	"github.com/quay/claircore"
+)
+
+func Digest(name string) claircore.Digest {
+	h := sha256.New()
+	io.WriteString(h, name)
+	d, err := claircore.NewDigest("sha256", h.Sum(nil))
+	if err != nil {
+		panic(err)
+	}
+	return d
+}
+
+func TestResolver(t *testing.T) {
+	firstLayerHash := Digest("first layer")
+	secondLayerHash := Digest("second layer")
+	thirdLayerHash := Digest("third layer")
+	tests := []struct {
+		name                string
+		ir                  *claircore.IndexReport
+		layers              []*claircore.Layer
+		lenPackage, lenEnvs int
+	}{
+		{
+			name: "same layer",
+			ir: &claircore.IndexReport{
+				Packages: map[string]*claircore.Package{
+					"1": {
+						Name:           "some-rh-package-slash-image",
+						RepositoryHint: "rhcc",
+						Version:        "v1.0.0",
+					},
+					"2": {
+						Name:    "grafana",
+						Version: "v4.7.0",
+					},
+				},
+				Environments: map[string][]*claircore.Environment{
+					"1": {{IntroducedIn: firstLayerHash}},
+					"2": {{IntroducedIn: firstLayerHash}},
+				},
+			},
+			layers: []*claircore.Layer{
+				{Hash: firstLayerHash},
+				{Hash: secondLayerHash},
+			},
+			lenPackage: 1,
+			lenEnvs:    1,
+		},
+		{
+			name: "different layers",
+			ir: &claircore.IndexReport{
+				Packages: map[string]*claircore.Package{
+					"1": {
+						Name:           "some-rh-package-slash-image",
+						RepositoryHint: "rhcc",
+						Version:        "v1.0.0",
+					},
+					"2": {
+						Name:    "grafana",
+						Version: "v4.7.0",
+					},
+				},
+				Environments: map[string][]*claircore.Environment{
+					"1": {{IntroducedIn: firstLayerHash}},
+					"2": {{IntroducedIn: secondLayerHash}},
+				},
+			},
+			layers: []*claircore.Layer{
+				{Hash: firstLayerHash},
+				{Hash: secondLayerHash},
+			},
+			lenPackage: 2,
+			lenEnvs:    2,
+		},
+		{
+			name: "different package versions",
+			ir: &claircore.IndexReport{
+				Packages: map[string]*claircore.Package{
+					"1": {
+						Name:           "some-rh-package-slash-image",
+						RepositoryHint: "rhcc",
+						Version:        "v1.0.0",
+					},
+					"2": {
+						Name:    "grafana",
+						Version: "v4.7.0",
+					},
+					"3": {
+						Name:    "grafana",
+						Version: "v4.8.0",
+					},
+				},
+				Environments: map[string][]*claircore.Environment{
+					"1": {{IntroducedIn: firstLayerHash}},
+					"2": {{IntroducedIn: firstLayerHash}},
+					"3": {{IntroducedIn: secondLayerHash}},
+				},
+			},
+			layers: []*claircore.Layer{
+				{Hash: firstLayerHash},
+				{Hash: secondLayerHash},
+			},
+			lenPackage: 2,
+			lenEnvs:    2,
+		},
+		{
+			name: "two rh layers",
+			ir: &claircore.IndexReport{
+				Packages: map[string]*claircore.Package{
+					"1": {
+						Name:           "some-rh-package-slash-image",
+						RepositoryHint: "rhcc",
+						Version:        "v1.0.0",
+					},
+					"2": {
+						Name:           "some-rh-other-package-slash-image",
+						RepositoryHint: "rhcc",
+						Version:        "v1.0.0",
+					},
+					"3": {
+						Name:    "grafana",
+						Version: "v4.8.0",
+					},
+				},
+				Environments: map[string][]*claircore.Environment{
+					"1": {{IntroducedIn: firstLayerHash}},
+					"2": {{IntroducedIn: secondLayerHash}},
+					"3": {{IntroducedIn: secondLayerHash}},
+				},
+			},
+			layers: []*claircore.Layer{
+				{Hash: firstLayerHash},
+				{Hash: secondLayerHash},
+			},
+			lenPackage: 2,
+			lenEnvs:    2,
+		},
+		{
+			name: "three layers, two rh",
+			ir: &claircore.IndexReport{
+				Packages: map[string]*claircore.Package{
+					"1": {
+						Name:           "some-rh-package-slash-image",
+						RepositoryHint: "rhcc",
+						Version:        "v1.0.0",
+					},
+					"2": {
+						Name:           "some-rh-other-package-slash-image",
+						RepositoryHint: "rhcc",
+						Version:        "v1.0.0",
+					},
+					"3": {
+						Name:    "grafana",
+						Version: "v4.8.0",
+					},
+				},
+				Environments: map[string][]*claircore.Environment{
+					"1": {{IntroducedIn: firstLayerHash}},
+					"2": {{IntroducedIn: secondLayerHash}},
+					"3": {{IntroducedIn: thirdLayerHash}},
+				},
+			},
+			layers: []*claircore.Layer{
+				{Hash: firstLayerHash},
+				{Hash: secondLayerHash},
+				{Hash: thirdLayerHash},
+			},
+			lenPackage: 3,
+			lenEnvs:    3,
+		},
+	}
+
+	r := &Resolver{}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			report := r.Resolve(context.Background(), tc.ir, tc.layers)
+			if tc.lenPackage != len(report.Packages) {
+				t.Fatalf("wrong number of packages: expected: %d got: %d", tc.lenPackage, len(report.Packages))
+			}
+			if tc.lenEnvs != len(report.Environments) {
+				t.Fatalf("wrong number of environments: expected: %d got: %d", tc.lenEnvs, len(report.Environments))
+			}
+		})
+
+	}
+}


### PR DESCRIPTION
This change adds an RHCC resolver that will check which packages came from the same layer as a Red Hat container layer and remove them from the final index report. This is to address the false positives that can be created when RH patches packages but they still report their vulnerable versions.

I'm sure there's a nicer way to do this but wanted to put something up so we have a reference of where a post-process step like this could exist.