### PR TITLE
cpe: fix cross-version matching

### DIFF
--- a/toolkit/types/cpe/match.go
+++ b/toolkit/types/cpe/match.go
@@ -7,6 +7,8 @@ import (
 // Compare implements the pairwise CPE comparison algorithm as defined by
 // the CPE Name Matching spec: https://nvlpubs.nist.gov/nistpubs/Legacy/IR/nistir7696.pdf
 func Compare(src, tgt WFN) Relations {
+	// Per Section 5.4.2 of the CPE Naming specification, "any" and "unset" are
+	// equivalent when reading from a WFN.
 	var m [NumAttr]Relation
 	for i := 0; i < NumAttr; i++ {
 		sv, tv := src.Attr[i], tgt.Attr[i]
@@ -16,9 +18,9 @@ func Compare(src, tgt WFN) Relations {
 			continue
 		}
 		switch sv.Kind {
-		case ValueAny:
+		case ValueAny, ValueUnset:
 			switch tv.Kind {
-			case ValueAny:
+			case ValueAny, ValueUnset:
 				m[i] = Equal
 			case ValueNA:
 				m[i] = Superset
@@ -27,7 +29,7 @@ func Compare(src, tgt WFN) Relations {
 			}
 		case ValueNA:
 			switch tv.Kind {
-			case ValueAny:
+			case ValueAny, ValueUnset:
 				m[i] = Subset
 			case ValueNA:
 				m[i] = Equal
@@ -37,7 +39,7 @@ func Compare(src, tgt WFN) Relations {
 		case ValueSet:
 			if hasWildcard(sv.V) {
 				switch tv.Kind {
-				case ValueAny:
+				case ValueAny, ValueUnset:
 					m[i] = Subset
 				case ValueNA:
 					m[i] = Disjoint
@@ -51,7 +53,7 @@ func Compare(src, tgt WFN) Relations {
 				break
 			}
 			switch tv.Kind {
-			case ValueAny:
+			case ValueAny, ValueUnset:
 				m[i] = Subset
 			case ValueNA:
 				m[i] = Disjoint
@@ -62,12 +64,6 @@ func Compare(src, tgt WFN) Relations {
 				}
 				m[i] = Disjoint
 			}
-		case ValueUnset:
-			if tv.Kind == ValueUnset {
-				m[i] = Equal
-				break
-			}
-			m[i] = Disjoint
 		}
 	}
 	return m

--- a/toolkit/types/cpe/match.go
+++ b/toolkit/types/cpe/match.go
@@ -12,7 +12,7 @@ func Compare(src, tgt WFN) Relations {
 		sv, tv := src.Attr[i], tgt.Attr[i]
 		// This encodes table 6-2 of the matching spec.
 		if tv.Kind == ValueSet && hasWildcard(tv.V) {
-			m[i] = Relation(0)
+			m[i] = Invalid
 			continue
 		}
 		switch sv.Kind {
@@ -182,7 +182,7 @@ type Relation uint
 // The super- and sub-sets indicate the conventional sense, meaning a set is
 // equal to itself and also a superset and subset of itself.
 const (
-	_        Relation = iota // invalid
+	Invalid  Relation = iota //∅
 	Superset                 //⊃
 	Subset                   //⊂
 	Equal                    //=

--- a/toolkit/types/cpe/match_test.go
+++ b/toolkit/types/cpe/match_test.go
@@ -1,26 +1,128 @@
 package cpe
 
 import (
+	"bytes"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
 	"testing"
+	"text/tabwriter"
 
 	"github.com/google/go-cmp/cmp"
 )
 
 func TestMatch(t *testing.T) {
-	// There seems to be no test vectors for the match specification.
-	src := MustUnbind(`cpe:/a:Adobe::9.*::PalmOS`)
-	t.Logf("srv: %+v", src)
-	tgt := MustUnbind(`cpe:/a::Reader:9.3.2:-:-`)
-	t.Logf("tgt: %+v", tgt)
-	got := Compare(src, tgt)
-	t.Logf("relations: %+v", got)
-	if !got.IsDisjoint() {
-		t.Error("wanted IsDisjoint() == true")
+	type testcase struct {
+		Source string
+		Target string
+		Want   Relations
 	}
-	want := Relations([NumAttr]Relation{
-		Equal, Subset, Superset, Superset, Superset, Disjoint, Equal, Equal, Equal, Equal, Equal,
-	})
-	if !cmp.Equal(got, want) {
-		t.Error(cmp.Diff(got, want))
+
+	// There seems to be no test vectors for the match specification.
+	matchTable := []testcase{
+		{
+			Source: `cpe:/a:Adobe::9.*::PalmOS`,
+			Target: `cpe:/a::Reader:9.3.2:-:-`,
+			Want: Relations([NumAttr]Relation{
+				Equal, Subset, Superset, Superset, Superset, Disjoint, Equal, Equal, Equal, Equal, Equal,
+			}),
+		},
+		// Check that comparing across CPE versions works:
+		{
+			Source: `cpe:/o:redhat:enterprise_linux:8::baseos`,
+			Target: `cpe:/o:redhat:enterprise_linux:8`,
+			Want: Relations([NumAttr]Relation{
+				Equal, Equal, Equal, Equal, Equal, Subset, Equal, Equal, Equal, Equal, Equal,
+			}),
+		},
+		{
+			Source: MustUnbind(`cpe:/o:redhat:enterprise_linux:8::baseos`).String(),
+			Target: MustUnbind(`cpe:/o:redhat:enterprise_linux:8`).String(),
+			Want: Relations([NumAttr]Relation{
+				Equal, Equal, Equal, Equal, Equal, Subset, Equal, Equal, Equal, Equal, Equal,
+			}),
+		},
+		{
+			Source: MustUnbind(`cpe:/o:redhat:enterprise_linux:8::baseos`).String(),
+			Target: `cpe:/o:redhat:enterprise_linux:8`,
+			Want: Relations([NumAttr]Relation{
+				Equal, Equal, Equal, Equal, Equal, Subset, Equal, Equal, Equal, Equal, Equal,
+			}),
+		},
+		{
+			Source: `cpe:/o:redhat:enterprise_linux:8::baseos`,
+			Target: MustUnbind(`cpe:/o:redhat:enterprise_linux:8`).String(),
+			Want: Relations([NumAttr]Relation{
+				Equal, Equal, Equal, Equal, Equal, Subset, Equal, Equal, Equal, Equal, Equal,
+			}),
+		},
+	}
+
+	var buf bytes.Buffer
+	w := tabwriter.NewWriter(&buf, 3, 4, 1, ' ', 0)
+	for _, tc := range matchTable {
+		t.Run("", func(t *testing.T) {
+			src, tgt := MustUnbind(tc.Source), MustUnbind(tc.Target)
+			got, want := Compare(src, tgt), tc.Want
+
+			buf.Reset()
+			fmt.Fprintf(w, "source:%s\n", tabfmtWFN(src))
+			fmt.Fprintf(w, "target:%s\n", tabfmtWFN(tgt))
+			fmt.Fprintf(w, "got:%s\n", tabfmtRelations(got))
+			fmt.Fprintf(w, "want:%s\n", tabfmtRelations(want))
+			w.Flush()
+			t.Logf("state:\n%s", buf.String())
+
+			buf.Reset()
+			tabfmtResults(w, got)
+			w.Flush()
+			t.Logf("results:\n%s", buf.String())
+
+			if !cmp.Equal(got, want) {
+				t.Error(cmp.Diff(got, want))
+			}
+		})
+	}
+}
+
+func tabfmtWFN(w WFN) string {
+	var b strings.Builder
+	for _, a := range w.Attr {
+		b.WriteByte('\t')
+		switch a.Kind {
+		case ValueUnset:
+			b.WriteString("∅")
+		case ValueAny:
+			b.WriteString("ANY")
+		case ValueNA:
+			b.WriteString("NA")
+		case ValueSet:
+			b.WriteString(strconv.Quote(a.V))
+		}
+	}
+	return b.String()
+}
+
+func tabfmtRelations(r Relations) string {
+	var b strings.Builder
+	for _, r := range r {
+		b.WriteByte('\t')
+		b.WriteString(r.String())
+	}
+	return b.String()
+}
+
+func tabfmtResults(w io.Writer, r Relations) {
+	for _, x := range []struct {
+		rel string
+		val bool
+	}{
+		{"superset", r.IsSuperset()},
+		{"subset", r.IsSubset()},
+		{"equal", r.IsEqual()},
+		{"disjoint", r.IsDisjoint()},
+	} {
+		fmt.Fprintf(w, "%s?\t%v\n", x.rel, x.val)
 	}
 }

--- a/toolkit/types/cpe/relation_string.go
+++ b/toolkit/types/cpe/relation_string.go
@@ -8,20 +8,20 @@ func _() {
 	// An "invalid array index" compiler error signifies that the constant values have changed.
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
+	_ = x[Invalid-0]
 	_ = x[Superset-1]
 	_ = x[Subset-2]
 	_ = x[Equal-3]
 	_ = x[Disjoint-4]
 }
 
-const _Relation_name = "⊃⊂=≠"
+const _Relation_name = "∅⊃⊂=≠"
 
-var _Relation_index = [...]uint8{0, 3, 6, 7, 10}
+var _Relation_index = [...]uint8{0, 3, 6, 9, 10, 13}
 
 func (i Relation) String() string {
-	i -= 1
 	if i >= Relation(len(_Relation_index)-1) {
-		return "Relation(" + strconv.FormatInt(int64(i+1), 10) + ")"
+		return "Relation(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 	return _Relation_name[_Relation_index[i]:_Relation_index[i+1]]
 }

--- a/toolkit/types/cpe/wfn.go
+++ b/toolkit/types/cpe/wfn.go
@@ -8,7 +8,7 @@ import (
 	"unicode/utf8"
 )
 
-//go:generate -command stringer go run golang.org/x/tools/cmd/stringer
+//go:generate -command stringer go run golang.org/x/tools/cmd/stringer@latest
 //go:generate stringer -type Attribute -linecomment
 //go:generate stringer -type ValueKind
 


### PR DESCRIPTION
@crozzy discovered that the matching implementation behaved differently depending on whether the incoming CPE was unbound from a 2.2 URI or a 2.3 formatted string.