### PR TITLE
ndb: bound slots data read to avoid over-reading

### DIFF
--- a/rpm/ndb/package.go
+++ b/rpm/ndb/package.go
@@ -42,7 +42,7 @@ func (db *PackageDB) Parse(r io.ReaderAt) error {
 	db.slot = make([]pkgSlot, 0, lastIndex)
 	b = b[:slotSize]
 	// Read every populated slot (these should be contiguous) and populate the lookup table.
-	for off := int64(slotStart * slotSize); ; off += slotSize {
+	for off := int64(slotStart * slotSize); off < int64(db.NPages*pageSz); off += slotSize {
 		if _, err := r.ReadAt(b, off); err != nil {
 			return fmt.Errorf("ndb: package: unable to read slot @%d: %w", off, err)
 		}

--- a/rpm/ndb/package_test.go
+++ b/rpm/ndb/package_test.go
@@ -28,13 +28,14 @@ func TestLoadPackage(t *testing.T) {
 				t.Fatal(err)
 			}
 			pkgf := bytes.NewReader(b)
+
 			var pkg PackageDB
 			if err := pkg.Parse(pkgf); err != nil {
-				t.Fatal(err)
+				t.Fatal("error parsing Packages file", err)
 			}
 			rds, err := pkg.AllHeaders(ctx)
 			if err != nil {
-				t.Fatal(err)
+				t.Fatal("error getting AllHeaders", err)
 			}
 			for _, rd := range rds {
 				var h rpm.Header


### PR DESCRIPTION
We error on some ndb files due to reading too many bytes and bleeding into the blob data (BlbS). This change bounds the data read to num slots * slots per page.