### PR TITLE
chore: add go1.22 to CI, update to go1.21

### DIFF
--- a/.github/scripts/get-latest-golang-minor-version.sh
+++ b/.github/scripts/get-latest-golang-minor-version.sh
@@ -1,26 +1,17 @@
 #!/bin/sh
 MAJOR_VERSION=${1?missing required argument: language version}
-CHECK_VERSION=$MAJOR_VERSION
-CHECK_MINOR_VERSION=0
 
-while true; do
-    URL=https://dl.google.com/go/go${CHECK_VERSION}.linux-amd64.tar.gz
-	code=$(curl -I -o /dev/null -s -w "%{http_code}\n" "$URL")
-	printf '%s\t%d\n' "$URL" "$code" >&2
-	case "$code" in
-	200)
-		OK="$CHECK_VERSION"
-		CHECK_VERSION=${MAJOR_VERSION}.$((CHECK_MINOR_VERSION+=1))
-		;;
-	*)
-		# Account for version scheme change. See issue #991.
-		if test -z "$(echo "${CHECK_VERSION}" | cut -d . -f 3 2>/dev/null)"; then
-			CHECK_VERSION=${MAJOR_VERSION}.${CHECK_MINOR_VERSION}
-			continue
-		fi
-		test -z "$OK" && exit 99
-		echo "$OK"
-		exit 0
-		;;
-	esac
-done
+curl -sSfL 'https://golang.org/dl/?mode=json&include=all' |
+jq -r --arg 'v' "$MAJOR_VERSION" '[
+	.[] |
+	.version |
+	select(
+		[
+			contains("go\($v)"),
+			(contains("rc") | not)
+		] |
+		all
+	) |
+	ltrimstr("go")
+] |
+first'

--- a/.github/workflows/golang-image.yml
+++ b/.github/workflows/golang-image.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.18', '1.19', '1.20', '1.21']
+        go: ['1.18', '1.19', '1.20', '1.21', '1.22']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
         if: ${{ !cancelled() && steps.checkout.conclusion == 'success' }}
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ fromJSON(needs.config.outputs.go_versions)[0] }}
+          go-version-file: ./go.mod
       - name: Go Tidy
         if: ${{ !cancelled() && steps.checkout.conclusion == 'success' && steps.setupgo.conclusion == 'success' }}
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - id: config
         run: |
-          echo 'go_versions=["1.21","1.20"]' >> $GITHUB_OUTPUT
+          echo 'go_versions=["1.22","1.21"]' >> $GITHUB_OUTPUT
 
   gating-lints:
     needs: ['config']

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,17 +10,7 @@ on:
       - "**"
 
 jobs:
-  config:
-    runs-on: ubuntu-latest
-    outputs:
-      go_versions: ${{ steps.config.outputs.go_versions }}
-    steps:
-      - id: config
-        run: |
-          echo 'go_versions=["1.22","1.21"]' >> $GITHUB_OUTPUT
-
   gating-lints:
-    needs: ['config']
     name: Gating Lints
     runs-on: ubuntu-latest
     steps:
@@ -73,13 +63,14 @@ jobs:
         run: mdbook build
 
   tests:
-    needs: ['config']
     name: Tests
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        go: ${{ fromJSON(needs.config.outputs.go_versions) }}
+        go:
+          - '1.22'
+          - '1.21'
     steps:
       - name: Check for Previous Run
         id: previous
@@ -123,7 +114,7 @@ jobs:
         if: >-
           steps.previous.outputs.cache-hit != 'true' &&
           success() &&
-          fromJSON(needs.config.outputs.go_versions)[0] == matrix.go
+          strategy.job-index == 0
         uses: codecov/codecov-action@v4
         with:
           directory: ${{ runner.temp }}

--- a/.github/workflows/updater-check.yml
+++ b/.github/workflows/updater-check.yml
@@ -15,5 +15,5 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           check-latest: true
-          go-version: '>=1.20'
+          go-version-file: ./go.mod
       - run: go test ./test/periodic -enable

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/quay/claircore
 
