### PR TITLE
aws: date format

### DIFF
--- a/.github/workflows/updater-check-failures.yml
+++ b/.github/workflows/updater-check-failures.yml
@@ -1,0 +1,27 @@
+---
+name: Create Issue on Updater Check Failure
+on:
+  workflow_run:
+    workflows: ['Updater Check']
+    types:
+      - completed
+
+jobs:
+  on-failure:
+    name: Failure
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - name: 'Create Issue'
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: 'periodic: updater check failed',
+              body: `See [output](${context.payload.workflow_run.logs_url}) for more.`,
+              labels: ['robot'],
+            })
+

--- a/.github/workflows/updater-check.yml
+++ b/.github/workflows/updater-check.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   test_schedule:
+    name: Periodic
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/aws/client.go
+++ b/aws/client.go
@@ -13,9 +13,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/quay/alas"
 	"github.com/quay/zlog"
 
+	"github.com/quay/claircore/aws/internal/alas"
 	"github.com/quay/claircore/internal/xmlutil"
 	"github.com/quay/claircore/pkg/tmp"
 )

--- a/aws/internal/alas/repomd.go
+++ b/aws/internal/alas/repomd.go
@@ -1,0 +1,85 @@
+// Copyright 2019 RedHat
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package alas
+
+import (
+	"errors"
+	"net/url"
+)
+
+type RepoType string
+
+var ErrRepoNotFound = errors.New("Repo not found")
+
+const (
+	PrimaryDB  RepoType = "primary_db"
+	OtherDB    RepoType = "other_db"
+	GroupGZ    RepoType = "group_gz"
+	Group      RepoType = "group"
+	FileLists  RepoType = "filelists_db"
+	UpdateInfo RepoType = "updateinfo"
+)
+
+type RepoMD struct {
+	XMLNS    string `xml:"xmlns,attr"`
+	XMLRPM   string `xml:"xmlns rpm,attr"`
+	Revision int    `xml:"revision"`
+	RepoList []Repo `xml:"data"`
+}
+
+type Repo struct {
+	Type            string   `xml:"type,attr"`
+	Checksum        Checksum `xml:"checksum"`
+	OpenChecksum    Checksum `xml:"open-checksum"`
+	Location        Location `xml:"location"`
+	Timestamp       int      `xml:"timestamp"`
+	DatabaseVersion int      `xml:"database_version"`
+	Size            int      `xml:"size"`
+	OpenSize        int      `xml:"open-size"`
+}
+
+type Checksum struct {
+	Sum  string `xml:",chardata"`
+	Type string `xml:"type,attr"`
+}
+
+type Location struct {
+	Href string `xml:"href,attr"`
+}
+
+// Repo returns a Repo struct per the specified RepoType.
+// If a mirror url is provided a fully qualified Repo.Location.Href is returned
+// A ErrRepoNotFound error is returned if the RepoType cannot be located.
+func (md *RepoMD) Repo(t RepoType, mirror string) (*Repo, error) {
+	for i := range md.RepoList {
+		repo := &md.RepoList[i]
+		if repo.Type != string(t) {
+			continue
+		}
+		if mirror != "" {
+			u, err := url.Parse(mirror)
+			if err != nil {
+				return nil, err
+			}
+			href, err := u.Parse(repo.Location.Href)
+			if err != nil {
+				return nil, err
+			}
+			repo.Location.Href = href.String()
+		}
+		return repo, nil
+	}
+	return nil, ErrRepoNotFound
+}

