### PR TITLE
rhel-updater: improve error messages

### DIFF
--- a/rhel/internal/common/updater.go
+++ b/rhel/internal/common/updater.go
@@ -96,12 +96,12 @@ func (u *Updater) Fetch(ctx context.Context, c *http.Client) error {
 			Msg("response not modified; no update necessary")
 		return nil
 	default:
-		return fmt.Errorf("received status code %q querying mapping url", resp.StatusCode)
+		return fmt.Errorf("received status code %d querying mapping url", resp.StatusCode)
 	}
 
 	v := reflect.New(u.typ).Interface()
 	if err := json.NewDecoder(resp.Body).Decode(v); err != nil {
-		return fmt.Errorf("failed to decode mapping file: %v", err)
+		return fmt.Errorf("failed to decode mapping file: %w", err)
 	}
 
 	u.mu.Lock()


### PR DESCRIPTION
I was testing something and saw the following:

```
{"level":"error","host":"scanner-v4-indexer-69c646f78f-n9fvh","component":"rhel/internal/common/Updater.Get","error":"received status code 'ƥ' querying mapping url","time":"2024-01-20T22:51:22Z","message":"error updating mapping file"}
```

I think it'd be more useful to see the number rather than the decoded value.

Also, I noticed a usage of `%v` with `fmt.Errorf`, and I believe `%w` is preferred, so I included that, too