### PR TITLE
datastore: refactor deleteManifests to deal with large datasets

### DIFF
--- a/datastore/postgres/deletemanifests.go
+++ b/datastore/postgres/deletemanifests.go
@@ -2,7 +2,10 @@ package postgres
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
+	"github.com/jackc/pgx/v4"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/quay/zlog"
@@ -33,55 +36,88 @@ var (
 
 func (s *IndexerStore) DeleteManifests(ctx context.Context, d ...claircore.Digest) ([]claircore.Digest, error) {
 	ctx = zlog.ContextWithValues(ctx, "component", "datastore/postgres/DeleteManifests")
-	rm, err := s.deleteManifests(ctx, d)
-	if err != nil {
-		return nil, err
-	}
-	return rm, s.layerCleanup(ctx)
+	return s.deleteManifests(ctx, d)
 }
 
-func (s *IndexerStore) deleteManifests(ctx context.Context, d []claircore.Digest) ([]claircore.Digest, error) {
-	const deleteManifest = `DELETE FROM manifest WHERE hash = ANY($1::TEXT[]) RETURNING manifest.hash;`
-	var err error
-	defer promTimer(deleteManifestsDuration, "deleteManifest", &err)()
-	defer func(e *error) {
-		deleteManifestsCounter.WithLabelValues("deleteManifest", success(*e)).Inc()
-	}(&err)
-	rows, err := s.pool.Query(ctx, deleteManifest, digestSlice(d))
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	rm := make([]claircore.Digest, 0, len(d)) // May over-allocate, but at least it's only doing it once.
-	for rows.Next() {
-		i := len(rm)
-		rm = rm[:i+1]
-		err = rows.Scan(&rm[i])
+func (s *IndexerStore) deleteManifests(ctx context.Context, ds []claircore.Digest) ([]claircore.Digest, error) {
+	const (
+		getManifestID      = `SELECT id FROM manifest WHERE hash = $1`
+		getLayers          = `SELECT layer_id FROM manifest_layer WHERE manifest_id = $1;`
+		getDeletableLayers = `
+SELECT l.id FROM layer l 
+LEFT JOIN manifest_layer ml 
+ON l.id = ml.layer_id 
+WHERE l.id = $1
+AND ml.layer_id IS NULL;`
+		deleteManifest = `DELETE FROM manifest WHERE id = $1;`
+		deleteLayers   = `DELETE FROM layer WHERE id = ANY($1);`
+	)
+
+	deletedManifests := make([]claircore.Digest, 0, len(ds))
+	for _, d := range ds {
+		tx, err := s.pool.Begin(ctx)
+		defer tx.Rollback(ctx)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("unable to start transaction: %w", err)
 		}
-	}
-	err = rows.Err()
-	if err != nil {
-		return nil, err
-	}
-	zlog.Debug(ctx).
-		Int("count", len(rm)).
-		Int("nonexistant", len(d)-len(rm)).
-		Msg("deleted manifests")
-	return rm, nil
-}
+		// Get manifest ID
+		var manifestID int64
+		err = tx.QueryRow(ctx, getManifestID, d).Scan(&manifestID)
+		switch {
+		case errors.Is(err, nil):
+		case errors.Is(err, pgx.ErrNoRows):
+			continue
+		default:
+			return nil, fmt.Errorf("unable query manifest: %w", err)
+		}
 
-func (s *IndexerStore) layerCleanup(ctx context.Context) (err error) {
-	const layerCleanup = `DELETE FROM layer WHERE NOT EXISTS (SELECT FROM manifest_layer WHERE manifest_layer.layer_id = layer.id);`
-	defer promTimer(deleteManifestsDuration, "layerCleanup", &err)()
-	tag, err := s.pool.Exec(ctx, layerCleanup)
-	deleteManifestsCounter.WithLabelValues("layerCleanup", success(err)).Inc()
-	if err != nil {
-		return err
+		// Get all layer IDs
+		lRows, err := tx.Query(ctx, getLayers, manifestID)
+		if err != nil {
+			return nil, fmt.Errorf("unable to query layers: %w", err)
+		}
+		defer lRows.Close()
+		lIDs := []int64{}
+		for lRows.Next() {
+			var layerID int64
+			err = lRows.Scan(&layerID)
+			if err != nil {
+				return nil, fmt.Errorf("unable to scan layer ID: %w", err)
+			}
+			lIDs = append(lIDs, layerID)
+		}
+		lRows.Close()
+		// TODO: feedback for how things went
+		// Delete manifest
+		_, err = tx.Exec(ctx, deleteManifest, manifestID)
+		if err != nil {
+			return nil, fmt.Errorf("unable to delete manifest: %w", err)
+		}
+		// Get eligible layers to delete
+		lToDelete := []int64{}
+		for _, lID := range lIDs {
+			var layerID int64
+			err := tx.QueryRow(ctx, getDeletableLayers, lID).Scan(&layerID)
+			switch {
+			case errors.Is(err, nil):
+				lToDelete = append(lToDelete, layerID)
+			case errors.Is(err, pgx.ErrNoRows):
+				// No rows, the layer still exists don't delete
+			default:
+				return nil, fmt.Errorf("unable check layer usage: %w", err)
+			}
+		}
+		// Delete layers
+		_, err = tx.Exec(ctx, deleteLayers, lToDelete)
+		if err != nil {
+			return nil, fmt.Errorf("unable to delete layers: %w", err)
+		}
+		err = tx.Commit(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("unable to commit transaction: %w", err)
+		}
+		// We got here with no errors, it's gone (probably)
+		deletedManifests = append(deletedManifests, d)
 	}
-	zlog.Debug(ctx).
-		Int64("count", tag.RowsAffected()).
-		Msg("deleted layers")
-	return nil
+	return deletedManifests, nil
 }

--- a/datastore/postgres/migrations/indexer/08-index-manifest_layer.sql
+++ b/datastore/postgres/migrations/indexer/08-index-manifest_layer.sql
@@ -1,0 +1,4 @@
+-- This index is needed when deleting manifests, we need to be able
+-- to query only by layer_id to find layers that are also associated
+-- with manifests other than the one being deleted.
+CREATE INDEX IF NOT EXISTS manifest_layer_layer_idx ON manifest_layer (layer_id);


### PR DESCRIPTION
Update the delete logic to try and follow the existing indexes. This splits the functionality into 4 calls, get manifest ID, get layer IDs, delete manifest, delete layers.

TODO:

- [ ] Logging feedback after delete
- [ ] Re add instrumentation
- [ ] Deal with stacking defers
- [ ] Enclose in a transaction 