### PR TITLE
gobin: allow for empty version segment strings

### DIFF
--- a/gobin/exe.go
+++ b/gobin/exe.go
@@ -60,7 +60,7 @@ func toPackages(ctx context.Context, out *[]*claircore.Package, p string, r io.R
 	case errors.Is(err, ErrInvalidSemVer):
 		badVers["stdlib"] = bi.GoVersion
 	default:
-		return err
+		return fmt.Errorf("error parsing runtime version: %q: %w", bi.GoVersion, err)
 	}
 
 	*out = append(*out, &claircore.Package{
@@ -116,7 +116,7 @@ func toPackages(ctx context.Context, out *[]*claircore.Package, p string, r io.R
 		badVers[bi.Main.Path] = bi.Main.Version
 		mmv = bi.Main.Version
 	default:
-		return err
+		return fmt.Errorf("error parsing main version: %q: %w", bi.Main.Version, err)
 	}
 
 	// This substitution makes the results look like `go version -m` output.
@@ -148,7 +148,7 @@ func toPackages(ctx context.Context, out *[]*claircore.Package, p string, r io.R
 		case errors.Is(err, ErrInvalidSemVer):
 			badVers[d.Path] = d.Version
 		default:
-			return err
+			return fmt.Errorf("error parsing dep version: %q: %w", d.Version, err)
 		}
 
 		*out = append(*out, &claircore.Package{
@@ -201,6 +201,9 @@ func fitInt32(seg string) (int32, error) {
 		// Slicing here to avoid any big.Int allocations at the expense of a little
 		// more accuracy.
 		seg = seg[:9]
+	}
+	if seg == "" {
+		return 0, nil
 	}
 	i, err := strconv.ParseInt(seg, 10, 32)
 	if err != nil {

--- a/gobin/exe_test.go
+++ b/gobin/exe_test.go
@@ -77,6 +77,14 @@ var versionTestcases = []struct {
 			V:    [...]int32{0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 		},
 	},
+	{
+		name:      "missing patch",
+		versionIn: `1.18`,
+		want: claircore.Version{
+			Kind: "semver",
+			V:    [...]int32{0, 1, 18, 0, 0, 0, 0, 0, 0, 0},
+		},
+	},
 }
 
 func TestParseVersion(t *testing.T) {


### PR DESCRIPTION
This error gets surfaced when the version is in the form 1.18. We see this in production due to the runtime version being sometimes reported as go1.18 (`go` is trimmed before the version conversion). Addition error context added for easier debugging.