### PR TITLE
ruby: enable matcher by default

### DIFF
--- a/matchers/defaults/defaults.go
+++ b/matchers/defaults/defaults.go
@@ -18,6 +18,7 @@ import (
 	"github.com/quay/claircore/python"
 	"github.com/quay/claircore/rhel"
 	"github.com/quay/claircore/rhel/rhcc"
+	"github.com/quay/claircore/ruby"
 	"github.com/quay/claircore/suse"
 	"github.com/quay/claircore/ubuntu"
 )
@@ -53,6 +54,7 @@ var defaultMatchers = []driver.Matcher{
 	&python.Matcher{},
 	rhcc.Matcher,
 	&rhel.Matcher{},
+	&ruby.Matcher{},
 	&suse.Matcher{},
 	&ubuntu.Matcher{},
 }

--- a/ruby/matcher.go
+++ b/ruby/matcher.go
@@ -18,7 +18,7 @@ var _ driver.Matcher = (*Matcher)(nil)
 type Matcher struct{}
 
 // Name implements driver.Matcher.
-func (*Matcher) Name() string { return "ruby" }
+func (*Matcher) Name() string { return "ruby-gem" }
 
 // Filter implements driver.Matcher.
 func (*Matcher) Filter(record *claircore.IndexRecord) bool {


### PR DESCRIPTION
Just realized this isn't enabled by default. After https://github.com/quay/claircore/pull/1125 was merged, I think (hope) the matcher is ready to be turned on by default.