### PR TITLE
java: grow buffers to the right capacity before use

### DIFF
--- a/java/jar/jar.go
+++ b/java/jar/jar.go
@@ -275,6 +275,7 @@ func extractInner(ctx context.Context, p srcPath, z *zip.Reader) ([]Info, error)
 		}
 		defer rc.Close()
 		buf.Reset()
+		buf.Grow(int(fi.Size()))
 		h.Reset()
 		sz, err := buf.ReadFrom(io.TeeReader(rc, h))
 		if err != nil {

--- a/java/packagescanner.go
+++ b/java/packagescanner.go
@@ -147,6 +147,10 @@ func (s *Scanner) Scan(ctx context.Context, layer *claircore.Layer) ([]*claircor
 		if err != nil {
 			return nil, err
 		}
+		fStat, err := f.Stat()
+		if err == nil {
+			buf.Grow(int(fStat.Size()))
+		}
 		sz, err := buf.ReadFrom(io.TeeReader(f, sh))
 		f.Close()
 		if err != nil {


### PR DESCRIPTION
Avoids reallocations when buffers grow repeatedly for large files, and oversizing (as buffer capacity doubles when capacity is reached).

When indexing an unusually large image we've seen, that has deeply nested jars, this reduces peak process size from 18.9Gb to 11.1Gb.

---

The jar spec says nested jars must be "stored" (not compressed) in the outer jar, so in principal the parsing of nested jars could re-use sections of the outer file's buffer, greatly reducing memory use ... but those changes would be much more intrusive so I don't know if you'd want to go that way.