### PR TITLE
chore: audit `errgroup` usage

### DIFF
--- a/indexer/layerscanner.go
+++ b/indexer/layerscanner.go
@@ -230,7 +230,7 @@ func (r *result) Do(ctx context.Context, s VersionedScanner, l *claircore.Layer)
 		panic(fmt.Sprintf("programmer error: unknown type %T used as scanner", s))
 	}
 
-	addrErr := &net.AddrError{}
+	var addrErr *net.AddrError
 	switch {
 	case errors.Is(err, nil):
 	case errors.As(err, &addrErr):

--- a/internal/matcher/controller.go
+++ b/internal/matcher/controller.go
@@ -28,6 +28,7 @@ func NewController(m driver.Matcher, store datastore.Vulnerability) *Controller 
 	}
 }
 
+// Match is the entrypoint for [Controller].
 func (mc *Controller) Match(ctx context.Context, records []*claircore.IndexRecord) (map[string][]*claircore.Vulnerability, error) {
 	ctx = zlog.ContextWithValues(ctx,
 		"component", "internal/matcher/Controller.Match",

--- a/internal/matcher/doc.go
+++ b/internal/matcher/doc.go
@@ -1,0 +1,2 @@
+// Package matcher implements claircore's advisory matching engine.
+package matcher

--- a/internal/matcher/match.go
+++ b/internal/matcher/match.go
@@ -3,8 +3,10 @@ package matcher
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"runtime"
+	"sync"
 	"sync/atomic"
 
 	"github.com/quay/zlog"
@@ -14,6 +16,14 @@ import (
 	"github.com/quay/claircore/datastore"
 	"github.com/quay/claircore/libvuln/driver"
 )
+
+// BUG(hank) Match and EnrichedMatch have different semantics for errors
+// returned by their inferior processes: Match runs all of them to completion or
+// the incoming Context is canceled. EnrichedMatch eagerly cancels all Matchers
+// upon the first error, ala "errgroup" semantics but purposefully does not
+// return errors on any Enricher errors. If I recall correctly, this was on
+// purpose. The Match function is probably obsolete now; we should work on
+// removing it from the relevant APIs.
 
 // Match receives an IndexReport and creates a VulnerabilityReport containing matched vulnerabilities
 func Match(ctx context.Context, ir *claircore.IndexReport, matchers []driver.Matcher, store datastore.Vulnerability) (*claircore.VulnerabilityReport, error) {
@@ -27,34 +37,37 @@ func Match(ctx context.Context, ir *claircore.IndexReport, matchers []driver.Mat
 		Vulnerabilities:        map[string]*claircore.Vulnerability{},
 		PackageVulnerabilities: map[string][]string{},
 	}
+	lim := runtime.GOMAXPROCS(0)
 
 	// extract IndexRecords from the IndexReport
 	records := ir.IndexRecords()
 	// a channel where concurrent controllers will deliver vulnerabilities affecting a package.
 	// maps a package id to a list of vulnerabilities.
-	ctrlC := make(chan map[string][]*claircore.Vulnerability, 1024)
-	// a channel where controller errors will be reported
-	errorC := make(chan error, 1024)
+	ctrlC := make(chan map[string][]*claircore.Vulnerability, lim)
+	var errMu sync.Mutex
+	errs := make([]error, 0, lim)
 	// fan out all controllers, write their output to ctrlC, close ctrlC once all writers finish
 	go func() {
 		defer close(ctrlC)
-		var g errgroup.Group
-		for _, m := range matchers {
-			mm := m
-			g.Go(func() error {
-				mc := NewController(mm, store)
+		var wg sync.WaitGroup
+		wg.Add(len(matchers))
+		for i := range matchers {
+			m := matchers[i]
+			go func() {
+				defer wg.Done()
+				mc := NewController(m, store)
 				vulns, err := mc.Match(ctx, records)
 				if err != nil {
-					return err
+					errMu.Lock()
+					errs = append(errs, err)
+					errMu.Unlock()
+					return
 				}
 				// in event of slow reader go routines will block
 				ctrlC <- vulns
-				return nil
-			})
+			}()
 		}
-		if err := g.Wait(); err != nil {
-			errorC <- err
-		}
+		wg.Wait()
 	}()
 	// loop ranges until ctrlC is closed and fully drained, ctrlC is guaranteed to close
 	for vulnsByPackage := range ctrlC {
@@ -65,12 +78,7 @@ func Match(ctx context.Context, ir *claircore.IndexReport, matchers []driver.Mat
 			}
 		}
 	}
-	select {
-	case err := <-errorC:
-		return nil, err
-	default:
-	}
-	return vr, nil
+	return vr, errors.Join(errs...)
 }
 
 // Store is the interface that can retrieve Enrichments and Vulnerabilities.
@@ -121,8 +129,8 @@ func EnrichedMatch(ctx context.Context, ir *claircore.IndexReport, ms []driver.M
 		})
 	}
 	// Set up a pool to watch the matchers and attach results to the report.
-	var vg errgroup.Group
-	vg.Go(func() error { // Pipeline watcher
+	var vg errgroup.Group // Used for easy grouping. Does cancellation on a previous Context.
+	vg.Go(func() error {  // Pipeline watcher
 	Send:
 		for _, m := range ms {
 			select {


### PR DESCRIPTION
While looking around in the code for `errors.Join` reimplementations, I noticed some other odd error-handling patterns, mostly around `errgroup`.

There's currently two `errgroup`+`semaphore` usages that I didn't touch: `libvuln/updates` and `datastore/postgres`. In both cases they're using the same pattern, and in both cases they're due to have more drastic changes than refactoring the internal concurrency.

## Todo
- [x] Update tests for better coverage.