### PR TITLE
osv: lower allowlist config values for osv ecosystems

### DIFF
--- a/updater/osv/osv.go
+++ b/updater/osv/osv.go
@@ -92,7 +92,7 @@ func (u *Factory) Configure(ctx context.Context, f driver.ConfigUnmarshaler, c *
 	if l := len(cfg.Allowlist); l != 0 {
 		u.allow = make(map[string]bool, l)
 		for _, a := range cfg.Allowlist {
-			u.allow[a] = true
+			u.allow[strings.ToLower(a)] = true
 		}
 	}
 


### PR DESCRIPTION
We mention https://ossf.github.io/osv-schema and the values there are (mostly) capitalized. As we lower the ecosystems we get from ecosystems.txt we should lower the config values too or they won't match (or we need to direct users to lower-case any ecosystems they add).