### PR TITLE
updater: Support max entry size in offline vuln load

### DIFF
--- a/libvuln/jsonblob/jsonblob_test.go
+++ b/libvuln/jsonblob/jsonblob_test.go
@@ -98,6 +98,62 @@ func TestRoundtrip(t *testing.T) {
 	}
 }
 
+func TestMaxSize(t *testing.T) {
+	ctx := context.Background()
+	a, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var want, got struct {
+		V []*claircore.Vulnerability
+		E []driver.EnrichmentRecord
+	}
+
+	want.V = test.GenUniqueVulnerabilities(20, "test")
+	ref, err := a.UpdateVulnerabilities(ctx, "test", "", want.V)
+	if err != nil {
+		t.Error(err)
+	}
+	t.Logf("ref: %v", ref)
+
+	var buf bytes.Buffer
+	defer func() {
+		t.Logf("wrote:\n%s", buf.String())
+	}()
+	r, w := io.Pipe()
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() error { defer w.Close(); return a.Store(w) })
+	eg.Go(func() error {
+		l, err := Load(ctx, io.TeeReader(r, &buf), MaxEntrySize(10))
+		if err != nil {
+			return err
+		}
+		for l.Next() {
+			e := l.Entry()
+			if e.Vuln != nil && e.Enrichment != nil {
+				t.Error("expecting entry to have either vulnerability or enrichment, got both")
+			}
+			if len(e.Vuln) != 10 {
+				t.Errorf("expected 10 vulns, found %d", len(e.Vuln))
+			}
+			if e.Vuln != nil {
+				got.V = append(got.V, l.Entry().Vuln...)
+			}
+		}
+		if err := l.Err(); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err := eg.Wait(); err != nil {
+		t.Error(err)
+	}
+	if !cmp.Equal(got, want) {
+		t.Error(cmp.Diff(got, want))
+	}
+}
+
 func TestEnrichments(t *testing.T) {
 	s, err := New()
 	if err != nil {


### PR DESCRIPTION
This PR allows clients to control the size of the offline importer entries. Up until now, the entry size was determined by the reference ID. Some updaters (eg. RHEL) fetch huge pages of vulnerabilities from their security source (eg. OVAL XML) into memory, and the [JSON blob storage will give them the same reference ID](https://github.com/quay/claircore/blob/e3d5d4b2ada7de7c02e06e8a4a43b1139dca60be/libvuln/jsonblob/jsonblob.go#L314-L313), forcing clients to have enough memory to load them.

Other alternatives are possible, but I concluded that this one was less intrusive and had the lowest impact on existing clients.

Returning multiple entries with the same fingerprint should be OK as long the clients are the only ones performing the updates, and the state of the operations is retrieved before updating, [which is what the offline importer does](https://github.com/quay/claircore/blob/e3d5d4b2ada7de7c02e06e8a4a43b1139dca60be/libvuln/jsonblob/jsonblob.go#L314-L313)