### PR TITLE
poolstats: support pgxpool metrics from two pools

### DIFF
--- a/pkg/poolstats/collector.go
+++ b/pkg/poolstats/collector.go
@@ -60,49 +60,48 @@ func NewCollector(stater Stater, appname string) *Collector {
 // application uses more than one pgxpool.Pool to enable differentiation between
 // them.
 func newCollector(fn staterFunc, n string) *Collector {
+	var constLabels = prometheus.Labels{"application_name": n}
 	return &Collector{
 		name: n,
 		stat: fn,
 		acquireCountDesc: prometheus.NewDesc(
 			"pgxpool_acquire_count",
 			"Cumulative count of successful acquires from the pool.",
-			staticLabels, nil),
+			nil, constLabels),
 		acquireDurationDesc: prometheus.NewDesc(
 			"pgxpool_acquire_duration_seconds_total",
 			"Total duration of all successful acquires from the pool in nanoseconds.",
-			staticLabels, nil),
+			nil, constLabels),
 		acquiredConnsDesc: prometheus.NewDesc(
 			"pgxpool_acquired_conns",
 			"Number of currently acquired connections in the pool.",
-			staticLabels, nil),
+			nil, constLabels),
 		canceledAcquireCountDesc: prometheus.NewDesc(
 			"pgxpool_canceled_acquire_count",
 			"Cumulative count of acquires from the pool that were canceled by a context.",
-			staticLabels, nil),
+			nil, constLabels),
 		constructingConnsDesc: prometheus.NewDesc(
 			"pgxpool_constructing_conns",
 			"Number of conns with construction in progress in the pool.",
-			staticLabels, nil),
+			nil, constLabels),
 		emptyAcquireCountDesc: prometheus.NewDesc(
 			"pgxpool_empty_acquire",
 			"Cumulative count of successful acquires from the pool that waited for a resource to be released or constructed because the pool was empty.",
-			staticLabels, nil),
+			nil, constLabels),
 		idleConnsDesc: prometheus.NewDesc(
 			"pgxpool_idle_conns",
 			"Number of currently idle conns in the pool.",
-			staticLabels, nil),
+			nil, constLabels),
 		maxConnsDesc: prometheus.NewDesc(
 			"pgxpool_max_conns",
 			"Maximum size of the pool.",
-			staticLabels, nil),
+			nil, constLabels),
 		totalConnsDesc: prometheus.NewDesc(
 			"pgxpool_total_conns",
 			"Total number of resources currently in the pool. The value is the sum of ConstructingConns, AcquiredConns, and IdleConns.",
-			staticLabels, nil),
+			nil, constLabels),
 	}
 }
-
-var staticLabels = []string{"application_name"}
 
 // Describe implements the prometheus.Collector interface.
 func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
@@ -116,54 +115,45 @@ func (c *Collector) Collect(metrics chan<- prometheus.Metric) {
 		c.acquireCountDesc,
 		prometheus.CounterValue,
 		float64(s.AcquireCount()),
-		c.name,
 	)
 	metrics <- prometheus.MustNewConstMetric(
 		c.acquireDurationDesc,
 		prometheus.CounterValue,
 		s.AcquireDuration().Seconds(),
-		c.name,
 	)
 	metrics <- prometheus.MustNewConstMetric(
 		c.acquiredConnsDesc,
 		prometheus.GaugeValue,
 		float64(s.AcquiredConns()),
-		c.name,
 	)
 	metrics <- prometheus.MustNewConstMetric(
 		c.canceledAcquireCountDesc,
 		prometheus.CounterValue,
 		float64(s.CanceledAcquireCount()),
-		c.name,
 	)
 	metrics <- prometheus.MustNewConstMetric(
 		c.constructingConnsDesc,
 		prometheus.GaugeValue,
 		float64(s.ConstructingConns()),
-		c.name,
 	)
 	metrics <- prometheus.MustNewConstMetric(
 		c.emptyAcquireCountDesc,
 		prometheus.CounterValue,
 		float64(s.EmptyAcquireCount()),
-		c.name,
 	)
 	metrics <- prometheus.MustNewConstMetric(
 		c.idleConnsDesc,
 		prometheus.GaugeValue,
 		float64(s.IdleConns()),
-		c.name,
 	)
 	metrics <- prometheus.MustNewConstMetric(
 		c.maxConnsDesc,
 		prometheus.GaugeValue,
 		float64(s.MaxConns()),
-		c.name,
 	)
 	metrics <- prometheus.MustNewConstMetric(
 		c.totalConnsDesc,
 		prometheus.GaugeValue,
 		float64(s.TotalConns()),
-		c.name,
 	)
 }


### PR DESCRIPTION
Fixes https://github.com/quay/claircore/issues/1326

Support publishing pxgpool stats from two different pools as Prometheus metrics with different `application_name` labels.

A clair running in `combo` mode after:
```sh
$ curl -s localhost:6061/metrics | grep pgxpool

# HELP pgxpool_acquire_count Cumulative count of successful acquires from the pool.
# TYPE pgxpool_acquire_count counter
pgxpool_acquire_count{application_name="libindex"} 22
pgxpool_acquire_count{application_name="libvuln"} 2
# HELP pgxpool_acquire_duration_seconds_total Total duration of all successful acquires from the pool in nanoseconds.
# TYPE pgxpool_acquire_duration_seconds_total counter
pgxpool_acquire_duration_seconds_total{application_name="libindex"} 0.044675038
pgxpool_acquire_duration_seconds_total{application_name="libvuln"} 0.0325225
# HELP pgxpool_acquired_conns Number of currently acquired connections in the pool.
# TYPE pgxpool_acquired_conns gauge
pgxpool_acquired_conns{application_name="libindex"} 1
pgxpool_acquired_conns{application_name="libvuln"} 1
# HELP pgxpool_canceled_acquire_count Cumulative count of acquires from the pool that were canceled by a context.
# TYPE pgxpool_canceled_acquire_count counter
pgxpool_canceled_acquire_count{application_name="libindex"} 0
pgxpool_canceled_acquire_count{application_name="libvuln"} 0
# HELP pgxpool_constructing_conns Number of conns with construction in progress in the pool.
# TYPE pgxpool_constructing_conns gauge
pgxpool_constructing_conns{application_name="libindex"} 0
pgxpool_constructing_conns{application_name="libvuln"} 0
# HELP pgxpool_empty_acquire Cumulative count of successful acquires from the pool that waited for a resource to be released or constructed because the pool was empty.
# TYPE pgxpool_empty_acquire counter
pgxpool_empty_acquire{application_name="libindex"} 2
pgxpool_empty_acquire{application_name="libvuln"} 1
# HELP pgxpool_idle_conns Number of currently idle conns in the pool.
# TYPE pgxpool_idle_conns gauge
pgxpool_idle_conns{application_name="libindex"} 1
pgxpool_idle_conns{application_name="libvuln"} 0
# HELP pgxpool_max_conns Maximum size of the pool.
# TYPE pgxpool_max_conns gauge
pgxpool_max_conns{application_name="libindex"} 10
pgxpool_max_conns{application_name="libvuln"} 10
# HELP pgxpool_total_conns Total number of resources currently in the pool. The value is the sum of ConstructingConns, AcquiredConns, and IdleConns.
# TYPE pgxpool_total_conns gauge
pgxpool_total_conns{application_name="libindex"} 2
pgxpool_total_conns{application_name="libvuln"} 1
```