--- a/aws/internal/alas/repomd_test.go
+++ b/aws/internal/alas/repomd_test.go
@@ -1,0 +1,123 @@
+// Copyright 2019 RedHat
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package alas
+
+import (
+	"encoding/xml"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func Test_RepoMD_Parse(t *testing.T) {
+	path := filepath.Join("testdata", "test_repomd.xml")
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("failed to open test data: %v", err)
+	}
+
+	repomdRoot := &RepoMD{}
+	err = xml.NewDecoder(f).Decode(repomdRoot)
+	if err != nil {
+		t.Fatalf("failed to parse repomd test data into struct: %v", err)
+	}
+
+	if got, want := len(repomdRoot.RepoList), 6; got != want {
+		t.Errorf("bad repo list length: got: %d, want: %d", got, want)
+	}
+}
+
+func Test_RepoMD_GetRepo(t *testing.T) {
+	tests := []RepoType{PrimaryDB, OtherDB, GroupGZ, Group, FileLists, UpdateInfo}
+
+	path := filepath.Join("testdata", "test_repomd.xml")
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("failed to open test data: %v", err)
+	}
+
+	repomdRoot := &RepoMD{}
+	err = xml.NewDecoder(f).Decode(repomdRoot)
+	if err != nil {
+		t.Fatalf("failed to parse repomd test data into struct: %v", err)
+	}
+
+	for _, test := range tests {
+		repo, err := repomdRoot.Repo(test, "")
+		if err != nil {
+			t.Error(err)
+		}
+		if repo == nil {
+			t.Error("return was <nil>")
+		}
+	}
+}
+
+func Test_RepoMD_FQDN(t *testing.T) {
+	tests := []struct {
+		repoType     RepoType
+		expectedFQDN string
+	}{
+		{
+			PrimaryDB,
+			"http://test-mirror/repodata/primary.sqlite.bz2",
+		}, {
+			OtherDB,
+			"http://test-mirror/repodata/other.sqlite.bz2",
+		}, {
+			GroupGZ,
+			"http://test-mirror/repodata/comps.xml.gz",
+		}, {
+			Group,
+			"http://test-mirror/repodata/comps.xml",
+		}, {
+			FileLists,
+			"http://test-mirror/repodata/filelists.sqlite.bz2",
+		}, {
+			UpdateInfo,
+			"http://test-mirror/repodata/updateinfo.xml.gz",
+		},
+	}
+
+	path := filepath.Join("testdata", "test_repomd.xml")
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("failed to open test data: %v", err)
+	}
+
+	repomdRoot := &RepoMD{}
+	err = xml.NewDecoder(f).Decode(repomdRoot)
+	if err != nil {
+		t.Fatalf("failed to parse repomd test data into struct: %v", err)
+	}
+
+	for _, test := range tests {
+		repo, err := repomdRoot.Repo(test.repoType, "http://test-mirror/")
+		if err != nil {
+			t.Error(err)
+		}
+		if repo == nil {
+			t.Error("return was <nil>")
+		}
+		if t.Failed() {
+			continue
+		}
+		if got, want := test.expectedFQDN, repo.Location.Href; got != want {
+			t.Error(cmp.Diff(got, want))
+		}
+	}
+}

