### PR TITLE
fix(libindex): temp files on non-linux

### DIFF
--- a/libindex/tempfile_linux.go
+++ b/libindex/tempfile_linux.go
@@ -1,0 +1,34 @@
+package libindex
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+type tempFile struct {
+	*os.File
+}
+
+func openTemp(dir string) (*tempFile, error) {
+	f, err := os.OpenFile(dir, os.O_WRONLY|unix.O_TMPFILE, 0644)
+	if err != nil {
+		return nil, err
+	}
+	return &tempFile{
+		File: f,
+	}, nil
+}
+
+func (t *tempFile) Reopen() (*os.File, error) {
+	fd := int(t.Fd())
+	if fd == -1 {
+		return nil, errStale
+	}
+	p := fmt.Sprintf("/proc/self/fd/%d", fd)
+	// Need to use OpenFile so that the symlink is not dereferenced.
+	// There's some proc magic so that opening that symlink itself copies the
+	// description.
+	return os.OpenFile(p, os.O_RDONLY, 0644)
+}

--- a/libindex/tempfile_unix.go
+++ b/libindex/tempfile_unix.go
@@ -1,0 +1,30 @@
+//go:build unix && !linux
+
+package libindex
+
+import (
+	"errors"
+	"os"
+)
+
+type tempFile struct {
+	*os.File
+}
+
+func openTemp(dir string) (*tempFile, error) {
+	f, err := os.CreateTemp(dir, "*.fetch")
+	if err != nil {
+		return nil, err
+	}
+	return &tempFile{
+		File: f,
+	}, nil
+}
+
+func (t *tempFile) Reopen() (*os.File, error) {
+	return os.OpenFile(t.Name(), os.O_RDONLY, 0644)
+}
+
+func (t *tempFile) Close() error {
+	return errors.Join(os.Remove(t.Name()), t.File.Close())
+}

--- a/libindex/tempfile_windows.go
+++ b/libindex/tempfile_windows.go
@@ -1,0 +1,43 @@
+package libindex
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	_ "unsafe" // linker tricks
+)
+
+// This is a very rough port of src/os/tempfile.go that adds the magic
+// autodelete flag.
+
+//go:linkname fastrand runtime.fastrand
+func fastrand() uint32
+
+type tempFile struct {
+	*os.File
+}
+
+func openTemp(dir string) (*tempFile, error) {
+	// Copied out of golang.org/x/sys/windows
+	const FILE_FLAG_DELETE_ON_CLOSE = 0x04000000
+	for {
+		fn := fmt.Sprintf("fetch.%d", fastrand())
+		f, err := os.OpenFile(filepath.Join(dir, fn), os.O_WRONLY|FILE_FLAG_DELETE_ON_CLOSE, 0644)
+		switch {
+		case errors.Is(err, nil):
+			return &tempFile{
+				File: f,
+			}, nil
+		case errors.Is(err, fs.ErrExist):
+			// Continue
+		default:
+			return nil, err
+		}
+	}
+}
+
+func (t *tempFile) Reopen() (*os.File, error) {
+	return os.OpenFile(t.Name(), os.O_RDONLY, 0644)
+}


### PR DESCRIPTION
`O_TMPFILE` does not exist on non-linux unix-based OSes, so I was unable to build ClairCore on my macOS (Darwin) machine. Similarly, I don't think it exists on Windows, but `FILE_FLAG_DELETE_ON_CLOSE` does, which sounds to be about the same.

The implemented solution for Darwin runs into the issue `O_TMPFILE` aimed to fix: ClairCore crashing can still leave files on the system. Since this was previous behavior, I don't see this as a regression, necessarily.