### PR TITLE
integration: fix panic on platforms without embedded DB support

### DIFF
--- a/test/integration/embedded.go
+++ b/test/integration/embedded.go
@@ -77,6 +77,13 @@ func startEmbedded(t testing.TB) func() {
 		// the logs.
 		t.Log("⚠️ PostgreSQL refuses to start as root; this will almost certainly not work ⚠️")
 	}
+	if embedDB.Arch == "" {
+		t.Logf(`⚠️ unsupported platform "%s/%s"; see https://mvnrepository.com/artifact/io.zonky.test.postgres/embedded-postgres-binaries-bom`,
+			runtime.GOOS, runtime.GOARCH,
+		)
+		t.Log("See the test/integration documentation for how to specify an external database.")
+		t.FailNow()
+	}
 	return func() {
 		pkgDB = &Engine{}
 		if err := pkgDB.Start(t); err != nil {

--- a/test/integration/fixup_other.go
+++ b/test/integration/fixup_other.go
@@ -3,7 +3,6 @@
 package integration
 
 import (
-	"fmt"
 	"runtime"
 )
 
@@ -29,10 +28,9 @@ func findArch() (arch string) {
 	default:
 	}
 	if !ok {
-		panic(fmt.Sprintf(
-			`unsupported platform "%s/%s"; see https://mvnrepository.com/artifact/io.zonky.test.postgres/embedded-postgres-binaries-bom`,
-			runtime.GOOS, runtime.GOARCH,
-		))
+		// Will cause the [startEmbedded] function to print a warning and fail
+		// the test if the environment requires an embedded database.
+		return ""
 	}
 	return arch
 }


### PR DESCRIPTION
This is an embarrassing one that I should have thought through. Now, nothing should be panicking from the package block or an init function.