### PR TITLE
chore: return if merged PRs exist with needs-changelog label

### DIFF
--- a/.github/scripts/prepare-release
+++ b/.github/scripts/prepare-release
@@ -21,6 +21,14 @@ shift $((OPTIND - 1))
 VERSION="${1:?need a version argument}"
 VERSION="v${VERSION#v}"
 
+prs=$(gh search prs --repo $GH_REPO --state closed --merged --label=needs-changelog --json=title,url | jq -r '.[] | (.url | @text) + " - " + (.title | @text)')
+if [ -n "$prs" ]
+then
+    echo "There are still PRs that need changelog entries"
+    echo $prs
+    exit 1
+fi
+
 printf 'operating on branch: %s\n' "$BRANCH" >&2
 gh workflow run prepare-release.yml -F "branch=$BRANCH" -F "tag=$VERSION"
 # TODO(hank) Watch for a gh update that has the above command output the ID.


### PR DESCRIPTION
Certain PRs are worthy of changelog entries and are tagged with the label `needs-changelog`, when it comes to release time we should make sure all merged PRs no longer have the label.