### PR TITLE
cicd: tweak per-patch codecov reporting

### DIFF
--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -4,6 +4,11 @@ ignore:
 
 coverage:
   status:
+    # Per-patch reporting is weird: refactors can crater the patch coverage
+    # percentage while keeping the same or better project coverage percentage.
+    patch:
+      default:
+        informational: true
     project:
       default:
         threshold: 0.5%


### PR DESCRIPTION
I find the "patch" stats failing CI to be very annoying. Refactors that net positive in coverage can still get hit by it. This change still has it reported, but it won't fail the CI.