### PR TITLE
fix(ruby): use more accurate versioning

### DIFF
--- a/ruby/matcher.go
+++ b/ruby/matcher.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/Masterminds/semver"
 	"github.com/quay/zlog"
 
 	"github.com/quay/claircore"
@@ -52,7 +51,7 @@ func (*Matcher) Vulnerable(ctx context.Context, record *claircore.IndexRecord, v
 		upperVersion = decodedVersions.Get("lastAffected")
 	}
 
-	rv, err := semver.NewVersion(record.Package.Version)
+	rv, err := NewVersion(record.Package.Version)
 	if err != nil {
 		zlog.Warn(ctx).
 			Str("package", record.Package.Name).
@@ -61,7 +60,7 @@ func (*Matcher) Vulnerable(ctx context.Context, record *claircore.IndexRecord, v
 		return false, err
 	}
 
-	uv, err := semver.NewVersion(upperVersion)
+	uv, err := NewVersion(upperVersion)
 	if err != nil {
 		zlog.Warn(ctx).
 			Str("vulnerability", vuln.Name).
@@ -78,7 +77,7 @@ func (*Matcher) Vulnerable(ctx context.Context, record *claircore.IndexRecord, v
 		return false, nil
 	case decodedVersions.Has("introduced"):
 		introduced := decodedVersions.Get("introduced")
-		iv, err := semver.NewVersion(introduced)
+		iv, err := NewVersion(introduced)
 		if err != nil {
 			zlog.Warn(ctx).
 				Str("vulnerability", vuln.Name).

--- a/ruby/matcher_test.go
+++ b/ruby/matcher_test.go
@@ -106,7 +106,7 @@ func TestVulnerable(t *testing.T) {
 			record: &claircore.IndexRecord{
 				Package: &claircore.Package{
 					Name:    "dependabot-omnibus",
-					Version: "0.120.0-beta2",
+					Version: "0.120.0.beta2",
 					Kind:    "binary",
 				},
 			},
@@ -118,7 +118,7 @@ func TestVulnerable(t *testing.T) {
 					Name:           "dependabot-omnibus",
 					RepositoryHint: "rubygems",
 				},
-				FixedInVersion: "fixed=0.125.1&introduced=0.119.0-beta1",
+				FixedInVersion: "fixed=0.125.1&introduced=0.119.0.beta1",
 			},
 			want: true,
 		},

--- a/ruby/version.go
+++ b/ruby/version.go
@@ -1,0 +1,210 @@
+package ruby
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+)
+
+var (
+	anchoredVersion = regexp.MustCompile(`^\s*([0-9]+(\.[0-9a-zA-Z]+)*(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?)?\s*$`)
+
+	errInvalidVersion = errors.New("invalid gem version")
+)
+
+// Version is a RubyGem version.
+// This is based on the official [implementation].
+//
+// [implementation]: https://github.com/rubygems/rubygems/blob/1a1948424aca90013b37cb8a78f5d1d5576023f1/lib/rubygems/version.rb
+type Version struct {
+	segs []Segment
+}
+
+// NewVersion creates a Version out of the given string.
+func NewVersion(version string) (Version, error) {
+	if !anchoredVersion.MatchString(version) {
+		return Version{}, errInvalidVersion
+	}
+
+	version = strings.TrimSpace(version)
+	if version == "" {
+		version = "0"
+	}
+	version = strings.ReplaceAll(version, "-", ".pre.")
+
+	return Version{
+		segs: canonicalize(version),
+	}, nil
+}
+
+// Compare returns an integer comparing this version, v, to other.
+// The result will be 0 if v == other, -1 if v < other, and +1 if v > other.
+func (v Version) Compare(other Version) int {
+	segs := v.segs
+	otherSegs := other.segs
+
+	leftLen := len(segs)
+	rightLen := len(otherSegs)
+	limit := max(leftLen, rightLen)
+	for i := 0; i < limit; i++ {
+		left, right := Segment(numericSegment("0")), Segment(numericSegment("0"))
+		if i < leftLen {
+			left = segs[i]
+		}
+		if i < rightLen {
+			right = otherSegs[i]
+		}
+
+		if cmp := left.Compare(right); cmp != 0 {
+			return cmp
+		}
+	}
+
+	return 0
+}
+
+func canonicalize(v string) []Segment {
+	segs, prerelease := partitionSegments(v)
+
+	// Remove trailing zero segments.
+	i := len(segs) - 1
+	for ; i >= 0; i-- {
+		seg, ok := segs[i].(numericSegment)
+		if !ok || !seg.isZero() {
+			break
+		}
+	}
+	segs = segs[:i+1]
+
+	// Remove all zero segments preceding the first letter in a prerelease version.
+	if prerelease {
+		// Find the first letter in the version.
+		end := -1
+		for i := 0; i < len(segs); i++ {
+			if _, ok := segs[i].(stringSegment); ok {
+				end = i
+				break
+			}
+		}
+		if end != -1 {
+			// Find where the preceding zeroes start.
+			var start int
+			for i := end - 1; i >= 0; i-- {
+				seg, ok := segs[i].(numericSegment)
+				if !ok || !seg.isZero() {
+					start = i + 1
+					break
+				}
+			}
+			segs = append(segs[:start], segs[end:]...)
+		}
+	}
+
+	return segs
+}
+
+func partitionSegments(v string) ([]Segment, bool) {
+	var prerelease bool
+	splitVersion := strings.Split(v, ".")
+	segs := make([]Segment, 0, len(splitVersion))
+	for _, s := range splitVersion {
+		if s == "" {
+			continue
+		}
+
+		if onlyDigits(s) {
+			segs = append(segs, numericSegment(s))
+			continue
+		}
+
+		// Ruby considers any version with a letter to be a prerelease.
+		prerelease = true
+		segs = append(segs, stringSegment(s))
+	}
+
+	return segs, prerelease
+}
+
+func onlyDigits(s string) bool {
+	// I don't know if converting to a []byte does anything
+	// special here, but [strconv.ParseUint] does it when ranging over a string,
+	// and this implementation is based on code from [strconv.ParseUint].
+	for _, c := range []byte(s) {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func max(a, b int) int {
+	if b > a {
+		return b
+	}
+	return a
+}
+
+// Segment is a part of a RubyGem version.
+type Segment interface {
+	Compare(other Segment) int
+}
+
+var (
+	_ Segment = (*stringSegment)(nil)
+	_ Segment = (*numericSegment)(nil)
+)
+
+type stringSegment string
+
+// Compare returns an integer comparing this version, s, to other.
+// The result will be 0 if v == other, -1 if v < other, and +1 if v > other.
+//
+// A stringSegment is always less than a numericSegment.
+func (s stringSegment) Compare(other Segment) int {
+	switch seg := other.(type) {
+	case numericSegment:
+		return -1
+	case stringSegment:
+		return strings.Compare(string(s), string(seg))
+	default:
+		panic("Programmer error")
+	}
+}
+
+type numericSegment string
+
+// Compare returns an integer comparing this version, n, to other.
+// The result will be 0 if n == other, -1 if n < other, and +1 if n > other.
+//
+// A numericSegment is always greater than a stringSegment.
+func (n numericSegment) Compare(other Segment) int {
+	switch seg := other.(type) {
+	case stringSegment:
+		return +1
+	case numericSegment:
+		left, leftLen := string(n), len(n)
+		right, rightLen := string(seg), len(seg)
+		// The length of each string must match to compare them properly.
+		// Pad the shorter string with zeroes.
+		if leftLen == max(leftLen, rightLen) {
+			right = strings.Repeat("0", leftLen-rightLen) + right
+		} else {
+			left = strings.Repeat("0", rightLen-leftLen) + left
+		}
+		return strings.Compare(left, right)
+	default:
+		panic("Programmer error")
+	}
+}
+
+func (n numericSegment) isZero() bool {
+	// Again, I don't know if converting to a []byte does anything
+	// special here, but [strconv.ParseUint] does it when ranging over a string,
+	// and this implementation is based on code from [strconv.ParseUint].
+	for _, c := range []byte(n) {
+		if c != '0' {
+			return false
+		}
+	}
+	return true
+}

--- a/ruby/version_test.go
+++ b/ruby/version_test.go
@@ -1,0 +1,247 @@
+package ruby
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestNewVersion(t *testing.T) {
+	testcases := []struct {
+		version string
+		valid   bool
+	}{
+		{
+			version: "1",
+			valid:   true,
+		},
+		{
+			version: "1.",
+			valid:   false,
+		},
+		{
+			version: "1.alpha",
+			valid:   true,
+		},
+		{
+			version: "1-alpha",
+			valid:   true,
+		},
+		{
+			version: "",
+			valid:   true,
+		},
+		{
+			version: ".3",
+			valid:   false,
+		},
+		{
+			version: "beta",
+			valid:   false,
+		},
+		{
+			version: "beta.1",
+			valid:   false,
+		},
+		{
+			version: "-",
+			valid:   false,
+		},
+		{
+			version: "0-0",
+			valid:   true,
+		},
+		{
+			version: "1/2",
+			valid:   false,
+		},
+		{
+			version: "1..2",
+			valid:   false,
+		},
+		{
+			version: "1111111111111111111111111111111111111111111111111111111",
+			valid:   true,
+		},
+		{
+			version: "1.234567890987654321234567890987654321234567890987654321234567890987654.3.21",
+			valid:   true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.version, func(t *testing.T) {
+			_, err := NewVersion(tc.version)
+			if !cmp.Equal(tc.valid, err == nil) {
+				t.Error(cmp.Diff(tc.valid, err == nil))
+			}
+		})
+	}
+}
+
+func TestVersionCompare(t *testing.T) {
+	testcases := []struct {
+		a, b string
+		want int
+	}{
+		{
+			a:    "1",
+			b:    "2",
+			want: -1,
+		},
+		{
+			a:    "1.1.2",
+			b:    "1.1.0",
+			want: +1,
+		},
+		{
+			a:    "1.1.02",
+			b:    "1.1.0",
+			want: +1,
+		},
+		{
+			a:    "1.1.2",
+			b:    "1.1.2",
+			want: 0,
+		},
+		{
+			a:    "5",
+			b:    "4.2.10",
+			want: +1,
+		},
+		{
+			a:    "4.2.10",
+			b:    "5",
+			want: -1,
+		},
+		{
+			a:    "4.2.10",
+			b:    "4.2.10.0.0.0.0.0.0",
+			want: 0,
+		},
+		{
+			a:    "0.9",
+			b:    "1.0",
+			want: -1,
+		},
+		{
+			a:    "0.9",
+			b:    "1.0.a.2",
+			want: -1,
+		},
+		{
+			a:    "1.0.a.2",
+			b:    "1.0.b1",
+			want: -1,
+		},
+		{
+			a:    "1.0.b1",
+			b:    "1.0",
+			want: -1,
+		},
+		{
+			a:    "0.alpha",
+			b:    "0",
+			want: -1,
+		},
+		{
+			a:    "1-2",
+			b:    "1-2",
+			want: 0,
+		},
+		{
+			a:    "1-1",
+			b:    "1-2",
+			want: -1,
+		},
+		{
+			a:    "1-2",
+			b:    "1-1",
+			want: +1,
+		},
+		{
+			a:    "1.2.3.0.00.0-0.0.0000.3.0000.00000000",
+			b:    "1.2.3.0.0.0-0.0.0.3.0.0",
+			want: 0,
+		},
+		{
+			a:    "1.2.3.0.00.0-0.0.000000000000000000000000000000000000000000000000000000000000000000.3.0000.00000000",
+			b:    "1.2.3.0.0.0-0.0.0.3.0.0",
+			want: 0,
+		},
+		{
+			a:    "1.2.3.0.00.0-0.0.0000.3.0000.00000000",
+			b:    "1.2.3.0.0.0-0.0.0.3",
+			want: 0,
+		},
+		{
+			a:    "1.2.3.0.00.0-0.0.0000.3.0000.00000000",
+			b:    "1.2.3-0.0.0.3",
+			want: 0,
+		},
+		{
+			a:    "1.0.3.beta",
+			b:    "1.beta",
+			want: +1,
+		},
+		{
+			a:    "1.0.3.00.0.0.4.0.0.0.0.beta.0.0.2.0.0.00000",
+			b:    "1.0.3.00.0.0.4.beta.0.0.2",
+			want: 0,
+		},
+		{
+			a:    "1.0.3.00.0.0.4.0.0.0.0.beta.0.0.2.0.0.00000",
+			b:    "1.0.3.00.0.0.4.alpha.0.0.2",
+			want: +1,
+		},
+		{
+			a:    "   1.alpha.0.1.0.5.00000.0",
+			b:    " 1.alpha.0.1.0.5.0          ",
+			want: 0,
+		},
+		{
+			a:    "",
+			b:    "\t",
+			want: 0,
+		},
+		{
+			a:    "1.2.000000000000000000000000000000000000000000000000000000000001",
+			b:    "1.2.1",
+			want: 0,
+		},
+		{
+			a:    "1.2.000000000000000000000000000000000000000000000000000000000001",
+			b:    "1.2.2",
+			want: -1,
+		},
+		{
+			a:    "1.234567890987654321234567890987654321234567890987654321234567890987654.3.21",
+			b:    "1.000000000000000000234567890987654321234567890987654321234567890987654.3.21",
+			want: +1,
+		},
+		{
+			a:    "9999999999999999999999999999999999999999999999999999999999999999999999999999",
+			b:    "00000000009999999999999999999999999999999999999999999999999999999999999999999999999999",
+			want: 0,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(fmt.Sprintf("%s_%s", tc.a, tc.b), func(t *testing.T) {
+			aVersion, err := NewVersion(tc.a)
+			if err != nil {
+				t.Fatal(err)
+			}
+			bVersion, err := NewVersion(tc.b)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			got := aVersion.Compare(bVersion)
+			if !cmp.Equal(tc.want, got) {
+				t.Error(cmp.Diff(tc.want, got))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implemented Ruby versioning based on https://github.com/rubygems/rubygems/blob/1a1948424aca90013b37cb8a78f5d1d5576023f1/lib/rubygems/version.rb