### PR TITLE
postgres: return empty map instead of nil

### DIFF
--- a/datastore/postgres/getupdateoperations.go
+++ b/datastore/postgres/getupdateoperations.go
@@ -270,7 +270,7 @@ func (s *MatcherStore) GetUpdateOperations(ctx context.Context, kind driver.Upda
 	switch {
 	case err == nil:
 	case errors.Is(err, pgx.ErrNoRows):
-		return nil, nil
+		return out, nil
 	default:
 		return nil, fmt.Errorf("failed to get distinct updates: %w", err)
 	}


### PR DESCRIPTION
All users of this function expect the returned map to be non-nil when the returned error is non-nil. Returning `nil, nil` causes a panic in `libvuln.OfflineImport`: https://github.com/quay/claircore/blob/v1.5.20/libvuln/updates.go#L40

There is already another line above this (line 230) which returns `out, nil` when `errors.Is(err, pgx.ErrNoRows)`. I guess the one that returned `nil, nil` was a mistake?

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x28b53dd]

goroutine 1 [running]:
github.com/quay/claircore/libvuln.OfflineImport({0x34f75e0?, 0xc0008782d0?}, 0xc00100b0e0, {0x34c55e0?, 0xc00048d000})
	github.com/quay/claircore@v1.5.21-0.20231211033403-8fd9a12427a0/libvuln/updates.go:40 +0x25d
github.com/stackrox/rox/scanner/matcher/updater.(*Updater).Update(0xc0010c0e40, {0x34f7688?, 0xc0010c6270?})
	github.com/stackrox/rox/scanner/matcher/updater/updater.go:192 +0x42a
github.com/stackrox/rox/scanner/matcher.NewMatcher({0x34f7688?, 0xc000132ed0?}, {{{0xc0000d0370, 0xa8}, {0xc000cd05d0, 0x2c}}, 0x1, {0x0, 0x0}, 0x0})
	github.com/stackrox/rox/scanner/matcher/matcher.go:87 +0x5a5
main.createBackends({0x34f7688, 0xc000132ed0}, 0xc000be20b0)
	github.com/stackrox/rox/scanner/cmd/scanner/main.go:190 +0x347
main.main()
	github.com/stackrox/rox/scanner/cmd/scanner/main.go:80 +0x665
```