### PR TITLE
tarfs: check a potential interger overflow

### DIFF
--- a/pkg/tarfs/parse.go
+++ b/pkg/tarfs/parse.go
@@ -185,7 +185,7 @@ func parseNumber(b []byte) (int64, error) {
 	if len(b) == 0 {
 		return 0, nil
 	}
-	n, err := strconv.ParseUint(cstring(b), 8, 64)
+	n, err := strconv.ParseUint(cstring(b), 8, 63) // Only positive int64 values allowed.
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
If the value is being loaded this way, it should only be up to 11 digits long and thus impossible to overflow an int64, but doing this way "proves" that.