### PR TITLE
rpm: add copy to SQLite test

### DIFF
--- a/rpm/native_db_test.go
+++ b/rpm/native_db_test.go
@@ -3,6 +3,8 @@ package rpm
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -82,6 +84,23 @@ func TestInfo(t *testing.T) {
 					}
 					nat = &db
 				case `sqlite`:
+					f, err := os.Create(filepath.Join(t.TempDir(), "db"))
+					if err != nil {
+						t.Fatal(err)
+					}
+					src, err := os.Open(filename)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if _, err := io.Copy(f, src); err != nil {
+						t.Fatal(err)
+					}
+					if err := errors.Join(src.Close(), f.Close()); err != nil {
+						t.Fatal(err)
+					}
+					filename = f.Name()
+					t.Logf("copied sqlite database to: %s", filename)
+
 					db, err := sqlite.Open(filename)
 					if err != nil {
 						t.Fatal(err)


### PR DESCRIPTION
SQLite attempts to open WAL files alongside the database, which is a problem when running the tests out of a module download.