### PR TITLE
claircore: fix `Layer` finalizer

### DIFF
--- a/dpkg/scanner_test.go
+++ b/dpkg/scanner_test.go
@@ -847,6 +847,11 @@ func TestExtraMetadata(t *testing.T) {
 	if err := l.Init(ctx, &test.AnyDescription, f); err != nil {
 		t.Error(err)
 	}
+	t.Cleanup(func() {
+		if err := l.Close(); err != nil {
+			t.Error(err)
+		}
+	})
 
 	ps, err := s.Scan(ctx, &l)
 	if err != nil {

--- a/libindex/fetcher.go
+++ b/libindex/fetcher.go
@@ -188,12 +188,10 @@ func (a *RemoteFetchArena) fetchInto(ctx context.Context, l *claircore.Layer, cl
 			return err
 		}
 		if err := l.Init(ctx, desc, f); err != nil {
-			f.Close()
-			r.Close()
-			return err
+			return errors.Join(err, f.Close(), r.Close())
 		}
 		*cl = closeFunc(func() error {
-			return errors.Join(f.Close(), r.Close())
+			return errors.Join(l.Close(), f.Close(), r.Close())
 		})
 		return nil
 	}

--- a/python/packagescanner_test.go
+++ b/python/packagescanner_test.go
@@ -118,6 +118,11 @@ func TestScanLocal(t *testing.T) {
 			if err := l.Init(ctx, &desc, f); err != nil {
 				t.Fatal(err)
 			}
+			t.Cleanup(func() {
+				if err := l.Close(); err != nil {
+					t.Error(err)
+				}
+			})
 
 			got, err := scanner.Scan(ctx, &l)
 			if err != nil {

--- a/rhel/repositoryscanner_test.go
+++ b/rhel/repositoryscanner_test.go
@@ -131,6 +131,11 @@ func TestRepositoryScanner(t *testing.T) {
 			if err := l.Init(ctx, &desc, f); err != nil {
 				t.Fatal(err)
 			}
+			t.Cleanup(func() {
+				if err := l.Close(); err != nil {
+					t.Error(err)
+				}
+			})
 
 			if tt.cfg != nil {
 				var buf bytes.Buffer

--- a/rpm/packagescanner_test.go
+++ b/rpm/packagescanner_test.go
@@ -137,15 +137,21 @@ func TestLayer(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer func() {
+			t.Cleanup(func() {
 				if err := f.Close(); err != nil {
 					t.Error(err)
 				}
-			}()
+			})
 			var l claircore.Layer
 			if err := l.Init(ctx, &desc, f); err != nil {
 				t.Fatal(err)
 			}
+			t.Cleanup(func() {
+				if err := l.Close(); err != nil {
+					t.Error(err)
+				}
+			})
+
 			got, err := s.Scan(ctx, &l)
 			if err != nil {
 				t.Error(err)

--- a/test/fetcher.go
+++ b/test/fetcher.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -90,6 +91,7 @@ func (a *CachedArena) Close(_ context.Context) error {
 type CachedRealizer struct {
 	remote string
 	local  string
+	layers []claircore.Layer
 }
 
 var (
@@ -147,6 +149,7 @@ func (r *CachedRealizer) RealizeDescriptions(ctx context.Context, descs []clairc
 	}
 
 	success = true
+	r.layers = out
 	return out, nil
 }
 
@@ -163,5 +166,9 @@ func (r *CachedRealizer) Realize(ctx context.Context, ls []*claircore.Layer) err
 
 // Close implements [indexer.Realizer] and [indexer.DescriptionRealizer].
 func (r *CachedRealizer) Close() error {
-	return nil
+	errs := make([]error, len(r.layers))
+	for i := range r.layers {
+		errs[i] = r.layers[i].Close()
+	}
+	return errors.Join(errs...)
 }


### PR DESCRIPTION
@RTann reported some unexpected memory usage, which led to figuring out that this finalizer doesn't work as intended.

This fixes the finalizer, then fixes the issues reported by the subsequent panics.