### PR TITLE
fix(libindex): use different temp perms per OS

### DIFF
--- a/libindex/fetcher.go
+++ b/libindex/fetcher.go
@@ -21,7 +21,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/singleflight"
-	"golang.org/x/sys/unix"
 
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/indexer"
@@ -250,7 +249,7 @@ func (a *RemoteFetchArena) fetchUnlinkedFile(ctx context.Context, key string, de
 		return v.(*rc), nil
 	}
 	// Otherwise, it needs to be populated.
-	f, err := os.OpenFile(a.root, os.O_WRONLY|unix.O_TMPFILE, 0644)
+	f, err := openTemp(a.root, 0644)
 	if err != nil {
 		return nil, err
 	}

--- a/libindex/open_linux.go
+++ b/libindex/open_linux.go
@@ -1,0 +1,11 @@
+package libindex
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func openTemp(name string, perm os.FileMode) (*os.File, error) {
+	return os.OpenFile(name, os.O_WRONLY|unix.O_TMPFILE, perm)
+}

--- a/libindex/open_unix.go
+++ b/libindex/open_unix.go
@@ -1,0 +1,17 @@
+//go:build unix && !linux
+
+package libindex
+
+import "os"
+
+func openTemp(name string, perm os.FileMode) (*os.File, error) {
+	f, err := os.OpenFile(name, os.O_WRONLY, perm)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.Remove(f.Name()); err != nil {
+		f.Close()
+		return nil, err
+	}
+	return f, nil
+}

--- a/libindex/open_windows.go
+++ b/libindex/open_windows.go
@@ -1,0 +1,9 @@
+package libindex
+
+import "os"
+
+func openTemp(name string, perm os.FileMode) (*os.File, error) {
+	// Copied out of golang.org/x/sys/windows
+	const FILE_FLAG_DELETE_ON_CLOSE = 0x04000000
+	return os.OpenFile(name, os.O_WRONLY|FILE_FLAG_DELETE_ON_CLOSE, perm)
+}


### PR DESCRIPTION
ClairCore 1.5.20 did not build on macOS due to non-existent file perms. This PR aims to correct that.