### PR TITLE
all: purge `http.DefaultClient`

### DIFF
--- a/aws/updater.go
+++ b/aws/updater.go
@@ -29,7 +29,6 @@ type Updater struct {
 func NewUpdater(release Release) (*Updater, error) {
 	return &Updater{
 		release: release,
-		c:       http.DefaultClient, // TODO(hank) Remove DefaultClient
 	}, nil
 }
 
@@ -45,9 +44,6 @@ func (u *Updater) Configure(ctx context.Context, _ driver.ConfigUnmarshaler, c *
 
 func (u *Updater) Fetch(ctx context.Context, fingerprint driver.Fingerprint) (io.ReadCloser, driver.Fingerprint, error) {
 	ctx = zlog.ContextWithValues(ctx, "component", "aws/Updater.Fetch")
-	if u.c == http.DefaultClient { // OK: checking for log purposes
-		zlog.Warn(ctx).Msg("DefaultClient used, this is almost certainly wrong")
-	}
 	client, err := NewClient(ctx, u.c, u.release)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to create client: %v", err)

--- a/datastore/postgres/gc_test.go
+++ b/datastore/postgres/gc_test.go
@@ -114,7 +114,7 @@ func TestGC(t *testing.T) {
 				ctx,
 				NewMatcherStore(pool),
 				locks,
-				http.DefaultClient,
+				http.DefaultClient, // Used on purpose -- shouldn't actually get called by anything.
 				updates.WithEnabled([]string{}),
 				updates.WithOutOfTree([]driver.Updater{mock}),
 			)

--- a/java/jar/jar_test.go
+++ b/java/jar/jar_test.go
@@ -134,7 +134,7 @@ func fetch(t testing.TB, u string, ck string) (name string) {
 	case errors.Is(err, os.ErrNotExist):
 		t.Logf("file %q missing", name)
 		integration.Skip(t)
-		res, err := http.Get(uri.String())
+		res, err := http.Get(uri.String()) // Use of http.DefaultClient guarded by integration.Skip call.
 		if err != nil {
 			t.Error(err)
 			break

--- a/libvuln/libvuln.go
+++ b/libvuln/libvuln.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"net/http"
 	"reflect"
 	"time"
 
@@ -51,10 +50,13 @@ func New(ctx context.Context, opts *Options) (*Libvuln, error) {
 
 	// required
 	if opts.Store == nil {
-		return nil, fmt.Errorf("field Store cannot be nil")
+		return nil, fmt.Errorf("libvuln: must provide a Store")
 	}
 	if opts.UpdateRetention == 1 || opts.UpdateRetention < 0 {
-		return nil, fmt.Errorf("update retention must be 0 or greater then 1")
+		return nil, fmt.Errorf("libvuln: must provide a valid UpdateRetention")
+	}
+	if opts.Client == nil {
+		return nil, fmt.Errorf("libvuln: must provide a *http.Client")
 	}
 
 	// optional
@@ -72,11 +74,6 @@ func New(ctx context.Context, opts *Options) (*Libvuln, error) {
 		opts.UpdateWorkers = DefaultUpdateWorkers
 	}
 
-	if opts.Client == nil {
-		zlog.Warn(ctx).
-			Msg("using default HTTP client; this will become an error in the future")
-		opts.Client = http.DefaultClient // TODO(hank) Remove DefaultClient
-	}
 	if opts.UpdaterConfigs == nil {
 		opts.UpdaterConfigs = make(map[string]driver.ConfigUnmarshaler)
 	}

--- a/libvuln/options.go
+++ b/libvuln/options.go
@@ -99,7 +99,8 @@ type Options struct {
 	// UpdaterConfigs is a map of functions for configuration of Updaters.
 	UpdaterConfigs map[string]driver.ConfigUnmarshaler
 
-	// Client is an http.Client for use by all updaters. If unset,
-	// http.DefaultClient will be used.
+	// Client is an http.Client for use by all updaters.
+	//
+	// Must be set.
 	Client *http.Client
 }

--- a/oracle/updater.go
+++ b/oracle/updater.go
@@ -2,7 +2,6 @@ package oracle
 
 import (
 	"fmt"
-	"net/http"
 	"net/url"
 	"strconv"
 
@@ -47,20 +46,8 @@ func NewUpdater(year int, opts ...Option) (*Updater, error) {
 			return nil, err
 		}
 	}
-	if u.Fetcher.Client == nil {
-		u.Fetcher.Client = http.DefaultClient // TODO(hank) Remove DefaultClient
-	}
 
 	return &u, nil
-}
-
-// WithClient returns an Option that will make the Updater use the specified
-// http.Client, instead of http.DefaultClient.
-func WithClient(c *http.Client) Option {
-	return func(u *Updater) error {
-		u.Fetcher.Client = c
-		return nil
-	}
 }
 
 // WithURL overrides the default URL to fetch an OVAL database.

--- a/oracle/updater_test.go
+++ b/oracle/updater_test.go
@@ -20,6 +20,9 @@ func TestFetch(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if err := u.Configure(ctx, func(_ any) error { return nil }, srv.Client()); err != nil {
+		t.Fatal(err)
+	}
 	rd, hint, err := u.Fetch(ctx, "")
 	if err != nil {
 		t.Error(err)

--- a/photon/photon.go
+++ b/photon/photon.go
@@ -2,7 +2,6 @@ package photon
 
 import (
 	"fmt"
-	"net/http"
 	"net/url"
 
 	"github.com/quay/claircore/libvuln/driver"
@@ -43,9 +42,6 @@ func NewUpdater(r Release, opts ...Option) (*Updater, error) {
 			return nil, err
 		}
 	}
-	if u.Fetcher.Client == nil {
-		u.Fetcher.Client = http.DefaultClient // TODO(hank) Remove DefaultClient
-	}
 	if u.Fetcher.URL == nil {
 		var err error
 		u.Fetcher.URL, err = upstreamBase.Parse("com.vmware.phsa-" + string(u.release) + ".xml")
@@ -73,16 +69,6 @@ func WithURL(uri, compression string) Option {
 		}
 		up.Fetcher.Compression = c
 		up.Fetcher.URL = u
-		return nil
-	}
-}
-
-// WithClient sets an http.Client for use with an Updater.
-//
-// If this Option is not supplied, http.DefaultClient will be used.
-func WithClient(c *http.Client) Option {
-	return func(u *Updater) error {
-		u.Fetcher.Client = c
 		return nil
 	}
 }

--- a/suse/suse.go
+++ b/suse/suse.go
@@ -2,7 +2,6 @@ package suse
 
 import (
 	"fmt"
-	"net/http"
 	"net/url"
 
 	"github.com/quay/claircore/libvuln/driver"
@@ -43,9 +42,6 @@ func NewUpdater(r Release, opts ...Option) (*Updater, error) {
 			return nil, err
 		}
 	}
-	if u.Fetcher.Client == nil {
-		u.Fetcher.Client = http.DefaultClient // TODO(hank) Remove DefaultClient
-	}
 	if u.Fetcher.URL == nil {
 		var err error
 		u.Fetcher.URL, err = upstreamBase.Parse(string(u.release) + ".xml")
@@ -73,16 +69,6 @@ func WithURL(uri, compression string) Option {
 		}
 		up.Fetcher.Compression = c
 		up.Fetcher.URL = u
-		return nil
-	}
-}
-
-// WithClient sets an http.Client for use with an Updater.
-//
-// If this Option is not supplied, http.DefaultClient will be used.
-func WithClient(c *http.Client) Option {
-	return func(u *Updater) error {
-		u.Fetcher.Client = c
 		return nil
 	}
 }

--- a/test/fetcher.go
+++ b/test/fetcher.go
@@ -3,7 +3,6 @@ package test
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -47,7 +46,7 @@ func (a *CachedArena) LoadLayerFromRegistry(ctx context.Context, t testing.TB, r
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = fetch.Layer(ctx, t, http.DefaultClient, ref.Registry, ref.Name, d)
+	_, err = fetch.Layer(ctx, t, ref.Registry, ref.Name, d)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/engine.go
+++ b/test/integration/engine.go
@@ -143,7 +143,7 @@ func fetchArchive(t testing.TB) {
 	// Fetch and buffer the jar.
 	u := downloadURL()
 	t.Logf("fetching %q", u)
-	res, err := http.Get(u)
+	res, err := http.Get(u) // Use of http.DefaultClient guarded by integration.Skip call.
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/poison_http.go
+++ b/test/integration/poison_http.go
@@ -5,16 +5,48 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"runtime"
+	"strings"
 )
 
 func init() {
 	if !skip {
 		return
 	}
-	http.DefaultTransport = &http.Transport{
+	http.DefaultTransport = poisonedTransport(`http.Transport`)
+	http.DefaultClient = &http.Client{
+		Transport: poisonedTransport(`http.Client`),
+	}
+}
+
+func poisonedTransport(n string) *http.Transport {
+	return &http.Transport{
 		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-			const msg = `unable to dial %s!%s: DefaultTransport disallowed`
-			return nil, fmt.Errorf(msg, network, addr)
+			cs := make([]uintptr, 10)
+			skip := 2 // skip == 1 starts in this function, which is less useful than one would like.
+			var pos string
+		Stack:
+			for {
+				n := runtime.Callers(skip, cs)
+				if n == 0 {
+					break
+				}
+				cs := cs[:n]
+				skip += len(cs)
+				fs := runtime.CallersFrames(cs)
+				for {
+					f, more := fs.Next()
+					if strings.Contains(f.Function, "claircore") {
+						pos = fmt.Sprintf("%s:%d ", f.File, f.Line)
+						break Stack
+					}
+					if !more {
+						break Stack
+					}
+				}
+			}
+			const msg = `%sunable to dial %s!%s: default %s disallowed`
+			return nil, fmt.Errorf(msg, pos, network, addr, n)
 		},
 	}
 }

--- a/test/integration/poison_http_test.go
+++ b/test/integration/poison_http_test.go
@@ -1,0 +1,30 @@
+package integration
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestPoison(t *testing.T) {
+	ctx := context.Background()
+	t.Run("Direct", func(t *testing.T) {
+		p := poisonedTransport("TEST")
+		_, err := p.DialContext(ctx, "tcp6", "::1")
+		if err == nil {
+			t.Errorf("expected error, got: %v", err)
+		}
+		t.Log(err)
+	})
+
+	t.Run("Client", func(t *testing.T) {
+		c := &http.Client{
+			Transport: poisonedTransport("TEST"),
+		}
+		_, err := c.Head("http://[::1]/")
+		if err == nil {
+			t.Errorf("expected error, got: %v", err)
+		}
+		t.Log(err)
+	})
+}

--- a/test/layer.go
+++ b/test/layer.go
@@ -125,7 +125,7 @@ func RealizeLayers(ctx context.Context, t *testing.T, refs ...LayerRef) []clairc
 					t.Error(err)
 					continue
 				}
-				f, err := fetch.Layer(ctx, t, nil, refs[n].Registry, refs[n].Name, id)
+				f, err := fetch.Layer(ctx, t, refs[n].Registry, refs[n].Name, id)
 				if err != nil {
 					t.Error(err)
 					continue

--- a/test/packagescanner.go
+++ b/test/packagescanner.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"context"
-	"net/http"
 	"sort"
 	"strings"
 	"testing"
@@ -113,7 +112,7 @@ func (tc ScannerTestcase) RunSubset(ctx context.Context, n int) func(*testing.T)
 
 func (tc *ScannerTestcase) getLayer(ctx context.Context, t *testing.T) *claircore.Layer {
 	d := tc.Digest()
-	n, err := fetch.Layer(ctx, t, http.DefaultClient, tc.Domain, tc.Name, d)
+	n, err := fetch.Layer(ctx, t, tc.Domain, tc.Name, d)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/periodic/periodic_test.go
+++ b/test/periodic/periodic_test.go
@@ -10,7 +10,9 @@ import (
 )
 
 var (
-	pkgClient = &http.Client{}
+	pkgClient = &http.Client{
+		Transport: &http.Transport{},
+	}
 
 	fp driver.Fingerprint
 )

--- a/test/periodic/rpm_test.go
+++ b/test/periodic/rpm_test.go
@@ -226,7 +226,7 @@ func (doc hydraDoc) Run(dir string) func(*testing.T) {
 		for _, ld := range image.Data[0].Parsed.Layers {
 			// TODO(hank) Need a way to use the nicer API, but pass the
 			// Integration bypass.
-			n, err := fetch.Layer(ctx, t, pkgClient, doc.Registry, doc.Repository, ld, fetch.IgnoreIntegration)
+			n, err := fetch.Layer(ctx, t, doc.Registry, doc.Repository, ld, fetch.IgnoreIntegration)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Almost all of these uses were introduced to make the ergonomics nicer, but they work against being explicit about network traffic.
This is a pass attempting to root out all the uses of the `http.DefaultClient`.

There's effectively 2 OK uses of the `http.Default*` variables:

  - When not in an integration test (or in a cached-tools database test), as an assert the test will not talk to the network as configured.
  - When in a test, after `integration.Skip` has been called.

Packages in the `test/` hierarchy should basically never use `DefaultClient`/`DefaultTransport`, as they have trickier logic to try to do as much as possible even if not in an integration test.