### PR TITLE
zreader: remove zlib support

### DIFF
--- a/internal/zreader/compression_string.go
+++ b/internal/zreader/compression_string.go
@@ -11,13 +11,12 @@ func _() {
 	_ = x[KindGzip-0]
 	_ = x[KindZstd-1]
 	_ = x[KindBzip2-2]
-	_ = x[KindZlib-3]
-	_ = x[KindNone-4]
+	_ = x[KindNone-3]
 }
 
-const _Compression_name = "KindGzipKindZstdKindBzip2KindZlibKindNone"
+const _Compression_name = "KindGzipKindZstdKindBzip2KindNone"
 
-var _Compression_index = [...]uint8{0, 8, 16, 25, 33, 41}
+var _Compression_index = [...]uint8{0, 8, 16, 25, 33}
 
 func (i Compression) String() string {
 	if i < 0 || i >= Compression(len(_Compression_index)-1) {


### PR DESCRIPTION
Noticed on #1213 that the zreader test was failing. I was able to reproduce reliably by just upping the number of test runs.

Ultimately, the zlib header is just 2 bytes and not sufficiently unique enough to get the autodetection to work. Currently we don't consume anything that's "bare" zlib (outside of HTTP requests, which are handled by `net/http` transparently), so I think it's fine to just drop it.

We never hit a problem in the fetcher because gzip and uncompressed tars have a sufficiently different header from the zlib header that it doesn't trip.