### PR TITLE
rhel: explicit RHEL Atomic Host support

### DIFF
--- a/rhel/distributionscanner.go
+++ b/rhel/distributionscanner.go
@@ -19,7 +19,7 @@ var (
 	_ indexer.DistributionScanner = (*DistributionScanner)(nil)
 	_ indexer.VersionedScanner    = (*DistributionScanner)(nil)
 
-	releaseRegexp = regexp.MustCompile(`Red Hat Enterprise Linux (?:Server)?\s*(?:release)?\s*(\d+)(?:\.\d)?`)
+	releaseRegexp = regexp.MustCompile(`Red Hat Enterprise Linux (?:Server|Atomic Host)?\s*(?:release)?\s*(\d+)(?:\.\d)?`)
 )
 
 // DistributionScanner implements distribution detection logic for RHEL by looking for

--- a/rhel/distributionscanner_test.go
+++ b/rhel/distributionscanner_test.go
@@ -4,6 +4,7 @@ import (
 	"io/fs"
 	"os"
 	"path"
+	"strings"
 	"testing"
 )
 
@@ -27,7 +28,7 @@ func TestDistributionScanner(t *testing.T) {
 			if d == nil {
 				t.Fatal("missing distribution")
 			}
-			if got, want := d.Version, n; got != want {
+			if got, want := d.Version, strings.TrimPrefix(n, "atomichost-"); got != want {
 				t.Errorf("got: %q, want %q", got, want)
 			}
 		})

--- a/rhel/testdata/releasefiles/atomichost-7/etc/os-release
+++ b/rhel/testdata/releasefiles/atomichost-7/etc/os-release
@@ -1,0 +1,1 @@
+../usr/lib/os-release

--- a/rhel/testdata/releasefiles/atomichost-7/etc/redhat-release
+++ b/rhel/testdata/releasefiles/atomichost-7/etc/redhat-release
@@ -1,0 +1,1 @@
+../usr/lib/redhat-release

--- a/rhel/testdata/releasefiles/atomichost-7/usr/lib/os-release
+++ b/rhel/testdata/releasefiles/atomichost-7/usr/lib/os-release
@@ -1,0 +1,17 @@
+NAME="Red Hat Enterprise Linux Atomic Host"
+VERSION="7.9"
+ID="rhel"
+ID_LIKE="fedora"
+VARIANT="Atomic Host"
+VARIANT_ID=atomic.host
+VERSION_ID="7.9"
+PRETTY_NAME="Red Hat Enterprise Linux Atomic Host 7.9"
+ANSI_COLOR="0;31"
+CPE_NAME="cpe:/o:redhat:enterprise_linux:7.9:GA:atomic-host"
+HOME_URL="https://www.redhat.com/"
+BUG_REPORT_URL="https://bugzilla.redhat.com/"
+
+REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 7"
+REDHAT_BUGZILLA_PRODUCT_VERSION="7.9"
+REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
+REDHAT_SUPPORT_PRODUCT_VERSION="7.9"

--- a/rhel/testdata/releasefiles/atomichost-7/usr/lib/redhat-release
+++ b/rhel/testdata/releasefiles/atomichost-7/usr/lib/redhat-release
@@ -1,0 +1,1 @@
+Red Hat Enterprise Linux Atomic Host release 7.9


### PR DESCRIPTION
Without the updated regex, ClairCore did correctly detect `rhel:7` for this scenario, but it seemed more due to luck from thei line in the `os-release`: `REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 7"`

This change make the support explicit