### PR TITLE
gobin: test +incompatible version

### DIFF
--- a/gobin/exe_test.go
+++ b/gobin/exe_test.go
@@ -85,6 +85,14 @@ var versionTestcases = []struct {
 			V:    [...]int32{0, 1, 18, 0, 0, 0, 0, 0, 0, 0},
 		},
 	},
+	{
+		name:      "incompatible",
+		versionIn: "v24.0.7+incompatible",
+		want: claircore.Version{
+			Kind: "semver",
+			V:    [...]int32{0, 24, 0, 7, 0, 0, 0, 0, 0, 0},
+		},
+	},
 }
 
 func TestParseVersion(t *testing.T) {


### PR DESCRIPTION
Just adding this here so it's clear how ClairCore handles this case