### PR TITLE
cicd: update go version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - id: config
         run: |
-          echo 'go_versions=["1.21","1.20","1.19"]' >> $GITHUB_OUTPUT
+          echo 'go_versions=["1.21","1.20"]' >> $GITHUB_OUTPUT
 
   gating-lints:
     needs: ['config']

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
         uses: gsactions/commit-message-checker@v2
         with:
           pattern: |
-            ^(.*):\s*(.*)\n.*$
+            ^[^:!]+: .+\n\n.*$
           error: 'Commit must begin with <scope>: <subject>'
           flags: 'gm'
           excludeTitle: true

--- a/updater/updater.go
+++ b/updater/updater.go
@@ -204,7 +204,7 @@ func (u *Updater) Run(ctx context.Context, strict bool) error {
 	// Print or return errors.
 	if len(errs) != 0 {
 		if strict {
-			return errSlice(errs)
+			return errors.Join(errs...)
 		}
 		zlog.Info(ctx).Errs("errors", errs).Msg("updater errors")
 	}
@@ -426,23 +426,6 @@ func feeder(ctx context.Context, ch chan<- taggedUpdater, us []taggedUpdater) fu
 		}
 		return nil
 	}
-}
-
-// ErrSlice implements error, for accumulating errors.
-type errSlice []error
-
-func (e errSlice) Error() string {
-	if e == nil {
-		return "<nil>"
-	}
-	var b strings.Builder
-	b.WriteString("updater errors:\n")
-	for _, err := range e {
-		b.WriteByte('\t')
-		b.WriteString(err.Error())
-		b.WriteByte('\n')
-	}
-	return b.String()
 }
 
 const (


### PR DESCRIPTION
This updates CI to only run on supported versions of go and allow us to use some 1.20 niceties, notably `errors.Join`.