### PR TITLE
fix OSV matching algorithms

### DIFF
--- a/java/matcher_test.go
+++ b/java/matcher_test.go
@@ -164,6 +164,27 @@ func TestVulnerable(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "pkg7",
+			record: &claircore.IndexRecord{
+				Package: &claircore.Package{
+					Name:    "org.apache.tiles:tiles-core",
+					Version: "3.0.7",
+					Kind:    "binary",
+				},
+			},
+			vuln: &claircore.Vulnerability{
+				Updater:     "osv",
+				Name:        "GHSA-qw4h-3xjj-84cc",
+				Description: "Go look it up: https://osv.dev/vulnerability/GHSA-qw4h-3xjj-84cc",
+				Package: &claircore.Package{
+					Name:           "org.apache.tiles:tiles-core",
+					RepositoryHint: "Maven",
+				},
+				FixedInVersion: "introduced=2.0.0",
+			},
+			want: true,
+		},
 	}
 
 	for _, testcase := range testcases {

--- a/ruby/matcher_test.go
+++ b/ruby/matcher_test.go
@@ -143,6 +143,27 @@ func TestVulnerable(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "dependabot-omnibus no upper bound",
+			record: &claircore.IndexRecord{
+				Package: &claircore.Package{
+					Name:    "dependabot-omnibus",
+					Version: "0.119.0",
+					Kind:    "binary",
+				},
+			},
+			vuln: &claircore.Vulnerability{
+				Updater:     "osv",
+				Name:        "GHSA-23f7-99jx-m54r",
+				Description: "Remote code execution in dependabot-core branch names when cloning",
+				Package: &claircore.Package{
+					Name:           "dependabot-omnibus",
+					RepositoryHint: "rubygems",
+				},
+				FixedInVersion: "introduced=0.119.0-beta1",
+			},
+			want: true,
+		},
 	}
 
 	for _, testcase := range testcases {


### PR DESCRIPTION
GHSA-qw4h-3xjj-84cc showed that `fixed` and `last_affected` are not required. See https://ossf.github.io/osv-schema/#requirements and https://ossf.github.io/osv-schema/#unfixed-vulnerability-example to see it is valid for neither one to exist in an entry.

This change accounts for this and updates the 'vulnerable' algorithm as follows:

1. Parse the `IndexRecord`'s version. If we cannot parse this, we cannot correctly know if it's vulnerable to anything
2. Compare the `IndexRecord` to the `introduced` version, if it exists
3. Compare the `IndexRecord` to the `fixed` version, if it exists
4. Compare the `IndexRecord` to the `last_affected` version, if it exists
5. Default to claim the package is vulnerable. This may introduce false positives/noise, but this may be unlikely enough to be ok so users can at least verify this on their end. This is the chosen default, as we cannot prove the package is not vulnerable.