### PR TITLE
gobin: improve handling of go versions

### DIFF
--- a/gobin/gobin.go
+++ b/gobin/gobin.go
@@ -35,7 +35,7 @@ type Detector struct{}
 
 const (
 	detectorName    = `gobin`
-	detectorVersion = `3`
+	detectorVersion = `4`
 	detectorKind    = `package`
 )
 

--- a/gobin/gobin.go
+++ b/gobin/gobin.go
@@ -1,5 +1,15 @@
 // Package gobin implements a package scanner that pulls go runtime and
 // dependency information out of a compiled executable.
+//
+// # Main module versioning
+//
+// The go toolchain currently only fills in version information for modules
+// obtained as a module. Most go executables are built from source checkouts,
+// meaning they are not in module form. See [issue 50603] for details on why and
+// what's being explored to provide this information. Accordingly, claircore
+// cannot report advisories for main modules.
+//
+// [issue 50603]: https://golang.org/issues/50603
 package gobin
 
 import (

--- a/gobin/gobin_test.go
+++ b/gobin/gobin_test.go
@@ -72,7 +72,9 @@ func TestScanner(t *testing.T) {
 	// Build a go binary.
 	outname := filepath.Join(tmpdir, "bisect")
 	cmd := exec.CommandContext(ctx, "go", "build", "-o", outname, "github.com/quay/claircore/test/bisect")
-	cmd.Env = append(cmd.Environ(), "GOOS=linux", "GOARCH=amd64") // build a Linux amd64 ELF exe, supported by clair. Unit tests may be running on another architecture
+	// Build a Linux amd64 ELF executable, as that's what's supported by claircore.
+	// Unit tests may be running on another architecture.
+	cmd.Env = append(cmd.Environ(), "GOOS=linux", "GOARCH=amd64")
 	out, err := cmd.CombinedOutput()
 	if len(out) != 0 {
 		t.Logf("%q", string(out))
@@ -137,7 +139,7 @@ func TestScanner(t *testing.T) {
 		switch {
 		case v.Name == "runtime":
 			continue
-		case v.Version == "(devel)":
+		case strings.HasPrefix(v.Version, "(devel)"):
 			continue
 		case v.Kind != claircore.BINARY:
 		case v.PackageDB != "go:bin/bisect":

--- a/gobin/gobin_test.go
+++ b/gobin/gobin_test.go
@@ -92,6 +92,18 @@ func TestScanner(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Logf("wrote binary to: %s", inf.Name())
+	defer func() {
+		if !t.Failed() {
+			return
+		}
+		cmd := exec.CommandContext(ctx, "go", "version", "-m", inf.Name())
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Logf("error looking at toolchain reporting: %v", err)
+			return
+		}
+		t.Logf("version information reported by toolchain:\n%s", string(out))
+	}()
 
 	// Write a tarball with the binary.
 	tarname := filepath.Join(tmpdir, "tar")
@@ -137,7 +149,7 @@ func TestScanner(t *testing.T) {
 	// would be annoying.
 	for _, v := range vs {
 		switch {
-		case v.Name == "runtime":
+		case v.Name == "stdlib":
 			continue
 		case strings.HasPrefix(v.Version, "(devel)"):
 			continue


### PR DESCRIPTION
This replaces the "runtime" package with its proper name, and documents and extends the main module handling.

See-also: PROJQUAY-5912