### PR TITLE
all: use `Layer.FS` method

### DIFF
--- a/alpine/distributionscanner.go
+++ b/alpine/distributionscanner.go
@@ -15,7 +15,6 @@ import (
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/indexer"
 	"github.com/quay/claircore/osrelease"
-	"github.com/quay/claircore/pkg/tarfs"
 )
 
 // Alpine linux has patch releases but their security database
@@ -69,14 +68,9 @@ func (s *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]*
 		"layer", l.Hash.String())
 	zlog.Debug(ctx).Msg("start")
 	defer zlog.Debug(ctx).Msg("done")
-	rc, err := l.Reader()
+	sys, err := l.FS()
 	if err != nil {
-		return nil, err
-	}
-	defer rc.Close()
-	sys, err := tarfs.New(rc)
-	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("alpine: unable to open layer: %w", err)
 	}
 	return s.scanFs(ctx, sys)
 }

--- a/apk/scanner.go
+++ b/apk/scanner.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io/fs"
 	"runtime/trace"
 
@@ -11,7 +12,6 @@ import (
 
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/indexer"
-	"github.com/quay/claircore/pkg/tarfs"
 )
 
 const (
@@ -59,13 +59,9 @@ func (*Scanner) Scan(ctx context.Context, layer *claircore.Layer) ([]*claircore.
 	zlog.Debug(ctx).Msg("start")
 	defer zlog.Debug(ctx).Msg("done")
 
-	rc, err := layer.Reader()
+	sys, err := layer.FS()
 	if err != nil {
-		return nil, err
-	}
-	sys, err := tarfs.New(rc)
-	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("apk: unable to open layer: %w", err)
 	}
 	b, err := fs.ReadFile(sys, installedFile)
 	switch {

--- a/debian/distributionscanner.go
+++ b/debian/distributionscanner.go
@@ -16,7 +16,6 @@ import (
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/indexer"
 	"github.com/quay/claircore/osrelease"
-	"github.com/quay/claircore/pkg/tarfs"
 )
 
 var (
@@ -47,12 +46,7 @@ func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]
 	zlog.Debug(ctx).Msg("start")
 	defer zlog.Debug(ctx).Msg("done")
 
-	rd, err := l.Reader()
-	if err != nil {
-		return nil, fmt.Errorf("debian: unable to open layer: %w", err)
-	}
-	defer rd.Close()
-	sys, err := tarfs.New(rd)
+	sys, err := l.FS()
 	if err != nil {
 		return nil, fmt.Errorf("debian: unable to open layer: %w", err)
 	}

--- a/dpkg/distroless_scanner.go
+++ b/dpkg/distroless_scanner.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/indexer"
-	"github.com/quay/claircore/pkg/tarfs"
 )
 
 const (
@@ -63,14 +62,9 @@ func (ps *DistrolessScanner) Scan(ctx context.Context, layer *claircore.Layer) (
 	zlog.Debug(ctx).Msg("start")
 	defer zlog.Debug(ctx).Msg("done")
 
-	rd, err := layer.Reader()
+	sys, err := layer.FS()
 	if err != nil {
-		return nil, fmt.Errorf("opening layer failed: %w", err)
-	}
-	defer rd.Close()
-	sys, err := tarfs.New(rd)
-	if err != nil {
-		return nil, fmt.Errorf("opening layer failed: %w", err)
+		return nil, fmt.Errorf("dpkg-distroless: opening layer failed: %w", err)
 	}
 
 	var pkgs []*claircore.Package
@@ -80,7 +74,7 @@ func (ps *DistrolessScanner) Scan(ctx context.Context, layer *claircore.Layer) (
 		}
 		if d.Name() == "status.d" && d.IsDir() {
 			zlog.Debug(ctx).Str("path", p).Msg("found potential distroless dpkg db directory")
-			dbFiles, err := sys.ReadDir(p)
+			dbFiles, err := fs.ReadDir(sys, p)
 			if err != nil {
 				return fmt.Errorf("error reading DB directory: %w", err)
 			}

--- a/dpkg/scanner.go
+++ b/dpkg/scanner.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/indexer"
-	"github.com/quay/claircore/pkg/tarfs"
 )
 
 const (
@@ -67,17 +66,9 @@ func (ps *Scanner) Scan(ctx context.Context, layer *claircore.Layer) ([]*clairco
 	zlog.Debug(ctx).Msg("start")
 	defer zlog.Debug(ctx).Msg("done")
 
-	// Grab a handle to the tarball, make sure we can seek.
-	// If we can't, we'd need another reader for every database found.
-	// It's cleaner to just demand that it's a seeker.
-	rd, err := layer.Reader()
+	sys, err := layer.FS()
 	if err != nil {
-		return nil, fmt.Errorf("opening layer failed: %w", err)
-	}
-	defer rd.Close()
-	sys, err := tarfs.New(rd)
-	if err != nil {
-		return nil, fmt.Errorf("opening layer failed: %w", err)
+		return nil, fmt.Errorf("dpkg: opening layer failed: %w", err)
 	}
 
 	// This is a map keyed by directory. A "score" of 2 means this is almost

--- a/gobin/gobin.go
+++ b/gobin/gobin.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/indexer"
-	"github.com/quay/claircore/pkg/tarfs"
 )
 
 // Detector detects go binaries and reports the packages used to build them.
@@ -74,14 +73,9 @@ func (Detector) Scan(ctx context.Context, l *claircore.Layer) ([]*claircore.Pack
 	zlog.Debug(ctx).Msg("start")
 	defer zlog.Debug(ctx).Msg("done")
 
-	rd, err := l.Reader()
+	sys, err := l.FS()
 	if err != nil {
-		return nil, err
-	}
-	defer rd.Close()
-	sys, err := tarfs.New(rd)
-	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("gobin: unable to open layer: %w", err)
 	}
 
 	var out []*claircore.Package

--- a/java/packagescanner.go
+++ b/java/packagescanner.go
@@ -24,7 +24,6 @@ import (
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/indexer"
 	"github.com/quay/claircore/java/jar"
-	"github.com/quay/claircore/pkg/tarfs"
 )
 
 var (
@@ -116,15 +115,9 @@ func (s *Scanner) Scan(ctx context.Context, layer *claircore.Layer) ([]*claircor
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-
-	r, err := layer.Reader()
+	sys, err := layer.FS()
 	if err != nil {
-		return nil, err
-	}
-	defer r.Close()
-	sys, err := tarfs.New(r)
-	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("java: unable to open layer: %w", err)
 	}
 
 	ars, err := archives(ctx, sys)

--- a/java/reposcanner.go
+++ b/java/reposcanner.go
@@ -4,16 +4,13 @@ package java
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"io"
 	"runtime/trace"
 
 	"github.com/quay/zlog"
 
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/indexer"
-	"github.com/quay/claircore/pkg/tarfs"
 )
 
 var (
@@ -53,21 +50,11 @@ func (rs *RepoScanner) Scan(ctx context.Context, layer *claircore.Layer) ([]*cla
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
+	sys, err := layer.FS()
+	if err != nil {
+		return nil, fmt.Errorf("java: unable to open layer: %w", err)
+	}
 
-	r, err := layer.Reader()
-	if err != nil {
-		return nil, err
-	}
-	defer r.Close()
-	ra, ok := r.(io.ReaderAt)
-	if !ok {
-		err := errors.New("unable to coerce to io.ReaderAt")
-		return nil, fmt.Errorf("opening layer failed: %w", err)
-	}
-	sys, err := tarfs.New(ra)
-	if err != nil {
-		return nil, err
-	}
 	ars, err := archives(ctx, sys)
 	if err != nil {
 		return nil, err

--- a/osrelease/scanner.go
+++ b/osrelease/scanner.go
@@ -16,7 +16,6 @@ import (
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/indexer"
 	"github.com/quay/claircore/pkg/cpe"
-	"github.com/quay/claircore/pkg/tarfs"
 )
 
 const (
@@ -65,12 +64,7 @@ func (s *Scanner) Scan(ctx context.Context, l *claircore.Layer) ([]*claircore.Di
 	zlog.Debug(ctx).Msg("start")
 	defer zlog.Debug(ctx).Msg("done")
 
-	r, err := l.Reader()
-	if err != nil {
-		return nil, fmt.Errorf("osrelease: unable to open layer: %w", err)
-	}
-	defer r.Close()
-	sys, err := tarfs.New(r)
+	sys, err := l.FS()
 	if err != nil {
 		return nil, fmt.Errorf("osrelease: unable to open layer: %w", err)
 	}

--- a/python/packagescanner.go
+++ b/python/packagescanner.go
@@ -19,7 +19,6 @@ import (
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/indexer"
 	"github.com/quay/claircore/pkg/pep440"
-	"github.com/quay/claircore/pkg/tarfs"
 )
 
 var (
@@ -64,14 +63,9 @@ func (ps *Scanner) Scan(ctx context.Context, layer *claircore.Layer) ([]*clairco
 		return nil, err
 	}
 
-	r, err := layer.Reader()
+	sys, err := layer.FS()
 	if err != nil {
-		return nil, err
-	}
-	defer r.Close()
-	sys, err := tarfs.New(r)
-	if err != nil {
-		return nil, fmt.Errorf("python: unable to open tar: %w", err)
+		return nil, fmt.Errorf("python: unable to open layer: %w", err)
 	}
 
 	ms, err := findDeliciousEgg(ctx, sys)

--- a/python/reposcanner.go
+++ b/python/reposcanner.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/indexer"
-	"github.com/quay/claircore/pkg/tarfs"
 )
 
 var (
@@ -52,14 +51,9 @@ func (rs *RepoScanner) Scan(ctx context.Context, layer *claircore.Layer) ([]*cla
 		return nil, err
 	}
 
-	r, err := layer.Reader()
+	sys, err := layer.FS()
 	if err != nil {
-		return nil, err
-	}
-	defer r.Close()
-	sys, err := tarfs.New(r)
-	if err != nil {
-		return nil, fmt.Errorf("python: unable to open tar: %w", err)
+		return nil, fmt.Errorf("python: unable to open layer: %w", err)
 	}
 
 	ms, err := findDeliciousEgg(ctx, sys)

--- a/rhel/distributionscanner.go
+++ b/rhel/distributionscanner.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/indexer"
-	"github.com/quay/claircore/pkg/tarfs"
 )
 
 var (
@@ -47,14 +46,9 @@ func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]
 		"layer", l.Hash.String())
 	zlog.Debug(ctx).Msg("start")
 	defer zlog.Debug(ctx).Msg("done")
-	rd, err := l.Reader()
+	sys, err := l.FS()
 	if err != nil {
-		return nil, fmt.Errorf("rhel: unable to create layer reader: %w", err)
-	}
-	defer rd.Close()
-	sys, err := tarfs.New(rd)
-	if err != nil {
-		return nil, fmt.Errorf("rhel: unable to open tarfs: %w", err)
+		return nil, fmt.Errorf("rhel: unable to open layer: %w", err)
 	}
 	d, err := findDistribution(sys)
 	if err != nil {

--- a/rhel/repositoryscanner.go
+++ b/rhel/repositoryscanner.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/indexer"
-	"github.com/quay/claircore/pkg/tarfs"
 	"github.com/quay/claircore/rhel/dockerfile"
 	"github.com/quay/claircore/rhel/internal/common"
 	"github.com/quay/claircore/rhel/internal/containerapi"
@@ -178,12 +177,7 @@ func (r *RepositoryScanner) Scan(ctx context.Context, l *claircore.Layer) (repos
 	zlog.Debug(ctx).Msg("start")
 	defer zlog.Debug(ctx).Msg("done")
 
-	rd, err := l.Reader()
-	if err != nil {
-		return nil, fmt.Errorf("rhel: unable to open layer: %w", err)
-	}
-	defer rd.Close()
-	sys, err := tarfs.New(rd)
+	sys, err := l.FS()
 	if err != nil {
 		return nil, fmt.Errorf("rhel: unable to open layer: %w", err)
 	}

--- a/ruby/packagescanner.go
+++ b/ruby/packagescanner.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/indexer"
-	"github.com/quay/claircore/pkg/tarfs"
 )
 
 var (
@@ -84,14 +83,9 @@ func (ps *Scanner) Scan(ctx context.Context, layer *claircore.Layer) ([]*clairco
 		return nil, err
 	}
 
-	r, err := layer.Reader()
+	sys, err := layer.FS()
 	if err != nil {
-		return nil, err
-	}
-	defer r.Close()
-	sys, err := tarfs.New(r)
-	if err != nil {
-		return nil, fmt.Errorf("ruby: unable to open tar: %w", err)
+		return nil, fmt.Errorf("ruby: unable to open layer: %w", err)
 	}
 
 	gs, err := gems(ctx, sys)

--- a/ruby/reposcanner.go
+++ b/ruby/reposcanner.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/indexer"
-	"github.com/quay/claircore/pkg/tarfs"
 )
 
 const repository = "rubygems"
@@ -53,14 +52,9 @@ func (rs *RepoScanner) Scan(ctx context.Context, layer *claircore.Layer) ([]*cla
 		return nil, err
 	}
 
-	r, err := layer.Reader()
+	sys, err := layer.FS()
 	if err != nil {
-		return nil, err
-	}
-	defer r.Close()
-	sys, err := tarfs.New(r)
-	if err != nil {
-		return nil, fmt.Errorf("ruby: unable to open tar: %w", err)
+		return nil, fmt.Errorf("ruby: unable to open layer: %w", err)
 	}
 
 	gs, err := gems(ctx, sys)

--- a/scanner/pkgconfig/scanner.go
+++ b/scanner/pkgconfig/scanner.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/indexer"
-	"github.com/quay/claircore/pkg/tarfs"
 )
 
 var _ indexer.PackageScanner = (*Scanner)(nil)
@@ -57,12 +56,7 @@ func (ps *Scanner) Scan(ctx context.Context, layer *claircore.Layer) ([]*clairco
 	zlog.Debug(ctx).Msg("start")
 	defer zlog.Debug(ctx).Msg("done")
 
-	r, err := layer.Reader()
-	if err != nil {
-		return nil, fmt.Errorf("pkgconfig: opening layer failed: %w", err)
-	}
-	defer r.Close()
-	sys, err := tarfs.New(r)
+	sys, err := layer.FS()
 	if err != nil {
 		return nil, fmt.Errorf("pkgconfig: opening layer failed: %w", err)
 	}

--- a/ubuntu/distributionscanner.go
+++ b/ubuntu/distributionscanner.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/indexer"
-	"github.com/quay/claircore/pkg/tarfs"
 )
 
 const (
@@ -52,12 +51,7 @@ func (ds *DistributionScanner) Scan(ctx context.Context, l *claircore.Layer) ([]
 		"layer", l.Hash.String())
 	zlog.Debug(ctx).Msg("start")
 	defer zlog.Debug(ctx).Msg("done")
-	rd, err := l.Reader()
-	if err != nil {
-		return nil, fmt.Errorf("ubuntu: unable to open layer: %w", err)
-	}
-	defer rd.Close()
-	sys, err := tarfs.New(rd)
+	sys, err := l.FS()
 	if err != nil {
 		return nil, fmt.Errorf("ubuntu: unable to open layer: %w", err)
 	}

--- a/whiteout/scanner.go
+++ b/whiteout/scanner.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/indexer"
-	"github.com/quay/claircore/pkg/tarfs"
 )
 
 const (
@@ -39,12 +38,7 @@ func (s *Scanner) Scan(ctx context.Context, l *claircore.Layer) ([]claircore.Fil
 		"layer", l.Hash.String())
 	zlog.Debug(ctx).Msg("start")
 	defer zlog.Debug(ctx).Msg("done")
-	rd, err := l.Reader()
-	if err != nil {
-		return nil, fmt.Errorf("whiteout: unable to read layer: %w", err)
-	}
-	defer rd.Close()
-	sys, err := tarfs.New(rd)
+	sys, err := l.FS()
 	if err != nil {
 		return nil, fmt.Errorf("whiteout: unable to create fs: %w", err)
 	}


### PR DESCRIPTION
Doing this should allow us to realize potential memory savings enabled by #1061.

All the in-tree Scanner implementations should now share a single `tarfs.FS` instance per layer.