### PR TITLE
periodic: tweak search pattern

### DIFF
--- a/test/periodic/rpm_test.go
+++ b/test/periodic/rpm_test.go
@@ -44,7 +44,7 @@ func TestRPMSpotCheck(t *testing.T) {
 			"redhat_client": {"claircore-tests"},
 			"fq": {
 				`documentKind:"ContainerRepository"`,
-				`-release_catagories:"Deprecated"`,
+				`-eol_date:[* TO NOW]`,
 			},
 			"fl":   {"id,repository,registry,parsed_data_layers"},
 			"rows": {"500"},


### PR DESCRIPTION
Using `eol_date` seems to work better than trying to filter on `release_categories`. Solr searching on lists seems to not work right.

Closes: #1249