-go 1.20
+go 1.21.8
 
 require (
 	github.com/Masterminds/semver v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,7 @@ github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/pprof v0.0.0-20221118152302-e6195bd50e26 h1:Xim43kblpZXfIBQsbuBVKCudVG457BR2GZFIz3uw3hQ=
+github.com/google/pprof v0.0.0-20221118152302-e6195bd50e26/go.mod h1:dDKJzRmX4S37WGHujM7tX//fmj1uioxKzKxz3lo4HJo=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -131,6 +132,7 @@ github.com/mattn/go-isatty v0.0.16 h1:bq3VjFmv/sOjHtdEhmkEV4x1AJtvUvOJ2PFAZ5+peK
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-sqlite3 v1.10.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
+github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/ncruces/go-strftime v0.1.9 h1:bY0MQC28UADQmHmaF5dgpLmImcShSi2kHU9XLdhx/f4=
 github.com/ncruces/go-strftime v0.1.9/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -180,6 +182,7 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/ulikunitz/xz v0.5.11 h1:kpFauv27b6ynzBNT/Xy+1k+fK4WswhN/6PN5WhFAGw8=
 github.com/ulikunitz/xz v0.5.11/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
@@ -291,8 +294,10 @@ gopkg.in/inconshreveable/log15.v2 v2.0.0-20180818164646-67afb5ed74ec/go.mod h1:a
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 modernc.org/fileutil v1.3.0 h1:gQ5SIzK3H9kdfai/5x41oQiKValumqNTDXMvKo62HvE=
+modernc.org/fileutil v1.3.0/go.mod h1:XatxS8fZi3pS8/hKG2GH/ArUogfxjpEKs3Ku3aK4JyQ=
 modernc.org/gc/v3 v3.0.0-20240107210532-573471604cb6 h1:5D53IMaUuA5InSeMu9eJtlQXS2NxAhyWQvkKEgXZhHI=
 modernc.org/gc/v3 v3.0.0-20240107210532-573471604cb6/go.mod h1:Qz0X07sNOR1jWYCrJMEnbW/X55x206Q7Vt4mz6/wHp4=
 modernc.org/libc v1.41.0 h1:g9YAc6BkKlgORsUWj+JwqoB1wU3o4DE3bM3yvA3k+Gk=

--- a/go.sum
+++ b/go.sum
@@ -38,7 +38,6 @@ github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
@@ -148,7 +147,6 @@ github.com/prometheus/common v0.48.0 h1:QO8U2CdOzSn1BBsmXJXduaaW+dY/5QLjfB8svtSz
 github.com/prometheus/common v0.48.0/go.mod h1:0/KsvlIEfPQCQ5I2iNSAWKPZziNCvRs5EC6ILDTlAPc=
 github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
-github.com/quay/claircore/toolkit v1.0.0/go.mod h1:3ELtgf92x7o1JCTSKVOAqhcnCTXc4s5qiGaEDx62i20=
 github.com/quay/claircore/toolkit v1.1.1 h1:9GFy14ffOkIOpl0fbR+bHr4i19VEwms1pXw8S8up0e4=
 github.com/quay/claircore/toolkit v1.1.1/go.mod h1:ZZHA/b/qpfUcNHFJeYVA0bOp7aL4r3CTFhlBV/ezoFI=
 github.com/quay/goval-parser v0.8.8 h1:Uf+f9iF2GIR5GPUY2pGoa9il2+4cdES44ZlM0mWm4cA=

--- a/toolkit/go.mod
+++ b/toolkit/go.mod
@@ -1,5 +1,5 @@
 module github.com/quay/claircore/toolkit
 
-go 1.18
+go 1.21.8
 
 require github.com/google/go-cmp v0.6.0

--- a/updater/driver/go.mod
+++ b/updater/driver/go.mod
@@ -1,6 +1,6 @@
 module github.com/quay/claircore/updater/driver
 
-go 1.16
+go 1.21.8
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
This adds go1.22 to the CI matrix, then updates the `go.mod` files to use go1.21.