### PR TITLE
jsonblob: add a disk buffering step

### DIFF
--- a/libvuln/jsonblob/diskbuf_linux.go
+++ b/libvuln/jsonblob/diskbuf_linux.go
@@ -1,0 +1,12 @@
+package jsonblob
+
+import (
+	"context"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func diskBuf(_ context.Context) (*os.File, error) {
+	return os.OpenFile(os.TempDir(), os.O_RDWR|unix.O_TMPFILE, 0600)
+}

--- a/libvuln/jsonblob/diskbuf_unix.go
+++ b/libvuln/jsonblob/diskbuf_unix.go
@@ -1,0 +1,20 @@
+//go:build unix && !linux
+
+package jsonblob
+
+import (
+	"context"
+	"os"
+)
+
+func diskBuf(_ context.Context) (*os.File, error) {
+	f, err := os.CreateTemp(os.TempDir(), "jsonblob.*.json")
+	if err != nil {
+		return nil, err
+	}
+	if err := os.Remove(f.Name()); err != nil {
+		f.Close()
+		return nil, err
+	}
+	return f, nil
+}

--- a/libvuln/jsonblob/diskbuf_windows.go
+++ b/libvuln/jsonblob/diskbuf_windows.go
@@ -1,0 +1,30 @@
+package jsonblob
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	_ "unsafe" // linker tricks
+)
+
+// This is a very rough port of src/os/tempfile.go that adds the magic
+// autodelete flag.
+
+//go:linkname fastrand runtime.fastrand
+func fastrand() uint32
+
+func diskBuf(_ context.Context) (*os.File, error) {
+	// Copied out of golang.org/x/sys/windows
+	const FILE_FLAG_DELETE_ON_CLOSE = 0x04000000
+	dir := os.TempDir()
+	for {
+		fn := fmt.Sprintf("jsonblob.%d.json", fastrand())
+		f, err := os.OpenFile(filepath.Join(dir, fn), os.O_RDWR|os.O_CREATE|os.O_EXCL|FILE_FLAG_DELETE_ON_CLOSE, 0600)
+		if errors.Is(err, os.ErrExist) {
+			continue
+		}
+		return f, err
+	}
+}


### PR DESCRIPTION
This eagerly encodes Vulnerabilities and EnrichmentRecords to JSON and writes them to a disk-backed buffer. This should reduce memory consumption as long as the system actually allows for flushing disk cache.

See-also: PROJQUAY-5915