### PR TITLE
osv: remove superfluous println from test

### DIFF
--- a/updater/osv/osv_test.go
+++ b/updater/osv/osv_test.go
@@ -47,7 +47,6 @@ func TestFetch(t *testing.T) {
 	}
 
 	for _, u := range s.Updaters() {
-		fmt.Println(u.Name())
 		rc, fp, err := u.Fetch(ctx, driver.Fingerprint(""))
 		if err != nil {
 			t.Error(err)


### PR DESCRIPTION
Delete a remnant that lifts sordid veil on author's debugging practices.