### PR TITLE
cicd: use latest mdBook

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1
         with:
-          mdbook-version: '0.3.5'
+          mdbook-version: 'latest'
       - name: mdBook Build
         run: mdbook build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1
         with:
-          mdbook-version: '0.3.5'
+          mdbook-version: 'latest'
 
       - name: mdBook Build
         run: mdbook build --dest-dir ./book/$(basename ${GITHUB_REF})

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1
         with:
-          mdbook-version: '0.3.5'
+          mdbook-version: 'latest'
 
       - name: mdBook Build
         run: mdbook build


### PR DESCRIPTION
I noticed the gh-pages docs aren't rendering correctly. I think this should fix it, but at the very least should make it behave more like my development environment.