### PR TITLE
libvuln: log offline enrichment count

### DIFF
--- a/libvuln/updates.go
+++ b/libvuln/updates.go
@@ -63,7 +63,8 @@ Update:
 		zlog.Info(ctx).
 			Str("updater", e.Updater).
 			Str("ref", ref.String()).
-			Int("count", len(e.Vuln)).
+			Int("vuln_count", len(e.Vuln)).
+			Int("enrichment_count", len(e.Enrichment)).
 			Msg("update imported")
 	}
 	if err := l.Err(); err != nil {


### PR DESCRIPTION
We have our own enricher running, and I got scared when I saw this log:

```
{"level":"info","host":"scanner-v4-matcher-dcff5f5cf-bl77v","component":"libvuln/OfflineImporter","updater":"nvd","ref":"5810c28c-e902-4529-b0a2-f7108ac78cf0","count":0,"time":"2024-02-01T17:44:46Z","message":"update imported"}
```

I realized this is just the vuln count and not the enrichment count, hence this PR