### PR TITLE
osv: set FixedInVersion for SEMVER ecosystems

### DIFF
--- a/nodejs/matcher_integration_test.go
+++ b/nodejs/matcher_integration_test.go
@@ -90,6 +90,16 @@ func TestMatcherIntegration(t *testing.T) {
 	t.Logf("Number of Vulnerabilities found: %d", len(vulns))
 
 	if len(vulns) < 2 {
-		t.Fatalf("failed to match vulns: %v", err)
+		t.Fatal("failed to match vulns")
+	}
+
+	var hasFixed bool
+	for _, v := range vulns {
+		if v.FixedInVersion != "" {
+			hasFixed = true
+		}
+	}
+	if !hasFixed {
+		t.Fatalf("failed to find a fixed vuln")
 	}
 }

--- a/updater/osv/osv.go
+++ b/updater/osv/osv.go
@@ -557,6 +557,7 @@ func (e *ecs) Insert(ctx context.Context, skipped *stats, name string, a *adviso
 						ver, err = semver.NewVersion(ev.Fixed)
 						if err == nil {
 							v.Range.Upper = claircore.FromSemver(ver)
+							v.FixedInVersion = ver.Original()
 						}
 					case ev.LastAffected != "" && len(af.Versions) != 0: // less than equal to
 						// TODO(hank) Should be able to convert this to a "less than."


### PR DESCRIPTION
For example, when looking at Go vulnerabilities, ClairCore does not specify any vulnerabilities are fixed. Only affected or not, essentially. This change includes `FixedByVersion`, when available.

