### PR TITLE
jar: improve recursive path tracking

### DIFF
--- a/java/jar/errors.go
+++ b/java/jar/errors.go
@@ -38,6 +38,12 @@ func (e *localError) Unwrap() error {
 func mkErr(msg string, err error) *localError {
 	return &localError{msg: msg, inner: err}
 }
+func archiveErr(m srcPath, err error) *localError {
+	return &localError{
+		msg:   fmt.Sprintf("at %q", m.String()),
+		inner: err,
+	}
+}
 
 type errUnidentified struct {
 	name string
@@ -60,8 +66,8 @@ type errNotAJar struct {
 	name  string
 }
 
-func notAJar(name string, reason error) *errNotAJar {
-	return &errNotAJar{name: name, inner: reason}
+func notAJar(p srcPath, reason error) *errNotAJar {
+	return &errNotAJar{name: p.String(), inner: reason}
 }
 
 func (e *errNotAJar) Error() string {

--- a/java/jar/jar_test.go
+++ b/java/jar/jar_test.go
@@ -103,7 +103,7 @@ func TestWAR(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	ps, err := Parse(ctx, name, z)
+	ps, err := Parse(ctx, filepath.Base(name), z)
 	switch {
 	case errors.Is(err, nil):
 		for _, p := range ps {

--- a/java/packagescanner.go
+++ b/java/packagescanner.go
@@ -64,7 +64,7 @@ type Scanner struct {
 func (*Scanner) Name() string { return "java" }
 
 // Version implements scanner.VersionedScanner.
-func (*Scanner) Version() string { return "4" }
+func (*Scanner) Version() string { return "5" }
 
 // Kind implements scanner.VersionedScanner.
 func (*Scanner) Kind() string { return "package" }


### PR DESCRIPTION
This should provide for more accurate details on where packages are discovered, especially when recursing into embedded jars.

Closes: #1065