### PR TITLE
rhel, rhcc: add transparent decompression of sideband data

### DIFF
--- a/internal/zreader/zreader.go
+++ b/internal/zreader/zreader.go
@@ -174,9 +174,9 @@ func detect(r io.Reader) (io.ReadCloser, Compression, error) {
 	case errors.Is(err, nil):
 	case errors.Is(err, io.ErrNoProgress):
 		return io.NopCloser(br), KindNone, nil
-	case errors.Is(err, io.ErrUnexpectedEOF), errors.Is(err, io.EOF):
+	case errors.Is(err, io.EOF):
 		// Not enough bytes, just return a reader containing the bytes.
-		return io.NopCloser(bytes.NewReader(b)), KindNone, err
+		return io.NopCloser(bytes.NewReader(b)), KindNone, nil
 	default:
 		return nil, KindNone, err
 	}

--- a/internal/zreader/zreader_test.go
+++ b/internal/zreader/zreader_test.go
@@ -1,0 +1,137 @@
+package zreader
+
+import (
+	"bytes"
+	"io"
+	"math/rand"
+	"reflect"
+	"testing"
+	"testing/quick"
+
+	"github.com/klauspost/compress/gzip"
+	"github.com/klauspost/compress/zlib"
+	"github.com/klauspost/compress/zstd"
+)
+
+// There's no encoder in the stdlib or github.com/klauspost/compress for bzip2, so no testing for it.
+//
+// It should be fine, as it's using all the same logic but with a different byte string.
+
+var testcases = []struct {
+	Kind   Compression
+	Values func([]reflect.Value, *rand.Rand)
+}{
+	{KindNone, blobUncompressed},
+	{KindGzip, blobGzip},
+	{KindZstd, blobZstd},
+	{KindZlib, blobZlib},
+}
+
+func TestDetect(t *testing.T) {
+	t.Parallel()
+	wantKind := func(k Compression) func(_, _ *bytes.Buffer) bool {
+		return func(_, z *bytes.Buffer) bool {
+			_, d, err := Detect(z)
+			if err != nil {
+				panic(err)
+			}
+			return d == k
+		}
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.Kind.String(), func(t *testing.T) {
+			if err := quick.Check(wantKind(tc.Kind), &quick.Config{Values: tc.Values}); err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}
+
+func TestRead(t *testing.T) {
+	t.Parallel()
+	check := func(k Compression) func(_, _ *bytes.Buffer) bool {
+		return func(want, z *bytes.Buffer) bool {
+			r, err := Reader(z)
+			if err != nil {
+				panic(err)
+			}
+			var got bytes.Buffer
+			got.Grow(want.Len())
+			if _, err := io.Copy(&got, r); err != nil {
+				panic(err)
+			}
+			if err := r.Close(); err != nil {
+				panic(err)
+			}
+			return bytes.Equal(got.Bytes(), want.Bytes())
+		}
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.Kind.String(), func(t *testing.T) {
+			if err := quick.Check(check(tc.Kind), &quick.Config{Values: tc.Values}); err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}
+
+func TestShortRead(t *testing.T) {
+	want := []byte("\xFF\xFF")
+	z, d, err := Detect(bytes.NewReader(want))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer z.Close()
+	if got, want := d, KindNone; got != want {
+		t.Errorf("wrong compression? got: %v, want %v", got, want)
+	}
+	got, err := io.ReadAll(z)
+	if err != nil {
+		t.Errorf("read error: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("bad roundtrip:\n%v\n%v", got, want)
+	}
+}
+
+func makeBlobs[W io.WriteCloser](mk func(io.Writer) W) func([]reflect.Value, *rand.Rand) {
+	const blobSize = 4096
+	return func(vs []reflect.Value, rng *rand.Rand) {
+		var orig, z bytes.Buffer
+
+		wc := mk(&z)
+		rd := io.LimitReader(rng, blobSize)
+		if _, err := orig.ReadFrom(io.TeeReader(rd, wc)); err != nil {
+			panic(err)
+		}
+		if err := wc.Close(); err != nil {
+			panic(err)
+		}
+
+		vs[0] = reflect.ValueOf(&orig)
+		vs[1] = reflect.ValueOf(&z)
+	}
+}
+
+var blobGzip = makeBlobs(gzip.NewWriter)
+var blobZlib = makeBlobs(zlib.NewWriter)
+var blobZstd = makeBlobs(func(w io.Writer) *zstd.Encoder {
+	z, err := zstd.NewWriter(w)
+	if err != nil {
+		panic(err)
+	}
+	return z
+})
+
+var blobUncompressed = makeBlobs(func(w io.Writer) io.WriteCloser {
+	r := struct {
+		io.Writer
+		io.Closer
+	}{
+		Writer: w,
+		Closer: io.NopCloser(nil),
+	}
+	return &r
+})

--- a/rhel/repositoryscanner.go
+++ b/rhel/repositoryscanner.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/indexer"
+	"github.com/quay/claircore/internal/zreader"
 	"github.com/quay/claircore/rhel/dockerfile"
 	"github.com/quay/claircore/rhel/internal/common"
 	"github.com/quay/claircore/rhel/internal/containerapi"
@@ -143,8 +144,13 @@ func (r *RepositoryScanner) Configure(ctx context.Context, f indexer.ConfigDeser
 			return err
 		}
 		defer f.Close()
+		z, err := zreader.Reader(f)
+		if err != nil {
+			return err
+		}
+		defer z.Close()
 		mf = &mappingFile{}
-		if err := json.NewDecoder(f).Decode(mf); err != nil {
+		if err := json.NewDecoder(z).Decode(mf); err != nil {
 			return err
 		}
 	}

--- a/rhel/rhcc/scanner.go
+++ b/rhel/rhcc/scanner.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/indexer"
+	"github.com/quay/claircore/internal/zreader"
 	"github.com/quay/claircore/pkg/rhctag"
 	"github.com/quay/claircore/rhel/dockerfile"
 	"github.com/quay/claircore/rhel/internal/common"
@@ -82,8 +83,13 @@ func (s *scanner) Configure(ctx context.Context, f indexer.ConfigDeserializer, c
 			return err
 		}
 		defer f.Close()
+		z, err := zreader.Reader(f)
+		if err != nil {
+			return err
+		}
+		defer z.Close()
 		mf = &mappingFile{}
-		if err := json.NewDecoder(f).Decode(mf); err != nil {
+		if err := json.NewDecoder(z).Decode(mf); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This should allow the data to fit in a k8s ConfigMap, for at least a little while longer.

```
% for z in bzip2 gzip zstd; do command $z -k *.json; done
% du -sh *.json*
100K    container-name-repos-map.json
12K     container-name-repos-map.json.bz2
16K     container-name-repos-map.json.gz
16K     container-name-repos-map.json.zst
2.0M    repository-to-cpe.json
60K     repository-to-cpe.json.bz2
96K     repository-to-cpe.json.gz
108K    repository-to-cpe.json.zst
```