### PR TITLE
cicd: db harness inside docker containers

### DIFF
--- a/test/integration/embedded.go
+++ b/test/integration/embedded.go
@@ -72,6 +72,11 @@ func init() {
 }
 
 func startEmbedded(t testing.TB) func() {
+	if os.Getuid() == 0 {
+		// Print warning to prevent wary travelers needing to go spelunking in
+		// the logs.
+		t.Log("⚠️ PostgreSQL refuses to start as root; this will almost certainly not work ⚠️")
+	}
 	return func() {
 		pkgDB = &Engine{}
 		if err := pkgDB.Start(t); err != nil {

--- a/test/integration/integration.go
+++ b/test/integration/integration.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -44,12 +43,14 @@ func skip() bool {
 	return testing.Short() || integrationTag && !inCI
 }
 
-var inCI, inGHA bool
+var inCI, inGHA, externalDB bool
 
 func init() {
-	inCI, _ = strconv.ParseBool(os.Getenv("CI"))
-	inGHA, _ = strconv.ParseBool(os.Getenv("GITHUB_ACTIONS"))
-	actuallyAct, _ := strconv.ParseBool(os.Getenv("ACT"))
+	_, inCI = os.LookupEnv("CI")
+	_, inGHA = os.LookupEnv("GITHUB_ACTIONS")
+	_, externalDB = os.LookupEnv(EnvPGConnString)
+	_, actuallyAct := os.LookupEnv("ACT")
+
 	inGHA = inGHA && !actuallyAct
 }
 


### PR DESCRIPTION
Here's what I did for testing this:

- Create a pod with a database in it.
  <details>

  ```
  % podman pod create claircore-integration-test
  % podman create \
          --pod claircore-integration-test \
          --env POSTGRES_DB=clair \
          --env POSTGRES_INITDB_ARGS=--no-sync \
          --env POSTGRES_PASSWORD=password \
          --env POSTGRES_USER=clair \
          --health-cmd "pg_isready -U clair" \
          --health-interval 10s \
          --health-timeout 5s \
          --health-retries 5 \
          docker.io/library/postgres:15
  % podman pod start claircore-integration-test
  ```
  </details>


- Test external, build tag
  <details>

  ```
  % podman run --rm --pod claircore-integration-test \
          --security-opt label=disable \
          --mount "type=tmpfs,dst=/var/tmp" \
          --mount "type=tmpfs,dst=/tmp" \
          --mount "type=bind,src=$(go env GOMODCACHE),dst=/go/pkg/mod" \
          --mount "type=bind,src=$(go env GOCACHE),dst=/root/.cache/go-build" \
          --mount "type=bind,src=${HOME}/.cache/clair-testing,dst=/root/.cache/clair-testing" \
          --mount "type=bind,src=$(git rev-parse --show-toplevel),dst=/build" \
          --env "POSTGRES_CONNECTION_STRING=host=localhost port=5432 user=clair dbname=clair password=password sslmode=disable" \
          -w /build \
          quay.io/projectquay/golang:1.22 \
          go test -tags integration -v ./debian
  === RUN   TestDistributionScanner
  === RUN   TestDistributionScanner/10
      distributionscanner_test.go:43: tc: testdata/dist | got: "10", want: "10"
  === RUN   TestDistributionScanner/11
      distributionscanner_test.go:43: tc: testdata/dist | got: "11", want: "11"
  === RUN   TestDistributionScanner/12
      distributionscanner_test.go:43: tc: testdata/dist | got: "12", want: "12"
  === RUN   TestDistributionScanner/7
      distributionscanner_test.go:43: tc: testdata/dist | got: "7", want: "7"
  === RUN   TestDistributionScanner/8
      distributionscanner_test.go:43: tc: testdata/dist | got: "8", want: "8"
  === RUN   TestDistributionScanner/9
      distributionscanner_test.go:43: tc: testdata/dist | got: "9", want: "9"
  === RUN   TestDistributionScanner/10#01
      distributionscanner_test.go:43: tc: testdata/distroless_dist | got: "10", want: "10"
  === RUN   TestDistributionScanner/11#01
      distributionscanner_test.go:43: tc: testdata/distroless_dist | got: "11", want: "11"
  === RUN   TestDistributionScanner/9#01
      distributionscanner_test.go:43: tc: testdata/distroless_dist | got: "9", want: "9"
  --- PASS: TestDistributionScanner (0.00s)
      --- PASS: TestDistributionScanner/10 (0.00s)
      --- PASS: TestDistributionScanner/11 (0.00s)
      --- PASS: TestDistributionScanner/12 (0.00s)
      --- PASS: TestDistributionScanner/7 (0.00s)
      --- PASS: TestDistributionScanner/8 (0.00s)
      --- PASS: TestDistributionScanner/9 (0.00s)
      --- PASS: TestDistributionScanner/10#01 (0.00s)
      --- PASS: TestDistributionScanner/11#01 (0.00s)
      --- PASS: TestDistributionScanner/9#01 (0.00s)
  === RUN   TestMatcherIntegration
      matcher_integration_test.go:39: using preconfigured external database
      adapter.go:32: info Dialing PostgreSQL server host=localhost
      adapter.go:32: info Exec commandTag=CREATE ROLE pid=523 sql=CREATE ROLE roleb37beb4e8d9ab2a0 LOGIN PASSWORD 'roleb37beb4e8d9ab2a0'; args=[] time=19.291328ms
      adapter.go:32: info Exec pid=523 sql=CREATE DATABASE dbf37d6ba0f4091c0 WITH OWNER roleb37beb4e8d9ab2a0 ENCODING 'UTF8'; args=[] time=46.100355ms commandTag=CREATE DATABASE
      adapter.go:32: info closed connection pid=523
      adapter.go:32: info Dialing PostgreSQL server host=localhost
      adapter.go:32: info Exec sql=CREATE EXTENSION IF NOT EXISTS "uuid-ossp"; args=[] time=7.32073ms commandTag=CREATE EXTENSION pid=524
      adapter.go:32: info closed connection pid=524
      db.go:78: config: {Host:localhost Database:dbf37d6ba0f4091c0 User:roleb37beb4e8d9ab2a0 Password:roleb37beb4e8d9ab2a0 Port:5432}
      db_common.go:27: loading global "all_version.psql"
      testing.go:98: {"level":"debug","component":"internal/ctxlock/Locker.reconnect","zlog.testname":"TestMatcherIntegration","gen":"1","caller":"ctxlock.go:153","message":"set up"}
      testing.go:98: {"level":"debug","component":"libvuln/updates/NewManager","zlog.testname":"TestMatcherIntegration","factory":"debian","caller":"registry.go:66","message":"configuring factory"}
      testing.go:98: {"level":"info","zlog.testname":"TestMatcherIntegration","component":"libvuln/updates/Manager.Run","total":1,"batchSize":16,"caller":"manager.go:194","message":"running updaters"}
      testing.go:98: {"level":"info","component":"libvuln/updates/Manager.driveUpdater","zlog.testname":"TestMatcherIntegration","updater":"debian/updater","caller":"manager.go:304","message":"starting update"}
      testing.go:98: {"level":"info","database":"http://127.0.0.1:43165","component":"debian/Updater.Fetch","zlog.testname":"TestMatcherIntegration","updater":"debian/updater","caller":"updater.go:327","message":"fetching latest JSON database"}
      testing.go:98: {"level":"info","updater":"debian/updater","database":"http://127.0.0.1:43165","component":"debian/Updater.Fetch","zlog.testname":"TestMatcherIntegration","caller":"updater.go:356","message":"fetched latest json database successfully"}
      testing.go:98: {"level":"info","zlog.testname":"TestMatcherIntegration","updater":"debian/updater","component":"debian/Updater.Parse","caller":"parser.go:38","message":"starting parse"}
      testing.go:98: {"level":"debug","zlog.testname":"TestMatcherIntegration","updater":"debian/updater","component":"datastore/postgres/MatcherStore.UpdateVulnerabilities","ref":"c6eb0e5b-fc2a-47a4-9616-78dc0cf5fb45","caller":"updatevulnerabilities.go:147","message":"update_operation created"}
      testing.go:98: {"level":"debug","zlog.testname":"TestMatcherIntegration","updater":"debian/updater","component":"datastore/postgres/MatcherStore.UpdateVulnerabilities","ref":"c6eb0e5b-fc2a-47a4-9616-78dc0cf5fb45","skipped":0,"inserted":97950,"caller":"updatevulnerabilities.go:270","message":"update_operation committed"}
      testing.go:98: {"level":"info","component":"libvuln/updates/Manager.driveUpdater","zlog.testname":"TestMatcherIntegration","updater":"debian/updater","ref":"c6eb0e5b-fc2a-47a4-9616-78dc0cf5fb45","caller":"manager.go:391","message":"successful update"}
      testing.go:98: {"level":"info","component":"libvuln/updates/Manager.driveUpdater","zlog.testname":"TestMatcherIntegration","updater":"debian/updater","caller":"manager.go:392","message":"finished update"}
      testing.go:98: {"level":"debug","component":"internal/vulnstore/postgres/recordUpdaterStatus","zlog.testname":"TestMatcherIntegration","updater":"debian/updater","updater":"debian/updater","caller":"recordupdatetime.go:74","message":"recording successful update"}
      testing.go:98: {"level":"debug","updater":"debian/updater","component":"internal/vulnstore/postgres/recordUpdaterStatus","zlog.testname":"TestMatcherIntegration","updater":"debian/updater","caller":"recordupdatetime.go:94","message":"updater status stored in database"}
      testing.go:98: {"level":"debug","zlog.testname":"TestMatcherIntegration","component":"internal/matcher/Controller.Match","matcher":"debian-matcher","interested":91,"records":91,"caller":"controller.go:41","message":"interest"}
      testing.go:98: {"level":"debug","component":"internal/matcher/Controller.Match","matcher":"debian-matcher","zlog.testname":"TestMatcherIntegration","opt-in":false,"authoritative":false,"caller":"controller.go:61","message":"version filter compatible?"}
      testing.go:98: {"level":"debug","zlog.testname":"TestMatcherIntegration","component":"internal/matcher/Controller.Match","matcher":"debian-matcher","vulnerabilities":52,"caller":"controller.go:70","message":"query"}
      testing.go:98: {"level":"debug","zlog.testname":"TestMatcherIntegration","component":"internal/matcher/Controller.Match","matcher":"debian-matcher","filtered":91,"caller":"controller.go:82","message":"filtered"}
      testing.go:98: {"level":"debug","component":"internal/ctxlock/Locker.reconnect","zlog.testname":"TestMatcherIntegration","gen":"1","caller":"ctxlock.go:151","message":"torn down"}
      testing.go:98: {"level":"debug","zlog.testname":"TestMatcherIntegration","component":"internal/ctxlock/Locker.run","caller":"ctxlock.go:105","message":"ctxlocker exiting"}
      adapter.go:32: info Dialing PostgreSQL server host=localhost
      adapter.go:32: info Exec sql=SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1 args=[dbf37d6ba0f4091c0] time=1.501582ms commandTag=SELECT 0 pid=531
      adapter.go:32: info Exec sql=DROP DATABASE dbf37d6ba0f4091c0; args=[] time=203.663383ms commandTag=DROP DATABASE pid=531
      adapter.go:32: info Exec sql=DROP ROLE roleb37beb4e8d9ab2a0; args=[] time=6.378732ms commandTag=DROP ROLE pid=531
      adapter.go:32: info closed connection pid=531
  --- PASS: TestMatcherIntegration (8.08s)
  === RUN   TestFindReleases
  === PAUSE TestFindReleases
  === CONT  TestFindReleases
  --- PASS: TestFindReleases (0.00s)
  PASS
  ok      github.com/quay/claircore/debian        8.094s
  ```
  </details>

- Test external, no tag
  <details>

  ```
  % podman run --rm --pod claircore-integration-test \
          --security-opt label=disable \
          --mount "type=tmpfs,dst=/var/tmp" \
          --mount "type=tmpfs,dst=/tmp" \
          --mount "type=bind,src=$(go env GOMODCACHE),dst=/go/pkg/mod" \
          --mount "type=bind,src=$(go env GOCACHE),dst=/root/.cache/go-build" \
          --mount "type=bind,src=${HOME}/.cache/clair-testing,dst=/root/.cache/clair-testing" \
          --mount "type=bind,src=$(git rev-parse --show-toplevel),dst=/build" \
          --env "POSTGRES_CONNECTION_STRING=host=localhost port=5432 user=clair dbname=clair password=password sslmode=disable" \
          -w /build \
          quay.io/projectquay/golang:1.22 \
          go test -v ./debian
  === RUN   TestDistributionScanner
  === RUN   TestDistributionScanner/10
      distributionscanner_test.go:43: tc: testdata/dist | got: "10", want: "10"
  === RUN   TestDistributionScanner/11
      distributionscanner_test.go:43: tc: testdata/dist | got: "11", want: "11"
  === RUN   TestDistributionScanner/12
      distributionscanner_test.go:43: tc: testdata/dist | got: "12", want: "12"
  === RUN   TestDistributionScanner/7
      distributionscanner_test.go:43: tc: testdata/dist | got: "7", want: "7"
  === RUN   TestDistributionScanner/8
      distributionscanner_test.go:43: tc: testdata/dist | got: "8", want: "8"
  === RUN   TestDistributionScanner/9
      distributionscanner_test.go:43: tc: testdata/dist | got: "9", want: "9"
  === RUN   TestDistributionScanner/10#01
      distributionscanner_test.go:43: tc: testdata/distroless_dist | got: "10", want: "10"
  === RUN   TestDistributionScanner/11#01
      distributionscanner_test.go:43: tc: testdata/distroless_dist | got: "11", want: "11"
  === RUN   TestDistributionScanner/9#01
      distributionscanner_test.go:43: tc: testdata/distroless_dist | got: "9", want: "9"
  --- PASS: TestDistributionScanner (0.00s)
      --- PASS: TestDistributionScanner/10 (0.00s)
      --- PASS: TestDistributionScanner/11 (0.00s)
      --- PASS: TestDistributionScanner/12 (0.00s)
      --- PASS: TestDistributionScanner/7 (0.00s)
      --- PASS: TestDistributionScanner/8 (0.00s)
      --- PASS: TestDistributionScanner/9 (0.00s)
      --- PASS: TestDistributionScanner/10#01 (0.00s)
      --- PASS: TestDistributionScanner/11#01 (0.00s)
      --- PASS: TestDistributionScanner/9#01 (0.00s)
  === RUN   TestMatcherIntegration
      matcher_integration_test.go:39: using preconfigured external database
      adapter.go:32: info Dialing PostgreSQL server host=localhost
      adapter.go:32: info Exec sql=CREATE ROLE rolef35a85f374f83540 LOGIN PASSWORD 'rolef35a85f374f83540'; args=[] time=19.456242ms commandTag=CREATE ROLE pid=543
      adapter.go:32: info Exec args=[] time=40.680665ms commandTag=CREATE DATABASE pid=543 sql=CREATE DATABASE db99d1cccfe4243d37 WITH OWNER rolef35a85f374f83540 ENCODING 'UTF8';
      adapter.go:32: info closed connection pid=543
      adapter.go:32: info Dialing PostgreSQL server host=localhost
      adapter.go:32: info Exec time=7.451211ms commandTag=CREATE EXTENSION pid=544 sql=CREATE EXTENSION IF NOT EXISTS "uuid-ossp"; args=[]
      adapter.go:32: info closed connection pid=544
      db.go:78: config: {Host:localhost Database:db99d1cccfe4243d37 User:rolef35a85f374f83540 Password:rolef35a85f374f83540 Port:5432}
      db_common.go:27: loading global "all_version.psql"
      testing.go:98: {"level":"debug","zlog.testname":"TestMatcherIntegration","component":"internal/ctxlock/Locker.reconnect","gen":"1","caller":"ctxlock.go:153","message":"set up"}
      testing.go:98: {"level":"debug","component":"libvuln/updates/NewManager","zlog.testname":"TestMatcherIntegration","factory":"debian","caller":"registry.go:66","message":"configuring factory"}
      testing.go:98: {"level":"info","zlog.testname":"TestMatcherIntegration","component":"libvuln/updates/Manager.Run","total":1,"batchSize":16,"caller":"manager.go:194","message":"running updaters"}
      testing.go:98: {"level":"info","component":"libvuln/updates/Manager.driveUpdater","updater":"debian/updater","zlog.testname":"TestMatcherIntegration","caller":"manager.go:304","message":"starting update"}
      testing.go:98: {"level":"info","zlog.testname":"TestMatcherIntegration","updater":"debian/updater","component":"debian/Updater.Fetch","database":"http://127.0.0.1:46629","caller":"updater.go:327","message":"fetching latest JSON database"}
      testing.go:98: {"level":"info","database":"http://127.0.0.1:46629","zlog.testname":"TestMatcherIntegration","updater":"debian/updater","component":"debian/Updater.Fetch","caller":"updater.go:356","message":"fetched latest json database successfully"}
      testing.go:98: {"level":"info","updater":"debian/updater","component":"debian/Updater.Parse","zlog.testname":"TestMatcherIntegration","caller":"parser.go:38","message":"starting parse"}
      testing.go:98: {"level":"debug","updater":"debian/updater","zlog.testname":"TestMatcherIntegration","component":"datastore/postgres/MatcherStore.UpdateVulnerabilities","ref":"7d0703b5-b1d8-48a7-aad0-cc96081e2909","caller":"updatevulnerabilities.go:147","message":"update_operation created"}
      testing.go:98: {"level":"debug","updater":"debian/updater","zlog.testname":"TestMatcherIntegration","component":"datastore/postgres/MatcherStore.UpdateVulnerabilities","ref":"7d0703b5-b1d8-48a7-aad0-cc96081e2909","skipped":0,"inserted":97950,"caller":"updatevulnerabilities.go:270","message":"update_operation committed"}
      testing.go:98: {"level":"info","updater":"debian/updater","zlog.testname":"TestMatcherIntegration","component":"libvuln/updates/Manager.driveUpdater","ref":"7d0703b5-b1d8-48a7-aad0-cc96081e2909","caller":"manager.go:391","message":"successful update"}
      testing.go:98: {"level":"info","zlog.testname":"TestMatcherIntegration","component":"libvuln/updates/Manager.driveUpdater","updater":"debian/updater","caller":"manager.go:392","message":"finished update"}
      testing.go:98: {"level":"debug","updater":"debian/updater","zlog.testname":"TestMatcherIntegration","component":"internal/vulnstore/postgres/recordUpdaterStatus","updater":"debian/updater","caller":"recordupdatetime.go:74","message":"recording successful update"}
      testing.go:98: {"level":"debug","updater":"debian/updater","zlog.testname":"TestMatcherIntegration","component":"internal/vulnstore/postgres/recordUpdaterStatus","updater":"debian/updater","caller":"recordupdatetime.go:94","message":"updater status stored in database"}
      testing.go:98: {"level":"debug","zlog.testname":"TestMatcherIntegration","component":"internal/matcher/Controller.Match","matcher":"debian-matcher","interested":91,"records":91,"caller":"controller.go:41","message":"interest"}
      testing.go:98: {"level":"debug","zlog.testname":"TestMatcherIntegration","component":"internal/matcher/Controller.Match","matcher":"debian-matcher","opt-in":false,"authoritative":false,"caller":"controller.go:61","message":"version filter compatible?"}
      testing.go:98: {"level":"debug","zlog.testname":"TestMatcherIntegration","component":"internal/matcher/Controller.Match","matcher":"debian-matcher","vulnerabilities":52,"caller":"controller.go:70","message":"query"}
      testing.go:98: {"level":"debug","zlog.testname":"TestMatcherIntegration","component":"internal/matcher/Controller.Match","matcher":"debian-matcher","filtered":91,"caller":"controller.go:82","message":"filtered"}
      testing.go:98: {"level":"debug","zlog.testname":"TestMatcherIntegration","component":"internal/ctxlock/Locker.reconnect","gen":"1","caller":"ctxlock.go:151","message":"torn down"}
      testing.go:98: {"level":"debug","zlog.testname":"TestMatcherIntegration","component":"internal/ctxlock/Locker.run","caller":"ctxlock.go:105","message":"ctxlocker exiting"}
      adapter.go:32: info Dialing PostgreSQL server host=localhost
      adapter.go:32: info Exec args=[db99d1cccfe4243d37] time=1.502283ms commandTag=SELECT 0 pid=551 sql=SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1
      adapter.go:32: info Exec args=[] time=287.545788ms commandTag=DROP DATABASE pid=551 sql=DROP DATABASE db99d1cccfe4243d37;
      adapter.go:32: info Exec sql=DROP ROLE rolef35a85f374f83540; args=[] time=6.7537ms commandTag=DROP ROLE pid=551
      adapter.go:32: info closed connection pid=551
  --- PASS: TestMatcherIntegration (7.44s)
  === RUN   TestFindReleases
  === PAUSE TestFindReleases
  === CONT  TestFindReleases
  --- PASS: TestFindReleases (0.00s)
  PASS
  ok      github.com/quay/claircore/debian        7.455s
  ```
  </details>

- Test no external, no tag
  <details>

  ```
  % podman run --rm --pod claircore-integration-test \
          --security-opt label=disable \
          --mount "type=tmpfs,dst=/var/tmp" \
          --mount "type=tmpfs,dst=/tmp" \
          --mount "type=bind,src=$(go env GOMODCACHE),dst=/go/pkg/mod" \
          --mount "type=bind,src=$(go env GOCACHE),dst=/root/.cache/go-build" \
          --mount "type=bind,src=${HOME}/.cache/clair-testing,dst=/root/.cache/clair-testing" \
          --mount "type=bind,src=$(git rev-parse --show-toplevel),dst=/build" \
          -w /build \
          quay.io/projectquay/golang:1.22 \
          go test -v ./debian
  === RUN   TestDistributionScanner
  === RUN   TestDistributionScanner/10
      distributionscanner_test.go:43: tc: testdata/distroless_dist | got: "10", want: "10"
  === RUN   TestDistributionScanner/11
      distributionscanner_test.go:43: tc: testdata/distroless_dist | got: "11", want: "11"
  === RUN   TestDistributionScanner/9
      distributionscanner_test.go:43: tc: testdata/distroless_dist | got: "9", want: "9"
  === RUN   TestDistributionScanner/10#01
      distributionscanner_test.go:43: tc: testdata/dist | got: "10", want: "10"
  === RUN   TestDistributionScanner/11#01
      distributionscanner_test.go:43: tc: testdata/dist | got: "11", want: "11"
  === RUN   TestDistributionScanner/12
      distributionscanner_test.go:43: tc: testdata/dist | got: "12", want: "12"
  === RUN   TestDistributionScanner/7
      distributionscanner_test.go:43: tc: testdata/dist | got: "7", want: "7"
  === RUN   TestDistributionScanner/8
      distributionscanner_test.go:43: tc: testdata/dist | got: "8", want: "8"
  === RUN   TestDistributionScanner/9#01
      distributionscanner_test.go:43: tc: testdata/dist | got: "9", want: "9"
  --- PASS: TestDistributionScanner (0.00s)
      --- PASS: TestDistributionScanner/10 (0.00s)
      --- PASS: TestDistributionScanner/11 (0.00s)
      --- PASS: TestDistributionScanner/9 (0.00s)
      --- PASS: TestDistributionScanner/10#01 (0.00s)
      --- PASS: TestDistributionScanner/11#01 (0.00s)
      --- PASS: TestDistributionScanner/12 (0.00s)
      --- PASS: TestDistributionScanner/7 (0.00s)
      --- PASS: TestDistributionScanner/8 (0.00s)
      --- PASS: TestDistributionScanner/9#01 (0.00s)
  === RUN   TestMatcherIntegration
      matcher_integration_test.go:39: using embedded database
      embedded.go:204: skipping integration test: would need to fetch bom & binaries
  --- SKIP: TestMatcherIntegration (0.01s)
  === RUN   TestFindReleases
  === PAUSE TestFindReleases
  === CONT  TestFindReleases
  --- PASS: TestFindReleases (0.00s)
  PASS
  ok      github.com/quay/claircore/debian        0.014s
  ```
  </details>

- Test no external, build tag
  <details>

  ```
  % podman run --rm --pod claircore-integration-test \
          --security-opt label=disable \
          --mount "type=tmpfs,dst=/var/tmp" \
          --mount "type=tmpfs,dst=/tmp" \
          --mount "type=bind,src=$(go env GOMODCACHE),dst=/go/pkg/mod" \
          --mount "type=bind,src=$(go env GOCACHE),dst=/root/.cache/go-build" \
          --mount "type=bind,src=${HOME}/.cache/clair-testing,dst=/root/.cache/clair-testing" \
          --mount "type=bind,src=$(git rev-parse --show-toplevel),dst=/build" \
          -w /build \
          quay.io/projectquay/golang:1.22 \
          go test -v -tags integration ./debian
  === RUN   TestDistributionScanner
  === RUN   TestDistributionScanner/10
      distributionscanner_test.go:43: tc: testdata/dist | got: "10", want: "10"
  === RUN   TestDistributionScanner/11
      distributionscanner_test.go:43: tc: testdata/dist | got: "11", want: "11"
  === RUN   TestDistributionScanner/12
      distributionscanner_test.go:43: tc: testdata/dist | got: "12", want: "12"
  === RUN   TestDistributionScanner/7
      distributionscanner_test.go:43: tc: testdata/dist | got: "7", want: "7"
  === RUN   TestDistributionScanner/8
      distributionscanner_test.go:43: tc: testdata/dist | got: "8", want: "8"
  === RUN   TestDistributionScanner/9
      distributionscanner_test.go:43: tc: testdata/dist | got: "9", want: "9"
  === RUN   TestDistributionScanner/10#01
      distributionscanner_test.go:43: tc: testdata/distroless_dist | got: "10", want: "10"
  === RUN   TestDistributionScanner/11#01
      distributionscanner_test.go:43: tc: testdata/distroless_dist | got: "11", want: "11"
  === RUN   TestDistributionScanner/9#01
      distributionscanner_test.go:43: tc: testdata/distroless_dist | got: "9", want: "9"
  --- PASS: TestDistributionScanner (0.00s)
      --- PASS: TestDistributionScanner/10 (0.00s)
      --- PASS: TestDistributionScanner/11 (0.00s)
      --- PASS: TestDistributionScanner/12 (0.00s)
      --- PASS: TestDistributionScanner/7 (0.00s)
      --- PASS: TestDistributionScanner/8 (0.00s)
      --- PASS: TestDistributionScanner/9 (0.00s)
      --- PASS: TestDistributionScanner/10#01 (0.00s)
      --- PASS: TestDistributionScanner/11#01 (0.00s)
      --- PASS: TestDistributionScanner/9#01 (0.00s)
  === RUN   TestMatcherIntegration
      matcher_integration_test.go:39: using embedded database
      embedded.go:152: pattern "latest" resolved to version: "16.2.0"
      embedded.go:78: ⚠️ PostgreSQL refuses to start as root; this will almost certainly not work ⚠️
      embedded.go:267: adding symlink "/root/.cache/clair-testing/postgres-linux-amd64-latest" → "/root/.cache/clair-testing/postgres-linux-amd64-16.2.0"
      embedded.go:285: fetching "https://repo1.maven.org/maven2/io/zonky/test/postgres/embedded-postgres-binaries-linux-amd64/16.2.0/embedded-postgres-binaries-linux-amd64-16.2.0.jar"
      embedded.go:294: fetch OK
      embedded.go:327: extracting "postgres-linux-x86_64.txz" to "/root/.cache/clair-testing/postgres-linux-amd64-16.2.0"
      embedded.go:391: extraction OK
      engine.go:29: using binaries at "/root/.cache/clair-testing/postgres-linux-amd64-16.2.0/bin"
      engine.go:36: using port "30217"
      engine.go:44: using data directory "/root/.cache/clair-testing/github.com_quay_claircore/debian/pg16.2.0"
      engine.go:57: log at "/root/.cache/clair-testing/github.com_quay_claircore/debian/pg16.2.0.initdb"
      engine.go:68: running [/root/.cache/clair-testing/postgres-linux-amd64-16.2.0/bin/initdb --encoding=UTF8 --auth=password --username=postgres --pgdata=/root/.cache/clair-testing/github.com_quay_claircore/debian/pg16.2.0 --pwfile=/tmp/TestMatcherIntegration1025595683/002/passwd]
      engine.go:70: exit status 1
  --- FAIL: TestMatcherIntegration (3.17s)
  === RUN   TestFindReleases
  === PAUSE TestFindReleases
  === CONT  TestFindReleases
  --- PASS: TestFindReleases (0.00s)
  FAIL
  FAIL    github.com/quay/claircore/debian        3.180s
  FAIL
  ```
  </details>
