### PR TITLE
indexer: persist layer scanned after persisting scan results

### DIFF
--- a/indexer/layerscanner.go
+++ b/indexer/layerscanner.go
@@ -205,11 +205,15 @@ func (ls *LayerScanner) scanLayer(ctx context.Context, l *claircore.Layer, s Ver
 		return err
 	}
 
+	if err = result.Store(ctx, ls.store, s, l); err != nil {
+		return err
+	}
+
 	if err = ls.store.SetLayerScanned(ctx, l.Hash, s); err != nil {
 		return fmt.Errorf("could not set layer scanned: %w", err)
 	}
 
-	return result.Store(ctx, ls.store, s, l)
+	return nil
 }
 
 // Result is a type that handles the kind-specific bits of the scan process.


### PR DESCRIPTION
Persisting a layer as "scanned" happens in a separate transaction, and may fail. Do it after successfully persisting the scan results.

Avoids the fault where:
1. persisting the layer as scanned succeeds
   ie. `ls.store.SetLayerScanned(...)` returns no error
1. persisting scan results fails
   ie. `result.Store(...)` returns an error
1. a HTTP500 failed index report is returned
1. future index reports for the same manifest have no effect: the layer is marked as "scanned", so nothing is done
1. future vuln reports may be wrong: eg. if the failed scanner was a distribution scanner, the report is missing a distribution, and no vulnerabilities can be matched