### PR TITLE
enrichers: Load enrichments from jsonblob storage

### DIFF
--- a/libvuln/updates.go
+++ b/libvuln/updates.go
@@ -2,8 +2,10 @@ package libvuln
 
 import (
 	"context"
+	"fmt"
 	"io"
 
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/quay/zlog"
 
@@ -47,9 +49,16 @@ Update:
 				continue Update
 			}
 		}
-		ref, err := s.UpdateVulnerabilities(ctx, e.Updater, e.Fingerprint, e.Vuln)
-		if err != nil {
-			return err
+		var ref uuid.UUID
+		if e.Enrichment != nil {
+			if ref, err = s.UpdateEnrichments(ctx, e.Updater, e.Fingerprint, e.Enrichment); err != nil {
+				return fmt.Errorf("updating enrichements: %w", err)
+			}
+		}
+		if e.Vuln != nil {
+			if ref, err = s.UpdateVulnerabilities(ctx, e.Updater, e.Fingerprint, e.Vuln); err != nil {
+				return fmt.Errorf("updating vulnerabilities: %w", err)
+			}
 		}
 		zlog.Info(ctx).
 			Str("updater", e.Updater).

--- a/test/enrichment.go
+++ b/test/enrichment.go
@@ -1,0 +1,24 @@
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/quay/claircore/libvuln/driver"
+)
+
+// GenEnrichments creates an array of enrichment records, with no meaningful
+// content.
+func GenEnrichments(n int) []driver.EnrichmentRecord {
+	var rs []driver.EnrichmentRecord
+	for i := 0; i < n; i++ {
+		t := strconv.Itoa(i)
+		e := fmt.Sprintf(`{"%[1]d":{"id":%[1]d}}`, i)
+		rs = append(rs, driver.EnrichmentRecord{
+			Tags:       []string{t},
+			Enrichment: json.RawMessage(e),
+		})
+	}
+	return rs
+}


### PR DESCRIPTION
A patch to fix the following BUG:

https://github.com/quay/claircore/blob/faffb8e880263171ca9b54dc2f5609547e53cbb7/libvuln/jsonblob/jsonblob.go#L94-L96
