### PR TITLE
rfc: add a "devcontainer" setup

### DIFF
--- a/.devcontainer/Containerfile
+++ b/.devcontainer/Containerfile
@@ -1,0 +1,47 @@
+ARG FEDORA_VERSION="39"
+FROM --platform=$TARGETPLATFORM registry.fedoraproject.org/fedora-toolbox:${FEDORA_VERSION}
+
+ARG TARGETOS
+ARG TARGETARCH
+
+COPY gh-cli.repo /etc/yum.repos.d/gh-cli.repo
+RUN dnf install -y \
+		curl \
+		gh \
+		jq \
+		neovim \
+		ragel \
+		shellcheck \
+		tree-sitter-cli \
+		yamllint \
+		zsh \
+	&& \
+	dnf clean all
+
+ARG MDBOOK_VERSION="0.4.37"
+RUN case "$TARGETARCH" in amd64) export arch=x86_64;; *) echo "unknown arch: $TARGETARCH"; exit 0;; esac; \
+	test "$TARGETOS" = linux || { echo "unknown os: $TARGETOS"; exit 0; }; \
+	curl -sSfL "https://github.com/rust-lang/mdBook/releases/download/v${MDBOOK_VERSION}/mdbook-v${MDBOOK_VERSION}-${arch}-unknown-linux-gnu.tar.gz" | \
+	tar xzC /usr/local/bin
+
+ARG GO_VERSION="1.22"
+COPY go_download.jq /root/go_download.jq
+RUN curl -sSfL 'https://golang.org/dl/?mode=json&include=all' | \
+	jq -r -f /root/go_download.jq | \
+	sh -ex
+
+ENV GOBIN=/usr/local/bin
+RUN go=/usr/local/go/bin/go; \
+	for exe in \
+		github.com/go-delve/delve/cmd/dlv@latest \
+		github.com/mgechev/revive@latest \
+		github.com/wagoodman/dive@latest \
+		golang.org/x/tools/cmd/deadcode@latest \
+		golang.org/x/tools/gopls@latest \
+	; do \
+		echo ": $exe" ; \
+		$go install "$exe"; \
+	done; \
+	rm -rf $($go env GOCACHE GOPATH)
+
+COPY profile.sh /etc/profile.d/claircore.sh

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,4 @@
+This devcontainer setup is mostly for creating a toolbx image.
+
+None of the core contributors use a workflow that integrates devcontainers, so
+it's largely untested _as_ a devcontainer.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+	"name": "Claircore",
+	"build": {
+		"dockerfile": "Containerfile",
+		"args": {
+			"FEDORA_VERSION": "39",
+			"GO_VERSION": "1.22",
+			"MDBOOK_VERSION": "0.4.37"
+		}
+	},
+	"mounts": [
+		{
+			"type": "bind",
+			"source": "${localEnv:HOME}/.cache/clair-testing",
+			"target": "/root/.cache/clair-testing"
+		},
+		{
+			"type": "bind",
+			"source": "${localEnv:HOME}/go/pkg/mod",
+			"target": "/root/go/pkg/mod"
+		}
+	]
+}

--- a/.devcontainer/gh-cli.repo
+++ b/.devcontainer/gh-cli.repo
@@ -1,0 +1,5 @@
+[gh-cli]
+name=packages for the GitHub CLI
+baseurl=https://cli.github.com/packages/rpm
+enabled=1
+gpgkey=https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x23F3D4EA75716059

--- a/.devcontainer/go_download.jq
+++ b/.devcontainer/go_download.jq
@@ -1,0 +1,17 @@
+[
+	.[] |
+	select(
+		(.version | startswith("go\($ENV.GO_VERSION)"))
+		and
+		.stable
+	) |
+	.files[] |
+	select(
+		.os==$ENV.TARGETOS
+		and
+		.arch==$ENV.TARGETARCH
+	)
+] |
+first |
+@uri "https://golang.org/dl/\(.filename)" |
+@sh "curl -sSfL \(.) | tar xzC /usr/local"

--- a/.devcontainer/profile.sh
+++ b/.devcontainer/profile.sh
@@ -1,0 +1,9 @@
+# shellcheck shell=sh
+
+pathmunge /usr/local/go/bin
+
+if [ "$(hostname)" == toolbox ]; then
+	HOSTNAME="$(. /run/.containerenv && echo "$name")"
+	export HOSTNAME HOST="$HOSTNAME"
+	sudo hostname "${HOSTNAME}" || :
+fi


### PR DESCRIPTION
This is a little proof-of-concept for a [devcontainer](https://containers.dev/).

My workflow (neovim and a mess of terminals) doesn't really integrate with devcontainers the way VS Code does, so I ended up building this such that it's usable as a [toolbx](https://containertoolbx.org/) image.

To try:
```sh
podman build -t devcontainer-claircore:latest .
toolbox create -i devcontainer-claircore:latest claircore-dev
toolbox enter claircore-dev
```