### PR TITLE
integration: poison default http resources

### DIFF
--- a/rhel/matcher_test.go
+++ b/rhel/matcher_test.go
@@ -79,7 +79,7 @@ func TestMatcherIntegration(t *testing.T) {
 		}
 		facs[u.Name()] = driver.StaticSet(s)
 	}
-	mgr, err := updates.NewManager(ctx, store, locks, http.DefaultClient, updates.WithFactories(facs))
+	mgr, err := updates.NewManager(ctx, store, locks, c, updates.WithFactories(facs))
 	if err != nil {
 		t.Error(err)
 	}

--- a/rhel/rhcc/updater.go
+++ b/rhel/rhcc/updater.go
@@ -115,7 +115,7 @@ func (u *updater) Fetch(ctx context.Context, hint driver.Fingerprint) (io.ReadCl
 		req.Header.Set("if-none-match", string(hint))
 	}
 
-	res, err := http.DefaultClient.Do(req)
+	res, err := u.client.Do(req)
 	if err != nil {
 		return nil, hint, fmt.Errorf("rhcc: error making request: %w", err)
 	}

--- a/test/integration/poison_http.go
+++ b/test/integration/poison_http.go
@@ -1,0 +1,20 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+)
+
+func init() {
+	if !skip {
+		return
+	}
+	http.DefaultTransport = &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			const msg = `unable to dial %s!%s: DefaultTransport disallowed`
+			return nil, fmt.Errorf(msg, network, addr)
+		},
+	}
+}


### PR DESCRIPTION
This should help us root out inappropriate uses of the default `net/http` resources.