### PR TITLE
chore: update go version to 1.21.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/quay/claircore
 
-go 1.21.8
+go 1.21.9
 
 require (
 	github.com/Masterminds/semver v1.5.0

--- a/toolkit/go.mod
+++ b/toolkit/go.mod
@@ -1,5 +1,5 @@
 module github.com/quay/claircore/toolkit
 
-go 1.21.8
+go 1.21.9
 
 require github.com/google/go-cmp v0.6.0

--- a/updater/driver/go.mod
+++ b/updater/driver/go.mod
@@ -1,6 +1,6 @@
 module github.com/quay/claircore/updater/driver
 
-go 1.21.8
+go 1.21.9
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
This go version includes an fix for a vulnerability in the net/http package. https://pkg.go.dev/vuln/GO-2024-2687