--- a/aws/internal/alas/testdata/test_repomd.xml
+++ b/aws/internal/alas/testdata/test_repomd.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<repomd xmlns="http://linux.duke.edu/metadata/repo" xmlns:rpm="http://linux.duke.edu/metadata/rpm">
+ <revision>1568754421</revision>
+<data type="primary_db">
+  <checksum type="sha256">8931ecdd9407bf434f4051229d5cff68bcdcda48d7a5f7706daac385b20f95ac</checksum>
+  <open-checksum type="sha256">9d9316bd4547223b17fc6c8ff26f30c62e2e1eba5860062418e0b2d008fe8c7b</open-checksum>
+  <location href="repodata/primary.sqlite.bz2"/>
+  <timestamp>1568754410</timestamp>
+  <database_version>10</database_version>
+  <size>2290399</size>
+  <open-size>11587584</open-size>
+</data>
+<data type="other_db">
+  <checksum type="sha256">452881918b03215900f70e2c90e4eb1533cf71e1f1013c1df9681dd886dc14f7</checksum>
+  <open-checksum type="sha256">5f162ee4f4fd0d682e1935e2889c4f47dec47dca07f3f0ba712f234775cbeae8</open-checksum>
+  <location href="repodata/other.sqlite.bz2"/>
+  <timestamp>1568754421</timestamp>
+  <database_version>10</database_version>
+  <size>475</size>
+  <open-size>24576</open-size>
+</data>
+<data type="group_gz">
+  <checksum type="sha256">09c2208f488c355bb674345bcba50435b1663e189e55756d3b19c74067073959</checksum>
+  <open-checksum type="sha256">15e8cea4bf15229236bc5641a33ca273b3661d09a31a8b1092c15d4e6ba8b89e</open-checksum>
+  <location href="repodata/comps.xml.gz"/>
+  <timestamp>1568754407</timestamp>
+  <database_version>10</database_version>
+  <size>4459</size>
+  <open-size>34460</open-size>
+</data>
+<data type="group">
+  <checksum type="sha256">15e8cea4bf15229236bc5641a33ca273b3661d09a31a8b1092c15d4e6ba8b89e</checksum>
+  <location href="repodata/comps.xml"/>
+  <timestamp>1568754407</timestamp>
+  <database_version>10</database_version>
+  <size>34460</size>
+</data>
+<data type="filelists_db">
+  <checksum type="sha256">ae2aa23895927583b7fd0ade2c7414dab70f29ae2fef75626e2971ddb95276e9</checksum>
+  <open-checksum type="sha256">8d65dcc33f5eb3794e856d2a488bd1848a0c919b182b880c2912726315bf5328</open-checksum>
+  <location href="repodata/filelists.sqlite.bz2"/>
+  <timestamp>1568754421</timestamp>
+  <database_version>10</database_version>
+  <size>11025366</size>
+  <open-size>63868928</open-size>
+</data>
+<data type="updateinfo">
+  <checksum type="sha256">9dd3ce045294b530720d13829817254e3cd67ec1ac36f66069238d9d111d3cc0</checksum>
+  <open-checksum type="sha256">3530bd37fdb291b0d5bc92e05fb86bc7403028c0878084626ed11986806865a6</open-checksum>
+  <location href="repodata/updateinfo.xml.gz"/>
+  <timestamp>1568754407</timestamp>
+  <database_version>10</database_version>
+  <size>610596</size>
+  <open-size>6402617</open-size>
+</data>
+</repomd>

--- a/aws/internal/alas/updates.go
+++ b/aws/internal/alas/updates.go
@@ -1,0 +1,87 @@
+// Copyright 2019 RedHat
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package alas
+
+import (
+	"encoding/xml"
+	"fmt"
+	"time"
+)
+
+type Updates struct {
+	Updates []Update `xml:"update"`
+}
+
+type Update struct {
+	Author      string      `xml:"author,attr"`
+	From        string      `xml:"from,attr"`
+	Status      string      `xml:"status,attr"`
+	Type        string      `xml:"type,attr"`
+	Version     string      `xml:"version,attr"`
+	ID          string      `xml:"id"`
+	Title       string      `xml:"title"`
+	Issued      DateElem    `xml:"issued"`
+	Updated     DateElem    `xml:"updated"`
+	Severity    string      `xml:"severity"`
+	Description string      `xml:"description"`
+	References  []Reference `xml:"references>reference"`
+	Packages    []Package   `xml:"pkglist>collection>package"`
+}
+
+type DateElem struct {
+	Date `xml:"date,attr"`
+}
+
+type Date time.Time
+
+var _ xml.UnmarshalerAttr = (*Date)(nil)
+
+// UnmarshalXMLAttr implements [xml.UnmarshalerAttr].
+func (d *Date) UnmarshalXMLAttr(attr xml.Attr) (err error) {
+	if attr.Name.Local != `date` {
+		return fmt.Errorf("unexpected attr name: %q", attr.Name.Local)
+	}
+	fmts := []string{
+		"2006-01-02 15:04", time.DateTime,
+	}
+	var t time.Time
+	for _, f := range fmts {
+		t, err = time.Parse(f, attr.Value)
+		if err == nil {
+			break
+		}
+	}
+	if err != nil {
+		return fmt.Errorf("parsing date attr: %w", err)
+	}
+	*d = Date(t)
+	return nil
+}
+
+type Reference struct {
+	Href  string `xml:"href,attr"`
+	ID    string `xml:"id,attr"`
+	Title string `xml:"title,attr"`
+	Type  string `xml:"type,attr"`
+}
+
+type Package struct {
+	Name     string `xml:"name,attr"`
+	Epoch    string `xml:"epoch,attr"`
+	Version  string `xml:"version,attr"`
+	Release  string `xml:"release,attr"`
+	Arch     string `xml:"arch,attr"`
+	Filename string `xml:"filename"`
+}

--- a/aws/internal/alas/updates_test.go
+++ b/aws/internal/alas/updates_test.go
@@ -1,0 +1,40 @@
+// Copyright 2019 RedHat
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package alas
+
+import (
+	"encoding/xml"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func Test_Updates_Parse(t *testing.T) {
+	path := filepath.Join("testdata", "test_updateinfo.xml")
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("failed to open test data: %v", err)
+	}
+
+	updates := &Updates{}
+	err = xml.NewDecoder(f).Decode(updates)
+	if err != nil {
+		t.Fatalf("failed to parse updateinfo test data into struct: %v", err)
+	}
+
+	if got, want := len(updates.Updates), 1170; got != want {
+		t.Errorf("unexpected number of updates: got: %d, want: %d", got, want)
+	}
+}

--- a/aws/matcher_test.go
+++ b/aws/matcher_test.go
@@ -10,101 +10,14 @@ import (
 
 func TestVulnerable(t *testing.T) {
 	m := &Matcher{}
-
-	testcases := []struct {
+	type testcase struct {
 		name   string
 		record *claircore.IndexRecord
 		vuln   *claircore.Vulnerability
 		want   bool
-	}{
-		{
-			name: "unfixed same arch",
-			record: &claircore.IndexRecord{
-				Package: &claircore.Package{
-					Version: "10:3.1.0-8.amzn2.0.8",
-					Arch:    "noarch",
-				},
-			},
-			vuln: &claircore.Vulnerability{
-				Package: &claircore.Package{
-					Arch: "noarch",
-				},
-				FixedInVersion: "",
-				ArchOperation:  claircore.OpEquals,
-			},
-			want: true,
-		},
-		{
-			name: "unfixed different arch",
-			record: &claircore.IndexRecord{
-				Package: &claircore.Package{
-					Version: "10:3.1.0-8.amzn2.0.8",
-					Arch:    "x86_64",
-				},
-			},
-			vuln: &claircore.Vulnerability{
-				Package: &claircore.Package{
-					Arch: "noarch",
-				},
-				FixedInVersion: "",
-				ArchOperation:  claircore.OpEquals,
-			},
-			want: false,
-		},
-		{
-			name: "fixed same arch",
-			record: &claircore.IndexRecord{
-				Package: &claircore.Package{
-					Version: "10:3.1.0-8.amzn2.0.8",
-					Arch:    "x86_64",
-				},
-			},
-			vuln: &claircore.Vulnerability{
-				Package: &claircore.Package{
-					Arch: "x86_64",
-				},
-				FixedInVersion: "10:3.1.0-9.amzn2.0.8",
-				ArchOperation:  claircore.OpEquals,
-			},
-			want: true,
-		},
-		{
-			name: "fixed unaffected arch",
-			record: &claircore.IndexRecord{
-				Package: &claircore.Package{
-					Version: "10:3.1.0-8.amzn2.0.8",
-					Arch:    "x86_64",
-				},
-			},
-			vuln: &claircore.Vulnerability{
-				Package: &claircore.Package{
-					Arch: "noarch",
-				},
-				FixedInVersion: "10:3.1.0-9.amzn2.0.8",
-				ArchOperation:  claircore.OpEquals,
-			},
-			want: false,
-		},
-		{
-			name: "fixed unaffected version",
-			record: &claircore.IndexRecord{
-				Package: &claircore.Package{
-					Version: "10:3.1.0-9.amzn2.0.8",
-					Arch:    "x86_64",
-				},
-			},
-			vuln: &claircore.Vulnerability{
-				Package: &claircore.Package{
-					Arch: "x86_64",
-				},
-				FixedInVersion: "9:3.1.0-9.amzn2.0.8",
-				ArchOperation:  claircore.OpEquals,
-			},
-			want: false,
-		},
 	}
-	for _, testcase := range testcases {
-		t.Run(testcase.name, func(t *testing.T) {
+	inner := func(testcase *testcase) func(*testing.T) {
+		return func(t *testing.T) {
 			got, err := m.Vulnerable(context.Background(), testcase.record, testcase.vuln)
 			if err != nil {
 				t.Fatal(err)
@@ -112,6 +25,107 @@ func TestVulnerable(t *testing.T) {
 			if !cmp.Equal(got, testcase.want) {
 				t.Error(cmp.Diff(got, testcase.want))
 			}
-		})
+		}
 	}
+
+	t.Run("Unfixed", func(t *testing.T) {
+		testcases := []testcase{
+			{
+				name: "SameArch",
+				record: &claircore.IndexRecord{
+					Package: &claircore.Package{
+						Version: "10:3.1.0-8.amzn2.0.8",
+						Arch:    "noarch",
+					},
+				},
+				vuln: &claircore.Vulnerability{
+					Package: &claircore.Package{
+						Arch: "noarch",
+					},
+					FixedInVersion: "",
+					ArchOperation:  claircore.OpEquals,
+				},
+				want: true,
+			},
+			{
+				name: "DifferentArch",
+				record: &claircore.IndexRecord{
+					Package: &claircore.Package{
+						Version: "10:3.1.0-8.amzn2.0.8",
+						Arch:    "x86_64",
+					},
+				},
+				vuln: &claircore.Vulnerability{
+					Package: &claircore.Package{
+						Arch: "noarch",
+					},
+					FixedInVersion: "",
+					ArchOperation:  claircore.OpEquals,
+				},
+				want: false,
+			},
+		}
+		for _, testcase := range testcases {
+			t.Run(testcase.name, inner(&testcase))
+		}
+	})
+	t.Run("Fixed", func(t *testing.T) {
+
+		testcases := []testcase{
+			{
+				name: "SameArch",
+				record: &claircore.IndexRecord{
+					Package: &claircore.Package{
+						Version: "10:3.1.0-8.amzn2.0.8",
+						Arch:    "x86_64",
+					},
+				},
+				vuln: &claircore.Vulnerability{
+					Package: &claircore.Package{
+						Arch: "x86_64",
+					},
+					FixedInVersion: "10:3.1.0-9.amzn2.0.8",
+					ArchOperation:  claircore.OpEquals,
+				},
+				want: true,
+			},
+			{
+				name: "UnaffectedArch",
+				record: &claircore.IndexRecord{
+					Package: &claircore.Package{
+						Version: "10:3.1.0-8.amzn2.0.8",
+						Arch:    "x86_64",
+					},
+				},
+				vuln: &claircore.Vulnerability{
+					Package: &claircore.Package{
+						Arch: "noarch",
+					},
+					FixedInVersion: "10:3.1.0-9.amzn2.0.8",
+					ArchOperation:  claircore.OpEquals,
+				},
+				want: false,
+			},
+			{
+				name: "UnaffectedVersion",
+				record: &claircore.IndexRecord{
+					Package: &claircore.Package{
+						Version: "10:3.1.0-9.amzn2.0.8",
+						Arch:    "x86_64",
+					},
+				},
+				vuln: &claircore.Vulnerability{
+					Package: &claircore.Package{
+						Arch: "x86_64",
+					},
+					FixedInVersion: "9:3.1.0-9.amzn2.0.8",
+					ArchOperation:  claircore.OpEquals,
+				},
+				want: false,
+			},
+		}
+		for _, testcase := range testcases {
+			t.Run(testcase.name, inner(&testcase))
+		}
+	})
 }

--- a/aws/updater.go
+++ b/aws/updater.go
@@ -9,10 +9,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/quay/alas"
 	"github.com/quay/zlog"
 
 	"github.com/quay/claircore"
+	"github.com/quay/claircore/aws/internal/alas"
 	"github.com/quay/claircore/internal/xmlutil"
 	"github.com/quay/claircore/libvuln/driver"
 )
@@ -89,15 +89,11 @@ func (u *Updater) Parse(ctx context.Context, contents io.ReadCloser) ([]*clairco
 
 	vulns := []*claircore.Vulnerability{}
 	for _, update := range updates.Updates {
-		issued, err := time.Parse("2006-01-02 15:04", update.Issued.Date)
-		if err != nil {
-			return vulns, err
-		}
 		partial := &claircore.Vulnerability{
 			Updater:            u.Name(),
 			Name:               update.ID,
 			Description:        update.Description,
-			Issued:             issued,
+			Issued:             time.Time(update.Issued.Date),
 			Links:              refsToLinks(update),
 			Severity:           update.Severity,
 			NormalizedSeverity: NormalizeSeverity(update.Severity),

--- a/aws/updater_test.go
+++ b/aws/updater_test.go
@@ -4,9 +4,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/quay/alas"
-
 	"github.com/google/go-cmp/cmp"
+
+	"github.com/quay/claircore/aws/internal/alas"
 )
 
 func TestVersionString(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/knqyf263/go-rpm-version v0.0.0-20170716094938-74609b86c936
 	github.com/prometheus/client_golang v1.17.0
 	github.com/prometheus/client_model v0.4.1-0.20230718164431-9a2bf3000d16
-	github.com/quay/alas v1.0.1
 	github.com/quay/claircore/toolkit v1.1.0
 	github.com/quay/claircore/updater/driver v1.0.0
 	github.com/quay/goval-parser v0.8.8

--- a/go.sum
+++ b/go.sum
@@ -146,8 +146,6 @@ github.com/prometheus/common v0.44.0 h1:+5BrQJwiBB9xsMygAB3TNvpQKOwlkc25LbISbrdO
 github.com/prometheus/common v0.44.0/go.mod h1:ofAIvZbQ1e/nugmZGz4/qCb9Ap1VoSTIO7x0VV9VvuY=
 github.com/prometheus/procfs v0.11.1 h1:xRC8Iq1yyca5ypa9n1EZnWZkt7dwcoRPQwX/5gwaUuI=
 github.com/prometheus/procfs v0.11.1/go.mod h1:eesXgaPo1q7lBpVMoMy0ZOFTth9hBn4W/y0/p/ScXhY=
-github.com/quay/alas v1.0.1 h1:MuFpGGXyZlDD7+F/hrnMZmzhS8P2bjRzX9DyGmyLA+0=
-github.com/quay/alas v1.0.1/go.mod h1:pseepSrG9pwry1joG7RO/RNRFJaWqiqx9qeoomeYwEk=
 github.com/quay/claircore/toolkit v1.0.0/go.mod h1:3ELtgf92x7o1JCTSKVOAqhcnCTXc4s5qiGaEDx62i20=
 github.com/quay/claircore/toolkit v1.1.0 h1:97DwHYUszafNiMXz7Wd1WexoWH55RNPas34nEBbBuPw=
 github.com/quay/claircore/toolkit v1.1.0/go.mod h1:ZZHA/b/qpfUcNHFJeYVA0bOp7aL4r3CTFhlBV/ezoFI=


### PR DESCRIPTION
See the [Period Check](https://github.com/quay/claircore/actions/runs/6376455252/job/17303489814) failure for the inciting incident.

This adds an additional CI action to create issues when that job fails, pulls the `alas` dependency internally (~~I thought I was going to have to fix this in there~~ Ended up doing that, it was less odd.), then adds the both-ways date parsing.

```
% go test -v -run AWS -enable
=== RUN   TestAWS
=== RUN   TestAWS/aws-AL1-updater
    testing.go:98: {"level":"debug","release":"AL1","component":"aws/Client.getMirrors","zlog.testname":"TestAWS/aws-AL1-updater","caller":"client.go:219","message":"successfully got list of mirrors"}
    testing.go:98: {"level":"debug","zlog.testname":"TestAWS/aws-AL1-updater","component":"aws/Client.RepoMD","mirror":"http://packages.us-west-2.amazonaws.com/2018.03/updates/0e84ecf3a65f/x86_64/repodata/repomd.xml","caller":"client.go:64","message":"attempting repomd download"}
    testing.go:98: {"level":"debug","zlog.testname":"TestAWS/aws-AL1-updater","component":"aws/Client.RepoMD","mirror":"http://packages.us-west-2.amazonaws.com/2018.03/updates/0e84ecf3a65f/x86_64/repodata/repomd.xml","caller":"client.go:93","message":"success"}
    testing.go:98: {"level":"debug","zlog.testname":"TestAWS/aws-AL1-updater","component":"aws/Client.Updates","mirror":"http://packages.us-west-2.amazonaws.com/2018.03/updates/0e84ecf3a65f/x86_64/repodata/updateinfo.xml.gz","caller":"client.go:158","message":"success"}
    updater_test.go:180: fa87f8ca4e20f485a1d8c9cc8d495c3ab93801c3ab2b8b2da636fea16e1f88c8
    updater_test.go:191: reported 30076 vulnerabilites
=== RUN   TestAWS/aws-AL2-updater
    testing.go:98: {"level":"debug","zlog.testname":"TestAWS/aws-AL2-updater","release":"AL2","component":"aws/Client.getMirrors","caller":"client.go:219","message":"successfully got list of mirrors"}
    testing.go:98: {"level":"debug","zlog.testname":"TestAWS/aws-AL2-updater","component":"aws/Client.RepoMD","mirror":"https://cdn.amazonlinux.com/2/core/2.0/x86_64/eb72ea01ca029aaf7a15e5b987f6bee895bae6c7ef9f3bd009d8a3181c6e78c8/repodata/repomd.xml","caller":"client.go:64","message":"attempting repomd download"}
    testing.go:98: {"level":"debug","zlog.testname":"TestAWS/aws-AL2-updater","component":"aws/Client.RepoMD","mirror":"https://cdn.amazonlinux.com/2/core/2.0/x86_64/eb72ea01ca029aaf7a15e5b987f6bee895bae6c7ef9f3bd009d8a3181c6e78c8/repodata/repomd.xml","caller":"client.go:93","message":"success"}
    testing.go:98: {"level":"debug","zlog.testname":"TestAWS/aws-AL2-updater","component":"aws/Client.Updates","mirror":"https://cdn.amazonlinux.com/2/core/2.0/x86_64/eb72ea01ca029aaf7a15e5b987f6bee895bae6c7ef9f3bd009d8a3181c6e78c8/repodata/updateinfo.xml.gz","caller":"client.go:158","message":"success"}
    updater_test.go:180: 578985af3dd75898406032531c5373d6748e9021b0bb5af53087092ebe5cab6e
    updater_test.go:191: reported 29299 vulnerabilites
=== RUN   TestAWS/aws-AL2023-updater
    testing.go:98: {"level":"debug","release":"AL2023","component":"aws/Client.getMirrors","zlog.testname":"TestAWS/aws-AL2023-updater","caller":"client.go:219","message":"successfully got list of mirrors"}
    testing.go:98: {"level":"debug","zlog.testname":"TestAWS/aws-AL2023-updater","component":"aws/Client.RepoMD","mirror":"https://cdn.amazonlinux.com/al2023/core/guids/29e4193825ebc2e92ed1826c416725f40ed385d15e0150ab2021454a47b9a782/x86_64/repodata/repomd.xml","caller":"client.go:64","message":"attempting repomd download"}
    testing.go:98: {"level":"debug","zlog.testname":"TestAWS/aws-AL2023-updater","component":"aws/Client.RepoMD","mirror":"https://cdn.amazonlinux.com/al2023/core/guids/29e4193825ebc2e92ed1826c416725f40ed385d15e0150ab2021454a47b9a782/x86_64/repodata/repomd.xml","caller":"client.go:93","message":"success"}
    testing.go:98: {"level":"debug","mirror":"https://cdn.amazonlinux.com/al2023/core/guids/29e4193825ebc2e92ed1826c416725f40ed385d15e0150ab2021454a47b9a782/x86_64/repodata/updateinfo.xml.gz","zlog.testname":"TestAWS/aws-AL2023-updater","component":"aws/Client.Updates","caller":"client.go:158","message":"success"}
    updater_test.go:180: 9771b222ef3c1bce3a497cda75a603359d7117c3efc3743b88070234451379d0
    updater_test.go:191: reported 10261 vulnerabilites
--- PASS: TestAWS (1.69s)
    --- PASS: TestAWS/aws-AL1-updater (0.82s)
    --- PASS: TestAWS/aws-AL2-updater (0.54s)
    --- PASS: TestAWS/aws-AL2023-updater (0.33s)
PASS
ok  	github.com/quay/claircore/test/periodic	1.702s
```