### PR TITLE
matcher: new database schema

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,7 @@ jobs:
 
   tests:
     name: Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04  # TODO(hank) Move back to "-latest" once stablized.
     strategy:
       fail-fast: false
       matrix:

--- a/datastore/postgres/migrations/main_test.go
+++ b/datastore/postgres/migrations/main_test.go
@@ -1,0 +1,174 @@
+// Package migrations_test does blackbox testing for the database migrations.
+//
+// By default, it simply runs all the migrations.
+// To run pure-SQL tests, add a txtar file in `${name}/migration_${NN}.txtar`
+// (where `name` is "indexer" or "matcher" and `NN` is the relevant migration ID).
+// Any comment in the txtar is executed before the files.
+// Files in the txtar are executed in separate tests.
+//
+// Tests should make sure to add any test-only objects or functions to the "$user" schema.
+// This schema is not cleared between tests, but previous tests may not have been run.
+// Make sure to use `OR REPLACE` constructs for the test helpers.
+package migrations_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"text/tabwriter"
+	"time"
+
+	"github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/jackc/pgx/v4/stdlib"
+	"github.com/quay/zlog"
+	"github.com/remind101/migrate"
+	"golang.org/x/tools/txtar"
+
+	"github.com/quay/claircore/datastore/postgres/migrations"
+	"github.com/quay/claircore/test/integration"
+	pgtest "github.com/quay/claircore/test/postgres"
+)
+
+func TestMain(m *testing.M) {
+	var c int
+	defer func() { os.Exit(c) }()
+	defer integration.DBSetup()()
+	c = m.Run()
+}
+
+func TestIndexer(t *testing.T) {
+	doTests(t, `indexer`, migrations.IndexerMigrations)
+}
+
+func TestMatcher(t *testing.T) {
+	doTests(t, `matcher`, migrations.MatcherMigrations)
+}
+
+func doTests(t *testing.T, n string, ms []migrate.Migration) {
+	t.Helper()
+	ctx := zlog.Test(context.Background(), t)
+	integration.NeedDB(t)
+	pool := pgtest.TestDB(ctx, t)
+
+	mdb := stdlib.OpenDB(*pool.Config().ConnConfig)
+	defer mdb.Close()
+	migrator := migrate.NewPostgresMigrator(mdb)
+
+	for i, m := range ms {
+		t.Run(fmt.Sprintf("%02d", i+1), func(t *testing.T) {
+			ctx := zlog.Test(ctx, t)
+			// Do it this way to let the `-run` flag work correctly.
+			if err := migrator.Exec(migrate.Up, ms[:i+1]...); err != nil {
+				t.Fatal(err)
+			}
+
+			arname := filepath.Join(n, `testdata`, fmt.Sprintf(`migration_%02d.txtar`, m.ID))
+			_, err := os.Stat(arname)
+			switch {
+			case err == nil:
+				t.Logf("running migration tests")
+			case errors.Is(err, fs.ErrNotExist):
+				t.Skip("no tests")
+			default:
+				t.Fatal(err)
+			}
+			ar, err := txtar.ParseFile(arname)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			runTests(t, ctx, pool, ar)
+		})
+	}
+}
+
+func runTests(t *testing.T, ctx context.Context, pool *pgxpool.Pool, ar *txtar.Archive) {
+	t.Helper()
+	if len(ar.Comment) != 0 {
+		t.Logf("loading helpers")
+		cmd := string(ar.Comment)
+		err := pool.AcquireFunc(ctx, func(conn *pgxpool.Conn) error {
+			defer printFromLogID(t, ctx, conn, getLogID(t, ctx, conn))
+
+			tag, err := conn.Exec(ctx, cmd)
+			if err != nil {
+				return err
+			}
+			t.Log(tag)
+			return nil
+		})
+		if err != nil {
+			t.Error(err)
+			return
+		}
+	}
+	for _, f := range ar.Files {
+		t.Run(f.Name, func(t *testing.T) {
+			ctx := zlog.Test(ctx, t)
+			cmd := string(f.Data)
+			err := pool.AcquireFunc(ctx, func(conn *pgxpool.Conn) error {
+				defer printFromLogID(t, ctx, conn, getLogID(t, ctx, conn))
+
+				tag, err := conn.Exec(ctx, cmd)
+				if err != nil {
+					return err
+				}
+				t.Log(tag)
+				return nil
+			})
+			if err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}
+
+// This is a hack and will blow up in the future.
+
+func getLogID(t *testing.T, ctx context.Context, conn *pgxpool.Conn) (id int64) {
+	err := conn.QueryRow(ctx, `SELECT id FROM matcher_v2_meta.log ORDER BY id DESC LIMIT 1`).Scan(&id)
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		t.Error(err)
+		id = -1
+	}
+	return id
+}
+
+func printFromLogID(t *testing.T, ctx context.Context, conn *pgxpool.Conn, id int64) {
+	rows, err := conn.Query(ctx, `SELECT ts, kind, message, event FROM matcher_v2_meta.log WHERE id > $1 ORDER BY id`, id)
+	if err != nil {
+		t.Log(err)
+		return
+	}
+	defer rows.Close()
+	var b strings.Builder
+	var st, prev, ts time.Time
+	var kind, msg string
+	var ev []byte
+	tw := tabwriter.NewWriter(&b, 1, 0, 1, ' ', 0)
+	for rows.Next() {
+		if err := rows.Scan(&ts, &kind, &msg, &ev); err != nil {
+			t.Error(err)
+			continue
+		}
+		if st.IsZero() {
+			st = ts
+			prev = ts
+		}
+		fmt.Fprintf(tw, "%v\t+%v\t%s:\t%s\t%s\n", ts.Sub(st), ts.Sub(prev), kind, msg, string(ev))
+		prev = ts
+	}
+	if err := rows.Err(); err != nil {
+		t.Error(err)
+	}
+	tw.Flush()
+	if b.Len() != 0 {
+		t.Logf("database log messages:\n%s", b.String())
+	}
+}

--- a/datastore/postgres/migrations/matcher/13-v2-schema-meta.sql
+++ b/datastore/postgres/migrations/matcher/13-v2-schema-meta.sql
@@ -1,0 +1,185 @@
+-- vim: set foldmethod=marker :
+-- The formatting in this file is best-effort, all SQL formatters are garbage.
+-- It's dangerous to go alone! Take this.
+-- https://www.postgresql.org/docs/current/plpgsql.html
+CREATE SCHEMA matcher_v2_meta;
+
+COMMENT ON SCHEMA matcher_v2_meta IS $$
+Matcher_v2_meta is data about objects in the matcher_v2 table.
+
+Needs to have the "housekeeping" function called at least weekly.
+$$;
+
+SET LOCAL search_path TO matcher_v2_meta, "$user", public;
+
+-- {{{ Meta
+CREATE OR REPLACE FUNCTION config_fingerprint (cfg JSONB)
+	RETURNS BYTEA IMMUTABLE STRICT PARALLEL SAFE
+	LANGUAGE SQL
+	AS $$
+	SELECT
+		sha256 (convert_to(cfg #>> '{}', 'utf8'));
+$$;
+
+COMMENT ON FUNCTION config_fingerprint (JSONB) IS 'Meta_config_fingerprint computes a fingerprint for the supplied JSONB.';
+
+CREATE OR REPLACE FUNCTION config_fingerprint (cfg TEXT)
+	RETURNS BYTEA IMMUTABLE STRICT PARALLEL SAFE
+	LANGUAGE SQL
+	AS $$
+	SELECT
+		matcher_v2_meta.config_fingerprint (to_jsonb (cfg));
+$$;
+
+COMMENT ON FUNCTION config_fingerprint (TEXT) IS $$
+Meta_config_fingerprint computes a fingerprint for the supplied JSON-formatted text.
+
+This function converts the input to JSONB internally, so it's better to use the function that accepts JSONB directly if you have it.
+$$;
+
+CREATE TABLE config (
+	id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+	config JSONB,
+	fingerprint BYTEA GENERATED ALWAYS AS (matcher_v2_meta.config_fingerprint (config)) STORED
+);
+
+COMMENT ON TABLE config IS $$
+Meta_config holds configuration for parts of the matcher database itself.
+
+This is implemented in-database (instead of relying on parameters being passed for every function) to help with observability.
+$$;
+
+CREATE OR REPLACE FUNCTION latest_config ()
+	RETURNS JSONB
+	LANGUAGE SQL
+	AS $$
+	SELECT
+		config
+	FROM
+		matcher_v2_meta.config
+	ORDER BY
+		id DESC
+	LIMIT 1
+$$;
+
+COMMENT ON FUNCTION latest_config IS 'Latest_config returns the latest config.';
+
+CREATE TABLE log (
+	id BIGINT GENERATED ALWAYS AS IDENTITY NOT NULL, -- NB *not* PRIMARY KEY
+	pid BIGINT NOT NULL DEFAULT pg_backend_pid(),
+	ts TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT clock_timestamp(),
+	kind TEXT,
+	event JSONB,
+	message TEXT,
+	UNIQUE (id, ts) -- Needed for the paritioning.
+)
+PARTITION BY RANGE (ts);
+
+COMMENT ON TABLE log IS $$
+Internal log table.
+
+Partitioned by week. Needs to have the function "housekeeping" called at least weekly.
+$$;
+
+CREATE OR REPLACE PROCEDURE emit_log (kind TEXT, message TEXT, event JSONB)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+	INSERT INTO matcher_v2_meta.log(kind, message, event) VALUES (kind, message, event);
+	RAISE INFO '%: % %', kind, message, event;
+END;
+$$;
+
+CREATE OR REPLACE PROCEDURE emit_log (kind TEXT, message TEXT)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+	INSERT INTO matcher_v2_meta.log(kind, message, event) VALUES (kind, message, NULL);
+	RAISE INFO '%: %', kind, message;
+END;
+$$;
+
+COMMENT ON PROCEDURE emit_log(TEXT, TEXT, JSONB) IS 'Emit_log is a helper that records a log message and uses the standard PostgreSQL logging.';
+
+CREATE OR REPLACE FUNCTION housekeeping ()
+	RETURNS void
+	LANGUAGE plpgsql
+	AS $$
+DECLARE
+	namefmt TEXT := 'log_IYYY_IW';
+	config JSONB;
+	instant TIMESTAMP;
+	tablename TEXT;
+	removed RECORD;
+	-- Config values:
+	log_table_precreate INTEGER;
+	log_table_keep INTEGER;
+	config_keep INTEGER;
+BEGIN
+	config := matcher_v2_meta.latest_config ();
+	SELECT
+		INTO log_table_keep coalesce((config -> 'log_table_keep')::INTEGER, 2);
+	SELECT
+		INTO log_table_precreate coalesce((config -> 'log_table_precreate')::INTEGER, 2);
+	SELECT
+		INTO config_keep coalesce((config -> 'config_keep')::INTEGER, 10);
+	-- Create log loop
+	-- Cannot call the log function in here until after the loop has run.
+	FOR w IN 0..log_table_precreate LOOP
+		instant := CURRENT_TIMESTAMP + make_interval(weeks => w);
+		tablename := to_char(instant, namefmt);
+		IF to_regclass ('' || tablename) IS NULL THEN
+			EXECUTE format('CREATE TABLE "matcher_v2_meta".%I PARTITION OF "matcher_v2_meta"."log" FOR VALUES FROM (%L) TO (%L)', tablename, date_trunc('week', instant), date_trunc('week', instant + make_interval(weeks => 1)));
+			CALL matcher_v2_meta.emit_log ('meta', 'created log table', jsonb_build_object('name', tablename));
+		END IF;
+	END LOOP;
+	-- Delete log loop
+	FOR w IN REVERSE - 1.. (-1 * log_table_keep)
+	LOOP
+		instant := CURRENT_TIMESTAMP + make_interval(weeks => w);
+		tablename := to_char(instant, namefmt);
+		IF to_regclass (tablename) IS NOT NULL THEN
+			EXECUTE format('DROP TABLE "matcher_v2_meta".%I', tablename);
+			CALL matcher_v2_meta.emit_log ('meta', 'deleted log table', jsonb_build_object('name', tablename));
+		END IF;
+	END LOOP;
+	-- Delete config loop
+	FOR removed IN DELETE FROM matcher_v2_meta.config
+	WHERE id IN (
+			SELECT
+				id
+			FROM
+				matcher_v2_meta.config
+			ORDER BY
+				id DESC OFFSET config_keep)
+		RETURNING (id,
+			fingerprint)
+			LOOP
+				CALL matcher_v2_meta.emit_log ('meta', 'deleted previous config', jsonb_build_object('id', removed.id, 'fingerprint', removed.fingerprint));
+			END LOOP;
+	CALL matcher_v2_meta.emit_log('meta', 'housekeeping run finished');
+END;
+$$;
+
+COMMENT ON FUNCTION housekeeping () IS $$
+Housekeeping manages the partitions of the "log" table and manages the number of rows in the "config" table.
+
+Uses the config keys:
+- log_table_precreate
+  Number of weeks of logs to pre-create tables for. (default: 2)
+  Setting this to 0 will almost certainly break things.
+- log_table_keep
+  Number of weeks of logs to keep. (default: 2)
+- config_keep
+  Number of config versions to keep. (default: 10)
+$$;
+
+-- }}}
+
+DO LANGUAGE plpgsql
+$$
+BEGIN
+	PERFORM matcher_v2_meta.housekeeping ();
+	CALL matcher_v2_meta.emit_log ('init', 'matcher_v2_meta schema populated');
+END
+$$;

--- a/datastore/postgres/migrations/matcher/14-v2-schema.sql
+++ b/datastore/postgres/migrations/matcher/14-v2-schema.sql
@@ -1,0 +1,586 @@
+-- vim: set foldmethod=marker :
+-- The formatting in this file is best-effort, all SQL formatters are garbage.
+-- It's dangerous to go alone! Take this.
+-- https://www.postgresql.org/docs/current/plpgsql.html
+CREATE SCHEMA matcher_v2;
+
+COMMENT ON SCHEMA matcher_v2 IS $$
+Matcher_v2 is a revised version of the schema for storing data to match against.
+
+Compared with the v1 structure this version normalizes more data, avoids some excessive write traffic pitfalls, and avoids client-side hashing schemes.
+$$;
+
+SET LOCAL search_path TO matcher_v2, "$user", public;
+
+-- {{{ Domain types
+CREATE TYPE Severity AS ENUM (
+	'Unknown',
+	'Negligible',
+	'Low',
+	'Medium',
+	'High',
+	'Critical'
+);
+
+COMMENT ON TYPE Severity IS 'Severity values are the defined Claircore "normalized" values.';
+-- {{{ VersionRange
+CREATE TYPE VersionRange AS RANGE (
+	SUBTYPE = TEXT[]
+	-- It would be great to be able to have a "canonical" function here that
+	-- handled digit-only strings transparently, but it's impossible:
+	-- 1. A shell type is a base type, so the user must be a superuser
+	-- 2. A PL cannot interact with shell types, so the function must be written in C.
+);
+
+COMMENT ON TYPE VersionRange IS 'VersionRange is a type for doing version comparisons in a standard way.';
+
+CREATE OR REPLACE FUNCTION version_check_array (vs TEXT[])
+	RETURNS BOOLEAN IMMUTABLE STRICT PARALLEL SAFE
+	LANGUAGE plpgsql
+	AS $$
+DECLARE
+	v TEXT;
+BEGIN
+	FOREACH v IN ARRAY vs LOOP
+		IF v ~ '\s' OR (v ~ '^\d+$' AND length(v) <> 10) THEN
+			RETURN FALSE;
+		END IF;
+	END LOOP;
+	RETURN TRUE;
+END;
+$$;
+
+COMMENT ON FUNCTION version_check_array IS 'This function reports whether a text array is well-formed to be used as a VersionRange';
+
+CREATE OR REPLACE FUNCTION version_check (mr matcher_v2.VersionMultiRange)
+	RETURNS BOOLEAN IMMUTABLE STRICT PARALLEL SAFE
+	LANGUAGE plpgsql
+	AS $$
+DECLARE
+	v matcher_v2.VersionRange;
+BEGIN
+	FOR v IN
+	SELECT
+		unnest(mr)
+		LOOP
+			IF NOT matcher_v2.version_check_array (lower(v)) AND matcher_v2.version_check_array (upper(v)) THEN
+				RETURN FALSE;
+			END IF;
+		END LOOP;
+	RETURN TRUE;
+END;
+$$;
+
+COMMENT ON FUNCTION version_check IS 'This function reports whether VersionMultiRange has well-formed VersionRange members.';
+-- }}}
+CREATE TYPE PackageKind AS ENUM (
+	'source',
+	'binary'
+);
+
+COMMENT ON TYPE PackageKind IS 'Enum for package kinds.';
+
+CREATE TYPE Architecture AS ENUM (
+	'any',
+	'386',
+	'amd64',
+	'arm',
+	'arm64',
+	'mips',
+	'mipsle',
+	'mips64',
+	'mips64le',
+	'ppc64',
+	'ppc64le',
+	'riscv64',
+	's390x'
+);
+
+COMMENT ON TYPE Architecture IS 'Enum for architectures. The text value is in Go notation';
+-- }}}
+-- {{{ Updater table
+CREATE TABLE updater (
+	id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+	"name" TEXT UNIQUE NOT NULL
+);
+
+COMMENT ON TABLE updater IS 'Updater keeps track of known Updaters in the system.';
+
+COMMENT ON COLUMN updater.name IS 'Updater name.';
+
+CREATE OR REPLACE FUNCTION updater_id (n TEXT)
+	RETURNS BIGINT STRICT
+	LANGUAGE plpgsql
+	AS $$
+DECLARE
+	out BIGINT;
+BEGIN
+	SELECT id INTO out FROM matcher_v2.updater WHERE name = n;
+	IF NOT FOUND THEN
+		INSERT INTO matcher_v2.updater (name)
+			VALUES (n)
+		RETURNING
+			id INTO out;
+	END IF;
+	RETURN out;
+END;
+$$;
+
+COMMENT ON FUNCTION updater_id IS 'Updater_id returns the id of the named updater, creating it if needed.';
+-- }}}
+-- {{{ Run tables
+CREATE TABLE run (
+	id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+	ref UUID UNIQUE NOT NULL,
+	date TIMESTAMP WITH TIME ZONE DEFAULT now()
+);
+
+COMMENT ON TABLE run IS 'Run logs updater system runs.';
+
+COMMENT ON COLUMN run.ref IS 'UUID for client presentation. Prevents leaking database IDs.';
+
+COMMENT ON COLUMN run.date IS 'Timestamp of this run. For debugging and reporting.';
+
+CREATE TABLE updater_run (
+	id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+	ref UUID UNIQUE NOT NULL,
+	updater BIGINT NOT NULL REFERENCES updater (id) ON DELETE CASCADE,
+	run BIGINT NOT NULL REFERENCES run (id) ON DELETE CASCADE,
+	success BOOLEAN GENERATED ALWAYS AS (error IS NULL) STORED,
+	fingerprint JSONB,
+	error TEXT
+);
+
+CREATE INDEX updater_run_updater_fk_idx ON updater_run (updater);
+
+CREATE INDEX updater_run_run_fk_idx ON updater_run (run);
+
+COMMENT ON TABLE updater_run IS 'Updater_run logs specific updater runs.';
+
+COMMENT ON COLUMN updater_run.ref IS 'UUID for client presentation. Prevents leaking database IDs.';
+
+COMMENT ON COLUMN updater_run.updater IS 'Reference to updater(id).';
+
+COMMENT ON COLUMN updater_run.run IS 'Reference to run(id).';
+
+COMMENT ON COLUMN updater_run.success IS 'Whether an error was reported for this run.';
+
+COMMENT ON COLUMN updater_run.fingerprint IS 'Fingerprint is JSON metadata passed into the next Updater run.';
+
+COMMENT ON COLUMN updater_run.error IS 'Error reported from the run. For debugging and reporting; may be NULL.';
+
+COMMENT ON INDEX updater_run_updater_fk_idx IS 'Index on foreign key for less costly deletes and joins.';
+
+COMMENT ON INDEX updater_run_run_fk_idx IS 'Index on foreign key for less costly deletes and joins.';
+-- }}}
+-- {{{ GC
+CREATE OR REPLACE PROCEDURE run_gc ()
+LANGUAGE plpgsql
+AS $$
+DECLARE
+	config JSONB;
+	rm_ref UUID;
+	rm_date TIMESTAMP WITH TIME ZONE;
+	rm_name TEXT;
+	rm_names TEXT[];
+	count INTEGER;
+	-- Config values:
+	retain_runs INTEGER;
+BEGIN
+	config := matcher_v2_meta.latest_config ();
+	SELECT
+		INTO retain_runs coalesce((config -> 'retain_runs')::INTEGER, 1);
+
+	CALL matcher_v2_meta.emit_log ('gc', 'start');
+
+	FOR rm_ref, rm_date IN 
+		DELETE FROM matcher_v2.run
+		WHERE id <= (
+				SELECT
+					id
+				FROM
+					matcher_v2.run
+				ORDER BY
+					id DESC
+				LIMIT 1 OFFSET retain_runs)
+		RETURNING
+			ref, date
+	LOOP
+		CALL matcher_v2_meta.emit_log ('gc', 'deleted run', jsonb_build_object('ref', rm_ref, 'date', rm_date));
+	END LOOP;
+
+	FOR rm_name IN
+		DELETE FROM matcher_v2.updater
+		WHERE NOT EXISTS (
+				SELECT
+					1
+				FROM
+					matcher_v2.updater_run
+				WHERE
+					updater = updater.id)
+		RETURNING
+			"name"
+	LOOP
+		CALL matcher_v2_meta.emit_log ('gc', 'deleted updater', jsonb_build_object('name', rm_name));
+	END LOOP;
+
+	INSERT INTO matcher_v2_meta.log(kind, event, message)
+	SELECT
+		'gc',
+		jsonb_build_object('updaters', array_agg(updater.name)),
+		'updaters in use'
+	FROM
+		matcher_v2.updater;
+
+	WITH del (name) AS (
+	DELETE FROM matcher_v2.reference WHERE NOT EXISTS (
+		SELECT 1 FROM matcher_v2.advisory_reference WHERE reference = reference.id
+	) RETURNING namespace || '-' || "name"
+	)
+	SELECT COALESCE(array_agg(del.name), ARRAY[]::TEXT[]) INTO rm_names FROM del;
+	CALL matcher_v2_meta.emit_log ('gc', 'deleted references', jsonb_build_object('names', rm_names));
+
+	WITH del (name) AS (
+	DELETE FROM matcher_v2.package_name WHERE NOT EXISTS (
+		SELECT 1 FROM matcher_v2.package WHERE name = package_name.id
+	) RETURNING name
+	)
+	SELECT COALESCE(array_agg(del.name), ARRAY[]::TEXT[]) INTO rm_names FROM del;
+	CALL matcher_v2_meta.emit_log ('gc', 'deleted package names', jsonb_build_object('names', rm_names));
+
+	DELETE FROM matcher_v2.attr WHERE NOT EXISTS (
+		SELECT 1 FROM matcher_v2.advisory_attr WHERE attr = attr.id
+	);
+	GET DIAGNOSTICS count = ROW_COUNT;
+	CALL matcher_v2_meta.emit_log ('gc', 'deleted attrs', jsonb_build_object('count', count));
+
+	WITH del (name) AS (
+	DELETE FROM matcher_v2.mediatype WHERE NOT EXISTS (
+		SELECT 1 FROM matcher_v2.attr WHERE mediatype = mediatype.id
+	) RETURNING mediatype
+	)
+	SELECT COALESCE(array_agg(del.name), ARRAY[]::TEXT[]) INTO rm_names FROM del;
+	CALL matcher_v2_meta.emit_log ('gc', 'deleted media types', jsonb_build_object('mediatypes', rm_names));
+
+	CALL matcher_v2_meta.emit_log ('gc', 'done');
+END;
+$$;
+
+COMMENT ON PROCEDURE run_gc () IS $$
+Run_gc runs a garbage collection pass.
+
+Uses the config keys:
+- retain_runs
+  Number of runs to retain per updater. (default: 1, meaning no history)
+$$;
+
+CREATE OR REPLACE PROCEDURE run_vacuum()
+LANGUAGE SQL
+AS $$
+	VACUUM (ANALYZE, PARALLEL 2)
+		matcher_v2.advisory,
+		matcher_v2.advisory_meta,
+		matcher_v2.reference,
+		matcher_v2.advisory_reference,
+		matcher_v2.package,
+		matcher_v2.package_name,
+		matcher_v2.mediatype,
+		matcher_v2.attr,
+		matcher_v2.advisory_attr;
+$$;
+
+COMMENT ON PROCEDURE run_vacuum() IS 'Helper for vacuumining the correct tables after GC.';
+-- }}}
+-- {{{ Advisory table
+CREATE TABLE advisory (
+	id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+	added BIGINT REFERENCES run (id) ON DELETE SET NULL, -- NB can be NULL
+	generation BIGINT NOT NULL REFERENCES run (id) ON DELETE CASCADE,
+	updater BIGINT NOT NULL REFERENCES updater (id) ON DELETE CASCADE,
+	name TEXT NOT NULL,
+	UNIQUE (updater, name)
+);
+
+CREATE INDEX advisory_added_fk_idx ON advisory (added);
+
+CREATE INDEX advisory_generation_fk_idx ON advisory (generation);
+
+COMMENT ON TABLE advisory IS 'Advisory is the parent object for an advisory.';
+
+COMMENT ON COLUMN advisory.added IS 'Reference to run(id). Used for garbage collection.';
+
+COMMENT ON COLUMN advisory.generation IS 'Reference to run(id). Used for garbage collection.';
+
+COMMENT ON COLUMN advisory.updater IS 'Reference to updater(id). Used to namespace the advisory name.';
+
+COMMENT ON COLUMN advisory.name IS 'Stable ID for the advisory within the updater''s namespace.';
+
+COMMENT ON INDEX advisory_added_fk_idx IS 'Index on foreign key for less costly deletes & joins.';
+
+COMMENT ON INDEX advisory_generation_fk_idx IS 'Index on foreign key for less costly deletes & joins.';
+
+CREATE OR REPLACE FUNCTION advisory_id (gen BIGINT, upd BIGINT, n TEXT)
+	RETURNS BIGINT STRICT
+	LANGUAGE plpgsql
+	AS $$
+DECLARE
+	out BIGINT;
+BEGIN
+	INSERT INTO matcher_v2.advisory (updater, name, generation, added)
+		VALUES (upd, n, gen, gen)
+	ON CONFLICT (updater, name)
+		DO UPDATE SET
+			generation = gen
+		RETURNING
+			id INTO out;
+	RETURN out;
+END;
+$$;
+
+COMMENT ON FUNCTION advisory_id IS 'Return the ID for the provided (updater, name) pair. Updates the observed generation.';
+
+CREATE OR REPLACE VIEW latest_advisory AS
+SELECT
+	advisory.*
+FROM
+	matcher_v2.advisory
+	JOIN (
+		SELECT
+			id
+		FROM
+			matcher_v2.run
+		ORDER BY
+			id DESC
+		LIMIT 1) run ON run.id = advisory.generation;
+
+COMMENT ON VIEW latest_advisory IS 'Latest_advisory is a view to simplify looking at the latest set of advisories.';
+
+CREATE TABLE advisory_meta (
+	id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+	advisory BIGINT NOT NULL UNIQUE REFERENCES advisory (id) ON DELETE CASCADE,
+	issued TIMESTAMPTZ,
+	summary TEXT,
+	description TEXT,
+	uri TEXT,
+	severity TEXT,
+	normalized_severity Severity
+);
+
+CREATE INDEX advisory_meta_advisory_fk_idx ON advisory_meta (advisory);
+
+COMMENT ON TABLE advisory_meta IS $$
+Advisory_meta is metadata not needed for matching or updating.
+
+Try to avoid indexes on this table so it's stored as HOT (https://www.postgresql.org/docs/current/storage-hot.html).
+$$;
+
+COMMENT ON COLUMN advisory_meta.advisory IS 'Foreign key to the advisory';
+
+COMMENT ON COLUMN advisory_meta.issued IS 'When the advisory was issued';
+
+COMMENT ON COLUMN advisory_meta.summary IS 'Human-readable summary from the advisory.';
+
+COMMENT ON COLUMN advisory_meta.description IS 'Human-readable description from the advisory. Likely much longer than the summary.';
+
+COMMENT ON COLUMN advisory_meta.uri IS 'Canonical URL for the advisory. Additional URLs may be in the "reference" table.';
+
+COMMENT ON COLUMN advisory_meta.severity IS 'Literal severity as reported in the advisory.';
+
+COMMENT ON COLUMN advisory_meta.normalized_severity IS 'Reported severity normalized to the Clair scale.';
+
+COMMENT ON INDEX advisory_meta_advisory_fk_idx IS 'Index on foreign key for less costly deletes & joins.';
+-- }}}
+-- {{{ Reference table
+CREATE TABLE reference (
+	id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+	namespace TEXT NOT NULL,
+	name TEXT NOT NULL,
+	uri TEXT[],
+	UNIQUE (namespace, "name")
+);
+
+CREATE INDEX reference_namespace_name_idx ON reference (namespace, name);
+
+COMMENT ON TABLE reference IS 'References are names shared across databases.';
+
+COMMENT ON COLUMN reference.namespace IS 'Reference namespace, eg "CVE" or "RHSA".';
+
+COMMENT ON COLUMN reference.name IS 'References'' namespaced name, eg "2014-0160" or "2014-0376".';
+
+COMMENT ON COLUMN reference.uri IS 'An array of URIs for more information.';
+
+COMMENT ON INDEX reference_namespace_name_idx IS 'Index on namespace-name pair to help reverse-lookups.';
+
+CREATE OR REPLACE FUNCTION reference_id (ns TEXT, n TEXT)
+	RETURNS BIGINT STRICT
+	LANGUAGE plpgsql
+	AS $$
+DECLARE
+	out BIGINT;
+BEGIN
+	INSERT INTO matcher_v2.reference (namespace, name)
+		VALUES (ns, n)
+	ON CONFLICT (namespace, name)
+		DO NOTHING
+	RETURNING
+		id INTO out;
+	RETURN out;
+END;
+$$;
+
+COMMENT ON FUNCTION reference_id IS 'Return the ID for the provided (namespace, name) pair.';
+
+CREATE TABLE advisory_reference (
+	advisory BIGINT NOT NULL REFERENCES advisory (id) ON DELETE CASCADE,
+	reference BIGINT NOT NULL REFERENCES reference (id) ON DELETE CASCADE,
+	PRIMARY KEY (advisory, reference)
+);
+
+CREATE INDEX advisory_reference_reference_fk_idx ON advisory_reference (reference);
+
+COMMENT ON TABLE advisory_reference IS 'Advisory_reference is the many-many mapping between advisories and references.';
+
+COMMENT ON COLUMN advisory_reference.advisory IS 'Foreign key to the advisory table.';
+
+COMMENT ON COLUMN advisory_reference.reference IS 'Foreign key to the reference table.';
+
+COMMENT ON INDEX advisory_reference_reference_fk_idx IS 'Index on foreign key for less costly deletes & joins.';
+-- }}}
+-- {{{ Package table
+CREATE TABLE package_name (
+	id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+	name TEXT UNIQUE NOT NULL
+);
+
+COMMENT ON TABLE package_name IS 'Package_name is the table for interning package names.';
+
+COMMENT ON COLUMN package_name.name IS 'Package name.';
+
+CREATE OR REPLACE FUNCTION package_name_id (n TEXT)
+	RETURNS BIGINT STRICT
+	LANGUAGE plpgsql
+	AS $$
+DECLARE
+	out BIGINT;
+BEGIN
+	INSERT INTO matcher_v2.package_name (name)
+		VALUES (n)
+	ON CONFLICT (name)
+		DO NOTHING
+	RETURNING
+		id INTO out;
+	RETURN out;
+END;
+$$;
+
+COMMENT ON FUNCTION package_name_id IS 'Return the ID for the provided name.';
+
+CREATE TABLE package (
+	id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+	advisory BIGINT NOT NULL REFERENCES advisory (id) ON DELETE CASCADE,
+	name BIGINT NOT NULL REFERENCES package_name (id),
+	kind PackageKind,
+	arch Architecture[],
+	vulnerable_range VersionMultiRange NOT NULL CHECK (version_check (vulnerable_range)),
+	version_upstream TEXT[],
+	version_kind TEXT,
+	purl TEXT,
+	cpe TEXT,
+	UNIQUE (advisory, name, kind)
+);
+
+CREATE INDEX package_advisory_fk_idx ON package (advisory);
+
+CREATE INDEX package_package_name_fk_idx ON package (name);
+
+COMMENT ON TABLE package IS 'Package is the table containing software packages referenced in advisories. Packages are a special case of Attr.';
+
+COMMENT ON COLUMN package.advisory IS 'Foreign key to the advisory table.';
+
+COMMENT ON COLUMN package.name IS 'Foreign key to the package_name table.';
+
+COMMENT ON COLUMN package.kind IS 'The "kind" of this package.';
+
+COMMENT ON COLUMN package.arch IS 'Array of applicable architectures.';
+
+COMMENT ON COLUMN package.vulnerable_range IS 'The normalized version ranges of an affected package.';
+
+COMMENT ON COLUMN package.version_upstream IS 'The literal version strings as reported in the advisory.';
+
+COMMENT ON COLUMN package.version_kind IS 'The "kind" of the upstream version. Range operations are unlikely to make sense if this is not the expected kind.';
+
+COMMENT ON COLUMN package.purl IS 'The purl of this package. Version information should be omitted, as this is not describing a single package.';
+
+COMMENT ON COLUMN package.cpe IS 'The CPE for this package.';
+
+COMMENT ON INDEX package_advisory_fk_idx IS 'Index on foreign key for less costly deletes & joins.';
+
+COMMENT ON INDEX package_package_name_fk_idx IS 'Index on foreign key for less costly deletes & joins.';
+-- }}}
+-- {{{ Attr table
+CREATE TABLE mediatype (
+	id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+	mediatype TEXT UNIQUE NOT NULL
+);
+
+COMMENT ON TABLE mediatype IS 'Mediatype is the table for interning mediatypes.';
+
+COMMENT ON COLUMN mediatype.mediatype IS 'Media type. Should have an "application" type, although this is not currently enforced.';
+
+CREATE TABLE attr (
+	id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+	mediatype BIGINT NOT NULL REFERENCES mediatype (id) ON DELETE CASCADE,
+	data JSONB NOT NULL
+);
+
+CREATE INDEX attr_mediatype_fk_idx ON attr (mediatype);
+
+CREATE INDEX attr_data_gidx ON attr USING GIN (data jsonb_path_ops);
+
+CREATE INDEX attr_data_hidx ON attr USING HASH (data);
+
+ALTER TABLE attr
+	ADD UNIQUE (mediatype, data);
+
+COMMENT ON TABLE attr IS $$
+Attrs are generic features of advisories and references.
+
+The attrs on references replaces the previous matcher's "enrichments".
+$$;
+
+COMMENT ON COLUMN attr.mediatype IS 'Foreign key to the mediatype table.';
+
+COMMENT ON COLUMN attr.data IS 'Data is key-value data.';
+
+COMMENT ON INDEX attr_mediatype_fk_idx IS 'Index on foreign key for less costly deletes & joins.';
+
+COMMENT ON INDEX attr_data_gidx IS 'Index for jsonpath operations. Does not support key-exists operators.';
+
+COMMENT ON INDEX attr_data_hidx IS 'Index for equality operator.';
+
+CREATE TABLE advisory_attr (
+	advisory BIGINT NOT NULL REFERENCES advisory (id) ON DELETE CASCADE,
+	attr BIGINT NOT NULL REFERENCES attr (id) ON DELETE CASCADE,
+	PRIMARY KEY (advisory, attr)
+);
+
+CREATE INDEX advisory_attr_advisory_fk_idx ON advisory_attr (advisory);
+
+CREATE INDEX advisory_attr_attr_fk_idx ON advisory_attr (attr);
+
+COMMENT ON TABLE advisory_attr IS 'Advisory_attr is the many-to-many mapping of advisories and attrs.';
+
+COMMENT ON COLUMN advisory_attr.advisory IS 'Foreign key to the advisory table.';
+
+COMMENT ON COLUMN advisory_attr.attr IS 'Foreign key to the attr table.';
+
+COMMENT ON INDEX advisory_attr_advisory_fk_idx IS 'Index on foreign key for less costly deletes & joins.';
+
+COMMENT ON INDEX advisory_attr_attr_fk_idx IS 'Index on foreign key for less costly deletes & joins.';
+-- }}}
+DO LANGUAGE plpgsql
+$$
+BEGIN
+	CALL matcher_v2_meta.emit_log ('init', 'matcher_v2 schema populated');
+END
+$$;

--- a/datastore/postgres/migrations/matcher/15-v2-import.sql
+++ b/datastore/postgres/migrations/matcher/15-v2-import.sql
@@ -1,0 +1,493 @@
+-- vim: set foldmethod=marker :
+-- The formatting in this file is best-effort, all SQL formatters are garbage.
+-- It's dangerous to go alone! Take this.
+-- https://www.postgresql.org/docs/current/plpgsql.html
+
+CREATE SCHEMA matcher_v2_import;
+
+COMMENT ON SCHEMA matcher_v2_import IS $$
+Matcher_v2_import holds all the machinery for importing advisories.
+
+To use:
+1. Create (in `matcher_v2`) rows for a `run`, `updater`, and `updater_run` and record the resulting IDs.
+2. Call `stage` to prepare temporary tables.
+3. Load the temporary table (`advisory_import`) with data
+4. Call `commit_snapshot`, `commit_add`, or `commit_remove` as needed.
+5. Repeat steps 3 and 4 as needed.
+6. Call `finish` to update the tables in the `matcher_v2` schema with any pending changes.
+
+The above is all assumed to be done in a transaction, but the procedures do not currently enforce this.
+$$;
+
+SET LOCAL search_path TO matcher_v2_import,"$user",public;
+-- {{{ Shadow types
+-- These are composite types shadowing the row types in the matcher_v2 schema.
+-- Make sure to ALTER these when those tables are ALTERed.
+CREATE TYPE advisory AS (
+	name TEXT,
+	issued TIMESTAMPTZ,
+	summary TEXT,
+	description TEXT,
+	uri TEXT,
+	severity TEXT,
+	normalized_severity matcher_v2.Severity
+);
+COMMENT ON TYPE advisory IS 'Advisory information needed for import.';
+
+CREATE TYPE reference AS (
+	namespace TEXT,
+	name TEXT,
+	uri TEXT[]
+);
+COMMENT ON TYPE reference IS 'Reference information needed for import.';
+
+CREATE TYPE package AS (
+	name TEXT,
+	kind matcher_v2.PackageKind,
+	arch matcher_v2.Architecture[],
+	vulnerable_range matcher_v2.VersionMultiRange,
+	version_upstream TEXT[],
+	version_kind TEXT,
+	purl TEXT,
+	cpe TEXT
+);
+COMMENT ON TYPE package IS 'Package information needed for import.';
+
+CREATE TYPE attr AS (
+	mediatype TEXT,
+	data JSONB
+);
+COMMENT ON TYPE attr IS 'Attr information needed for import.';
+
+CREATE TYPE advisory_import_row AS (
+	-- id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+	advisory_id BIGINT,
+	advisory matcher_v2_import.advisory,
+	reference matcher_v2_import.reference[],
+	package matcher_v2_import.package[],
+	attr matcher_v2_import.attr[]
+);
+
+COMMENT ON TYPE advisory_import_row IS 'Advisory_import_row is the shape of the "advisory_import" table. It is disallowed to SET the "id" column.';
+-- }}}
+CREATE FUNCTION array_distinct (a anyarray)
+	RETURNS anyarray
+	LANGUAGE SQL
+	IMMUTABLE STRICT
+	AS $$
+	SELECT
+		array_agg(DISTINCT x)
+	FROM
+		unnest(a) t (x);
+$$;
+
+COMMENT ON FUNCTION array_distinct IS 'Array_distinct returns an array with only distinct elements.';
+-- {{{ Run management
+CREATE OR REPLACE FUNCTION start_run (ref UUID)
+	RETURNS BIGINT
+	LANGUAGE plpgsql
+	STRICT
+	AS $$
+BEGIN
+	INSERT INTO matcher_v2.run (ref) VALUES(ref) RETURNING id;
+END;
+$$;
+
+COMMENT ON FUNCTION start_run IS 'Create a `matcher_v2.run` object, returning the ID.';
+
+CREATE OR REPLACE FUNCTION start_updater_run (ref UUID, upd BIGINT, run BIGINT)
+	RETURNS BIGINT
+	LANGUAGE plpgsql
+	STRICT
+	AS $$
+BEGIN
+	INSERT INTO matcher_v2.updater_run (ref, updater, run)
+		VALUES (upd_run_ref, upd_id, run_id)
+	RETURNING
+		id;
+END;
+$$;
+
+COMMENT ON FUNCTION start_updater_run IS $$Create a `matcher_v2.update_run` object, returning the ID.
+
+See also: start_run, matcher_v2.updater_id
+$$;
+
+CREATE OR REPLACE FUNCTION finish_updater_run (id BIGINT, fingerprint JSONB, error TEXT)
+	RETURNS void
+	LANGUAGE plpgsql
+	AS $$
+BEGIN
+	UPDATE
+		matcher_v2.updater_run
+	SET
+		fingerprint = fingerprint,
+		error = error
+	WHERE
+		id = id;
+END;
+$$;
+
+COMMENT ON FUNCTION finish_updater_run IS 'Finish_updater_run should be called when an updater''s import is completed.';
+
+CREATE OR REPLACE FUNCTION finish_run (id BIGINT)
+	RETURNS void
+	LANGUAGE plpgsql
+	IMMUTABLE STRICT
+	AS $$
+BEGIN
+	-- Does nothing, currently.
+END;
+$$;
+
+COMMENT ON FUNCTION finish_run IS 'Finish_run should be called when an entire run is completed.';
+-- }}}
+-- {{{ Stage
+CREATE OR REPLACE PROCEDURE stage ()
+LANGUAGE plpgsql
+AS $$
+BEGIN
+	IF to_regclass ('advisory_import') IS NOT NULL THEN
+		TRUNCATE advisory_import;
+		TRUNCATE advisory_import_to_copy;
+		CALL matcher_v2_meta.emit_log ('import', 'reset temporary tables');
+	ELSE
+		CREATE TEMPORARY TABLE advisory_import OF advisory_import_row ON COMMIT DROP;
+		--ALTER TABLE advisory_import
+			--ADD COLUMN id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY;
+		CREATE TEMPORARY TABLE advisory_import_to_copy (
+			id BIGINT
+		) ON COMMIT DROP;
+		CALL matcher_v2_meta.emit_log ('import', 'created temporary tables');
+	END IF;
+END;
+$$;
+
+COMMENT ON PROCEDURE stage IS $$Stage prepares the 'advisory_import' table for use with 'advisory_import_commit' and 'advisory_import_finish'.$$;
+-- }}}
+-- {{{ Commit_add
+CREATE OR REPLACE PROCEDURE commit_add(run_id BIGINT, upd_id BIGINT, upd_run_id BIGINT)
+	LANGUAGE plpgsql
+	AS $$
+DECLARE
+	ev JSONB := jsonb_build_object('run', run_id, 'updater', upd_id, 'update_run', upd_run_id);
+BEGIN
+	-- TODO(hank) Experiment with adding additional writeback fields for the latter imports.
+
+	CALL matcher_v2_meta.emit_log ('import', 'merge start', jsonb_insert(ev, '{table}', '"advisory"'));
+	MERGE INTO matcher_v2.advisory AS tgt
+	USING (
+		SELECT
+			upd_id AS updater, (advisory).name AS name
+		FROM
+			advisory_import) AS src ON tgt.updater = src.updater
+		AND tgt.name = src.name
+	WHEN MATCHED THEN
+		UPDATE SET
+			generation = run_id
+	WHEN NOT MATCHED THEN
+		INSERT (updater, name, generation, added)
+			VALUES (src.updater, src.name, run_id, run_id);
+	CALL matcher_v2_meta.emit_log ('import', 'merge done', jsonb_insert(ev, '{table}', '"advisory"'));
+
+	CALL matcher_v2_meta.emit_log ('import', 'update start', jsonb_insert(ev, '{table}', '"advisory_import"'));
+	-- Write back the advisory IDs to make the subsequent MERGE statements simpler.
+	UPDATE
+		advisory_import AS i
+	SET
+		advisory_id = adv.id
+	FROM
+		matcher_v2.advisory AS adv
+	WHERE (i.advisory).name = adv.name
+		AND adv.updater = upd_id
+		AND adv.generation = run_id;
+	CALL matcher_v2_meta.emit_log ('import', 'update done', jsonb_insert(ev, '{table}', '"advisory_import"'));
+
+	CALL matcher_v2_meta.emit_log ('import', 'merge start', jsonb_insert(ev, '{table}', '"advisory_meta"'));
+	MERGE INTO matcher_v2.advisory_meta AS tgt
+	USING (
+		SELECT
+			upd_id AS updater, adv.id AS advisory, i.*
+		FROM
+			matcher_v2.advisory AS adv
+			JOIN (
+				SELECT
+					(advisory).*
+				FROM
+					advisory_import) AS i ON i.name = adv.name
+				WHERE
+					upd_id = adv.updater
+					AND run_id = adv.generation) AS src ON tgt.advisory = src.advisory
+	WHEN MATCHED
+		AND ROW (src) IS NOT DISTINCT FROM ROW (tgt) THEN
+			DO NOTHING
+	WHEN MATCHED THEN
+		UPDATE SET
+			issued = src.issued, summary = src.summary, description = src.description, uri = src.uri, severity = src.severity, normalized_severity = src.normalized_severity
+	WHEN NOT MATCHED THEN
+		INSERT (advisory, issued, summary, description, uri, severity, normalized_severity)
+			VALUES (src.advisory, src.issued, src.summary, src.description, src.uri, src.severity, src.normalized_severity);
+	CALL matcher_v2_meta.emit_log ('import', 'merge done', jsonb_insert(ev, '{table}', '"advisory_meta"'));
+
+	-- Reference
+	CALL matcher_v2_meta.emit_log ('import', 'merge start', jsonb_insert(ev, '{table}', '"reference"'));
+	MERGE INTO matcher_v2.reference AS tgt
+	USING (
+		SELECT
+			(unnest(reference)).*
+			FROM
+				advisory_import) AS src ON tgt.namespace = src.namespace
+		AND tgt.name = src.name
+	WHEN MATCHED
+		AND src.uri = tgt.uri THEN
+			DO NOTHING
+	WHEN MATCHED THEN
+		UPDATE SET
+			uri = matcher_v2_import.array_distinct (tgt.uri || src.uri)
+	WHEN NOT MATCHED THEN
+		INSERT (namespace, name, uri)
+			VALUES (src.namespace, src.name, src.uri);
+	CALL matcher_v2_meta.emit_log ('import', 'merge done', jsonb_insert(ev, '{table}', '"reference"'));
+
+	CALL matcher_v2_meta.emit_log ('import', 'merge start', jsonb_insert(ev, '{table}', '"advisory_reference"'));
+	MERGE INTO matcher_v2.advisory_reference AS tgt
+	USING (
+		SELECT
+			i.advisory_id AS advisory, r.id AS reference
+		FROM
+			matcher_v2.reference r
+			JOIN (
+				SELECT
+					advisory_id, unnest(reference) AS ref
+					FROM
+						advisory_import) AS i ON ((i.ref).name = r.name
+							AND (i.ref).namespace = r.namespace)) AS src ON tgt.advisory = src.advisory
+		AND tgt.reference = src.reference
+	WHEN MATCHED THEN
+			DO NOTHING
+	WHEN NOT MATCHED THEN
+			INSERT
+				(advisory, reference)
+				VALUES (src.advisory, src.reference);
+	CALL matcher_v2_meta.emit_log ('import', 'merge done', jsonb_insert(ev, '{table}', '"advisory_reference"'));
+
+	-- Package
+	CALL matcher_v2_meta.emit_log ('import', 'merge start', jsonb_insert(ev, '{table}', '"package_name"'));
+	MERGE INTO matcher_v2.package_name AS tgt
+	USING (
+		SELECT
+			DISTINCT
+				(unnest(package)).name
+				FROM
+					advisory_import) AS src ON tgt.name = src.name
+	WHEN MATCHED THEN
+			DO NOTHING
+	WHEN NOT MATCHED THEN
+		INSERT (name)
+			VALUES (src.name);
+	CALL matcher_v2_meta.emit_log ('import', 'merge done', jsonb_insert(ev, '{table}', '"package_name"'));
+
+	CALL matcher_v2_meta.emit_log ('import', 'merge start', jsonb_insert(ev, '{table}', '"package"'));
+	MERGE INTO matcher_v2.package AS tgt
+	USING (
+		SELECT
+			i.advisory_id, n.id AS name_id, (i.pkg).*
+		FROM (
+			SELECT
+				advisory_id, unnest(package) AS pkg
+				FROM
+					advisory_import) AS i
+					JOIN matcher_v2.package_name AS n ON ((i.pkg).name = n.name)) AS src ON tgt.advisory = src.advisory_id
+			AND tgt.name = src.name_id
+			AND tgt.kind = src.kind
+	WHEN MATCHED
+		AND ROW (tgt) IS NOT DISTINCT FROM ROW (src) THEN
+			DO NOTHING
+	WHEN MATCHED THEN
+		UPDATE SET
+			arch = src.arch, vulnerable_range = src.vulnerable_range, version_upstream = src.version_upstream, version_kind = src.version_kind, purl = src.purl, cpe = src.cpe
+	WHEN NOT MATCHED THEN
+		INSERT (advisory, name, kind, arch, vulnerable_range, version_upstream, version_kind, purl, cpe)
+			VALUES (src.advisory_id, src.name_id, src.kind, src.arch, src.vulnerable_range, src.version_upstream, src.version_kind, src.purl, src.cpe);
+	CALL matcher_v2_meta.emit_log ('import', 'merge done', jsonb_insert(ev, '{table}', '"package"'));
+
+	-- Attr
+	CALL matcher_v2_meta.emit_log ('import', 'merge start', jsonb_insert(ev, '{table}', '"mediatype"'));
+	MERGE INTO matcher_v2.mediatype AS tgt
+	USING (
+		SELECT
+			DISTINCT
+				(unnest(attr)).mediatype
+				FROM
+					advisory_import) AS src ON tgt.mediatype = src.mediatype
+	WHEN MATCHED THEN
+			DO NOTHING
+	WHEN NOT MATCHED THEN
+		INSERT (mediatype)
+			VALUES (src.mediatype);
+	CALL matcher_v2_meta.emit_log ('import', 'merge done', jsonb_insert(ev, '{table}', '"mediatype"'));
+
+	CALL matcher_v2_meta.emit_log ('import', 'merge start', jsonb_insert(ev, '{table}', '"attr"'));
+	MERGE INTO matcher_v2.attr AS tgt
+	USING (
+		SELECT
+			mt.id AS mediatype, i.data AS data
+		FROM (
+			SELECT
+				DISTINCT
+					(unnest(attr)).*
+					FROM
+						advisory_import) AS i
+						JOIN matcher_v2.mediatype AS mt ON i.mediatype = mt.mediatype) AS src ON tgt.mediatype = src.mediatype
+			AND tgt.data = src.data
+	WHEN MATCHED THEN
+			DO NOTHING
+	WHEN NOT MATCHED THEN
+			INSERT
+				(mediatype, data)
+				VALUES (src.mediatype, src.data);
+	CALL matcher_v2_meta.emit_log ('import', 'merge done', jsonb_insert(ev, '{table}', '"attr"'));
+
+	CALL matcher_v2_meta.emit_log ('import', 'merge start', jsonb_insert(ev, '{table}', '"advisory_attr"'));
+	MERGE INTO matcher_v2.advisory_attr AS tgt
+	USING (
+		SELECT
+			i.advisory_id AS advisory, a.id AS attr
+		FROM (
+			SELECT
+				advisory_id, (unnest(attr)).*
+				FROM
+					advisory_import) AS i
+					JOIN (
+						SELECT
+							attr.id AS id, mediatype.mediatype AS mediatype, attr.data AS data
+						FROM
+							matcher_v2.attr
+							JOIN matcher_v2.mediatype ON mediatype.id = attr.mediatype) AS a ON i.mediatype = a.mediatype
+								AND i.data = a.data) AS src ON tgt.advisory = src.advisory
+		AND tgt.attr = src.attr
+	WHEN MATCHED THEN
+			DO NOTHING
+	WHEN NOT MATCHED THEN
+			INSERT
+				(advisory, attr)
+				VALUES (src.advisory, src.attr);
+	CALL matcher_v2_meta.emit_log ('import', 'merge done', jsonb_insert(ev, '{table}', '"advisory_attr"'));
+
+	CALL matcher_v2_meta.emit_log ('import', 'truncating input table', jsonb_insert(ev, '{table}', '"advisory_import"'));
+	TRUNCATE advisory_import;
+END;
+$$;
+
+COMMENT ON PROCEDURE commit_add(BIGINT, BIGINT, BIGINT) IS 'Commit_add adds all the provided data to the current run.';
+-- }}}
+-- {{{ Commit_snapshot
+CREATE OR REPLACE PROCEDURE commit_snapshot(run_id BIGINT, upd_id BIGINT, upd_run_id BIGINT)
+	LANGUAGE plpgsql
+	AS $$
+DECLARE
+	ev JSONB := jsonb_build_object('run', run_id, 'updater', upd_id, 'update_run', upd_run_id);
+BEGIN
+	-- It seems like it'd be easier to just bump the generation for everything
+	-- (and I agree), but we'd need to keep track of the previous state and
+	-- restore that if the relevant advisory is named in a subsequent remove.
+	CALL matcher_v2_meta.emit_log ('import', 'insert start', jsonb_insert(ev, '{table}', '"advisory_import_to_copy"'));
+	WITH prev AS (
+		SELECT
+			run
+		FROM
+			matcher_v2.updater_run
+		WHERE
+			updater = upd_id
+			AND run < run_id
+			AND success
+		ORDER BY
+			id DESC
+		LIMIT 1)
+	INSERT INTO advisory_import_to_copy
+	SELECT
+		id
+	FROM
+		matcher_v2.advisory,
+		prev
+	WHERE
+		updater = upd_id
+		AND generation = prev.run;
+	CALL matcher_v2_meta.emit_log ('import', 'insert done', jsonb_insert(ev, '{table}', '"advisory_import_to_copy"'));
+
+	CALL matcher_v2_meta.emit_log ('import', 'truncating input table', jsonb_insert(ev, '{table}', '"advisory_import"'));
+	TRUNCATE advisory_import;
+END;
+$$;
+
+COMMENT ON PROCEDURE commit_snapshot(BIGINT, BIGINT, BIGINT) IS 'Commit_snapshot copies all advisories from the latest successful update run to the current run.';
+-- }}}
+-- {{{ Commit_remove
+CREATE OR REPLACE PROCEDURE commit_remove(run_id BIGINT, upd_id BIGINT, upd_run_id BIGINT)
+	LANGUAGE plpgsql
+	AS $$
+DECLARE
+	ev JSONB := jsonb_build_object('run', run_id, 'updater', upd_id, 'update_run', upd_run_id);
+BEGIN
+	CALL matcher_v2_meta.emit_log ('import', 'delete start', jsonb_insert(ev, '{table}', '"advisory_import_to_copy"'));
+	DELETE FROM advisory_import_to_copy
+	WHERE id IN (
+			SELECT
+				a.id
+			FROM
+				matcher_v2.advisory AS a
+				JOIN advisory_import AS i ON a.name = i.name
+			WHERE
+				updater = upd_id);
+	CALL matcher_v2_meta.emit_log ('import', 'delete done', jsonb_insert(ev, '{table}', '"advisory_import_to_copy"'));
+
+	CALL matcher_v2_meta.emit_log ('import', 'truncating input table', jsonb_insert(ev, '{table}', '"advisory_import"'));
+	TRUNCATE advisory_import;
+END;
+$$;
+
+COMMENT ON PROCEDURE commit_remove(BIGINT, BIGINT, BIGINT) IS 'Commit_remove removes the named advisories from the current run. All other data in the table is not considered.';
+-- }}}
+-- {{{ Finish
+CREATE OR REPLACE PROCEDURE finish (run_id BIGINT, upd_id BIGINT, upd_run_id BIGINT)
+	LANGUAGE plpgsql
+	AS $$
+DECLARE
+	ev JSONB;
+BEGIN
+	ev := jsonb_build_object('run', run_id, 'updater', upd_id, 'update_run', upd_run_id);
+	CALL matcher_v2_meta.emit_log ('import', 'update start', jsonb_insert(ev, '{table}', '"advisory"'));
+	UPDATE
+		matcher_v2.advisory
+	SET
+		generation = run_id
+	FROM
+		advisory_import_to_copy AS c
+	WHERE
+		c.id = advisory.id;
+	CALL matcher_v2_meta.emit_log ('import', 'update done', jsonb_insert(ev, '{table}', '"advisory"'));
+	CALL matcher_v2_meta.emit_log ('import', 'truncating input table', jsonb_insert(ev, '{table}', '"advisory_import_to_copy"'));
+	TRUNCATE advisory_import_to_copy;
+
+	CALL matcher_v2_meta.emit_log ('import', 'ANALYZE start');
+	ANALYZE matcher_v2.advisory,
+	matcher_v2.advisory_meta,
+	matcher_v2.reference,
+	matcher_v2.advisory_reference,
+	matcher_v2.package,
+	matcher_v2.package_name,
+	matcher_v2.mediatype,
+	matcher_v2.attr,
+	matcher_v2.advisory_attr;
+	CALL matcher_v2_meta.emit_log ('import', 'ANALYZE done');
+END;
+$$;
+
+COMMENT ON PROCEDURE finish (BIGINT, BIGINT, BIGINT) IS 'Finish updates advisory generations as needed and performs ANALYZE on the new data.';
+-- }}}
+DO LANGUAGE plpgsql
+$$
+BEGIN
+	CALL matcher_v2_meta.emit_log ('init', 'matcher_v2_import schema populated');
+END
+$$;

--- a/datastore/postgres/migrations/matcher/testdata/migration_13.txtar
+++ b/datastore/postgres/migrations/matcher/testdata/migration_13.txtar
@@ -1,0 +1,35 @@
+-- MetaFunctions --
+SET search_path TO "$user",matcher_v2_meta,public;
+SET plpgsql.extra_errors TO 'all';
+SET plpgsql.extra_warnings TO 'all';
+-- Check that these two forms work at all:
+DO LANGUAGE plpgsql $$
+DECLARE
+	obj JSONB := '{}';
+	want BYTEA := '\x44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a';
+	got BYTEA;
+BEGIN
+	got := config_fingerprint(obj);
+	IF
+		got <> want
+	THEN
+		RAISE EXCEPTION 'bad fingerprint: % <> %', got, want;
+	END IF;
+END
+
+$$;
+-- NB this varies only in the input type.
+DO LANGUAGE plpgsql $$
+DECLARE
+	obj TEXT := '{}';
+	want BYTEA := '\x44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a';
+	got BYTEA;
+BEGIN
+	got := config_fingerprint(obj);
+	IF
+		got <> want
+	THEN
+		RAISE EXCEPTION 'bad fingerprint: % <> %', got, want;
+	END IF;
+END
+$$;

--- a/datastore/postgres/migrations/matcher/testdata/migration_14.txtar
+++ b/datastore/postgres/migrations/matcher/testdata/migration_14.txtar
@@ -1,0 +1,321 @@
+SET search_path TO "$user",public;
+
+CREATE OR REPLACE PROCEDURE check_count (tablename TEXT, want INTEGER, msg TEXT)
+	LANGUAGE plpgsql
+	AS $proc$
+DECLARE
+	got INTEGER;
+BEGIN
+	EXECUTE format('SELECT COUNT(*) FROM "matcher_v2".%I', tablename) INTO got;
+	IF got <> want THEN
+		RAISE 'unexpected number of % rows; got: %, want: % (message: %)', tablename, got, want, msg;
+	END IF;
+END;
+$proc$;
+
+CREATE PROCEDURE make_run (TEXT[])
+LANGUAGE SQL
+BEGIN ATOMIC
+	WITH run AS (
+		INSERT INTO matcher_v2.run (ref)
+			VALUES (gen_random_uuid ())
+		RETURNING id
+	), upd AS (
+		SELECT
+			id
+		FROM
+			matcher_v2.updater
+		WHERE
+			name = ANY($1)
+	)
+	INSERT INTO matcher_v2.updater_run (ref, updater, run, fingerprint, error)
+		SELECT gen_random_uuid (), upd.id, run.id, '{}', NULL FROM run, upd;
+END;
+
+CREATE OR REPLACE PROCEDURE reset_tables ()
+	LANGUAGE SQL
+AS $proc$
+	-- Omit the log table.
+	TRUNCATE matcher_v2_meta.config RESTART IDENTITY CASCADE;
+	TRUNCATE
+		matcher_v2.updater,
+		matcher_v2.run,
+		matcher_v2.updater_run,
+		matcher_v2.advisory,
+		matcher_v2.advisory_meta,
+		matcher_v2.reference,
+		matcher_v2.advisory_reference,
+		matcher_v2.package,
+		matcher_v2.attr,
+		matcher_v2.package_name,
+		matcher_v2.mediatype,
+		matcher_v2.advisory_attr
+	RESTART IDENTITY
+	CASCADE;
+$proc$;
+-- VersionRange --
+SET search_path TO "$user",matcher_v2,public;
+SET plpgsql.extra_errors TO 'all';
+SET plpgsql.extra_warnings TO 'all';
+/*
+Test the "semver" encoding:
+
+	[ major, minor, patch, pre ]
+
+Build information is omitted, per spec.
+
+If not a prerelease version, "pre" is NULL.
+"Major," "minor," and "patch" components are defined to be numeric, and so are zero-padded to uniform width.
+*/
+DO LANGUAGE plpgSQL $$
+DECLARE
+	-- 1.0.0
+	r VersionRange := VersionRange (NULL, ARRAY['0000000001', '0000000000', '0000000000', NULL], '()');
+	v TEXT[];
+
+	member TEXT[] := ARRAY[
+		ARRAY['0000000000', '0000000005', '0000000000', NULL],      -- 0.5.0
+		ARRAY['0000000000', '0000000005', '0000000000', 'alpha.1'], -- 0.5.0-alpha.1
+		ARRAY['0000000001', '0000000000', '0000000000', 'pre']      -- 1.0.0-pre
+	];
+BEGIN
+	FOREACH v SLICE 1 IN ARRAY member
+	LOOP
+		PERFORM 1 WHERE r @> v;
+		ASSERT FOUND, format('expected to find %s in range', v);
+	END LOOP;
+END;
+$$;
+DO LANGUAGE plpgSQL $$
+DECLARE
+	-- 1.0.0-beta.1
+	r VersionRange := VersionRange (NULL, ARRAY['0000000001', '0000000000', '0000000000', 'beta.1'], '()');
+	v TEXT[];
+
+	member TEXT[] := ARRAY[
+		ARRAY['0000000000', '0000000005', '0000000000', NULL],      -- 0.5.0
+		ARRAY['0000000000', '0000000005', '0000000000', 'alpha.1'], -- 0.5.0-alpha.1
+		ARRAY['0000000001', '0000000000', '0000000000', 'alpha.1']  -- 1.0.0-alpha.1
+	];
+BEGIN
+	FOREACH v SLICE 1 IN ARRAY member
+	LOOP
+		PERFORM 1 WHERE r @> v;
+		ASSERT FOUND, format('expected to find %s in range', v);
+	END LOOP;
+END;
+$$;
+
+DO LANGUAGE plpgSQL $$
+DECLARE
+	-- 1.0.0
+	r VersionRange := VersionRange (NULL, ARRAY['0000000001', '0000000000', '0000000000', NULL], '()');
+	v TEXT[];
+
+	member TEXT[] := ARRAY[
+		ARRAY['0000000001', '0000000000', '0000000000', NULL], -- 1.0.0
+		ARRAY['0000000001', '0000000000', '0000000001', NULL], -- 1.0.1
+		ARRAY['0000000001', '0000000001', '0000000000', NULL], -- 1.1.0
+		ARRAY['0000000002', '0000000000', '0000000000', NULL]  -- 2.0.0
+	];
+BEGIN
+	FOREACH v SLICE 1 IN ARRAY member
+	LOOP
+		PERFORM 1 WHERE r @> v;
+		ASSERT NOT FOUND, format('expected to not find %s in range', v);
+	END LOOP;
+END;
+$$;
+DO LANGUAGE plpgSQL $$
+DECLARE
+	-- 1.0.0-beta.1
+	r VersionRange := VersionRange (NULL, ARRAY['0000000001', '0000000000', '0000000000', 'beta.1'], '()');
+	v TEXT[];
+
+	member TEXT[] := ARRAY[
+		ARRAY['0000000001', '0000000000', '0000000000', NULL],     -- 1.0.0
+		ARRAY['0000000001', '0000000000', '0000000000', 'beta.2'], -- 1.0.0-beta.2
+		ARRAY['0000000001', '0000000000', '0000000000', 'rc.1']    -- 1.0.0-rc.1
+	];
+BEGIN
+	FOREACH v SLICE 1 IN ARRAY member
+	LOOP
+		PERFORM 1 WHERE r @> v;
+		ASSERT NOT FOUND, format('expected to not find %s in range', v);
+	END LOOP;
+END;
+$$;
+-- GarbageCollectUpdaters --
+SET search_path TO "$user",matcher_v2,public;
+SET plpgsql.extra_errors TO 'all';
+SET plpgsql.extra_warnings TO 'all';
+
+-- Create some updaters.
+INSERT INTO updater (name) VALUES ('test.00'), ('test.01');
+
+CALL check_count ('updater', 2, 'create updaters');
+
+-- Create some runs.
+CALL make_run (ARRAY['test.00', 'test.01']);
+CALL make_run (ARRAY['test.00', 'test.01']);
+CALL make_run (ARRAY['test.00', 'test.01']);
+
+CALL check_count ('run', 3, 'initial run check');
+CALL check_count ('updater_run', 3 * 2, 'initial updater_run check');
+CALL check_count ('updater', 2, 'initial updater check');
+
+-- Configure the retention so that this `run_gc` call should do nothing.
+INSERT INTO matcher_v2_meta.config (config) VALUES (jsonb_build_object('retain_runs', 4));
+CALL run_gc ();
+
+CALL check_count ('run', 3, 'second run check');
+CALL check_count ('updater_run', 3 * 2, 'second updater_run check');
+CALL check_count ('updater', 2, 'second updater check');
+
+-- update the config to give the GC something to do.
+INSERT INTO matcher_v2_meta.config (config) VALUES (jsonb_build_object());
+CALL run_gc ();
+
+CALL check_count ('run', 1, 'after gc run check');
+CALL check_count ('updater_run', 1 * 2, 'after gc updater_run check');
+CALL check_count ('updater', 2, 'after gc updater check');
+
+-- Stop using some updaters
+CALL make_run (ARRAY['test.00']);
+CALL run_gc ();
+
+CALL check_count ('run', 1, 'disused updaters run check');
+CALL check_count ('updater_run', 1, 'disused updaters updater_run check');
+CALL check_count ('updater', 1, 'disused updaters updater check');
+
+CALL reset_tables();
+-- UpdaterRun --
+SET search_path TO "$user",matcher_v2,public;
+SET plpgsql.extra_errors TO 'all';
+SET plpgsql.extra_warnings TO 'all';
+
+-- Create an updater:
+DO LANGUAGE plpgsql $$
+DECLARE
+	updater_name TEXT := 'test.00';
+BEGIN
+	INSERT INTO updater (name) VALUES (updater_name);
+
+	CALL check_count ('updater', 1, 'create updater');
+END;
+$$;
+
+-- Use some premade uuids:
+--
+-- run:         fd49a914-2606-43b8-8363-8c151db15436
+-- updater run: 196a69a2-193f-4574-9445-be94a3806afb
+
+DO LANGUAGE plpgsql $$
+DECLARE
+	updater_name TEXT := 'test.00';
+	run_ref UUID := 'fd49a914-2606-43b8-8363-8c151db15436';
+	upd_run_ref UUID := '196a69a2-193f-4574-9445-be94a3806afb';
+
+	run_id BIGINT;
+	upd_id BIGINT;
+	upd_run_id BIGINT;
+BEGIN
+	SELECT id INTO upd_id FROM updater WHERE name = updater_name;
+
+	INSERT INTO run (ref) VALUES (run_ref) RETURNING id INTO run_id;
+	INSERT INTO updater_run (ref, updater, run) VALUES (upd_run_ref, upd_id, run_id)
+		RETURNING id INTO upd_run_id;
+	UPDATE updater_run SET fingerprint = '{}', error = NULL WHERE ref = upd_run_ref;
+
+	CALL check_count ('run', 1, 'create run');
+	CALL check_count ('updater_run', 1, 'create updater_run');
+END;
+$$;
+
+DO LANGUAGE plpgsql $$
+DECLARE
+	updater_name TEXT := 'test.00';
+	run_ref UUID := 'fd49a914-2606-43b8-8363-8c151db15436';
+
+	run_id BIGINT;
+	upd_id BIGINT;
+BEGIN
+	SELECT id INTO upd_id FROM updater WHERE name = updater_name;
+	SELECT id INTO run_id FROM run WHERE ref = run_ref;
+
+	INSERT INTO advisory_meta (advisory, summary, description)
+		VALUES (advisory_id (run_id, upd_id, 'TEST-0001'), 'test', 'a real cool testing advisory');
+
+	CALL check_count ('advisory', 1, 'create advisory');
+	CALL check_count ('advisory_meta', 1, 'create advisory');
+END;
+$$;
+
+DO LANGUAGE plpgsql $$
+DECLARE
+	updater_name TEXT := 'test.00';
+	run_ref UUID := 'fd49a914-2606-43b8-8363-8c151db15436';
+
+	run_id BIGINT;
+	upd_id BIGINT;
+	adv_id BIGINT;
+BEGIN
+	SELECT id INTO upd_id FROM updater WHERE name = updater_name;
+	SELECT id INTO run_id FROM run WHERE ref = run_ref;
+	adv_id := advisory_id (run_id, upd_id, 'TEST-0001');
+
+	INSERT INTO advisory_reference (advisory, reference) VALUES (adv_id, reference_id ('TEST', '0001'));
+	INSERT INTO advisory_reference (advisory, reference) VALUES (adv_id, reference_id ('CVE', '2038-0001'));
+
+	CALL check_count ('reference', 2, 'create reference');
+	CALL check_count ('advisory_reference', 2, 'create reference');
+END;
+$$;
+
+DO LANGUAGE plpgsql $$
+DECLARE
+	updater_name TEXT := 'test.00';
+	run_ref UUID := 'fd49a914-2606-43b8-8363-8c151db15436';
+
+	run_id BIGINT;
+	upd_id BIGINT;
+	adv_id BIGINT;
+BEGIN
+	SELECT id INTO upd_id FROM updater WHERE name = updater_name;
+	SELECT id INTO run_id FROM run WHERE ref = run_ref;
+	adv_id := advisory_id (run_id, upd_id, 'TEST-0001');
+
+	INSERT INTO package (advisory, name, arch, vulnerable_range, version_upstream, version_kind, kind)
+		VALUES (
+			adv_id,
+			package_name_id('fakepackage'),
+			NULL,
+			VersionMultirange (VersionRange (NULL, ARRAY['0000000001', '0000000000', '0000000000', NULL], '()')),
+			ARRAY['<1.0.0'],
+			'semver',
+			'source'
+		);
+
+	CALL check_count ('package', 1, 'create package');
+END;
+$$;
+
+DO LANGUAGE plpgSQL $$
+BEGIN
+	PERFORM 1 FROM package WHERE vulnerable_range @> ARRAY['0000000000', '0000000005', '0000000000', 'alpha.1'];
+	ASSERT FOUND, 'expected to find "0.5.0-alpha.1" in range';
+	PERFORM 1 FROM package WHERE vulnerable_range @> ARRAY['0000000001', '0000000000', '0000000000', 'pre'];
+	ASSERT FOUND, 'expected to find "1.0.0-pre" in range';
+
+	PERFORM 1 FROM package WHERE vulnerable_range @> ARRAY['0000000001', '0000000000', '0000000000', NULL];
+	ASSERT NOT FOUND, 'expected to not find "1.0.0" in range';
+	PERFORM 1 FROM package WHERE vulnerable_range @> ARRAY['0000000001', '0000000000', '0000000001', NULL];
+	ASSERT NOT FOUND, 'expected to not find "1.0.1" in range';
+	PERFORM 1 FROM package WHERE vulnerable_range @> ARRAY['0000000001', '0000000001', '0000000000', NULL];
+	ASSERT NOT FOUND, 'expected to not find "1.1.0" in range';
+	PERFORM 1 FROM package WHERE vulnerable_range @> ARRAY['0000000002', '0000000000', '0000000000', NULL];
+	ASSERT NOT FOUND, 'expected to not find "2.0.0" in range';
+END;
+$$;
+
+CALL reset_tables();

--- a/datastore/postgres/migrations/matcher/testdata/migration_15.txtar
+++ b/datastore/postgres/migrations/matcher/testdata/migration_15.txtar
@@ -1,0 +1,172 @@
+SET search_path TO "$user",public;
+
+CREATE OR REPLACE PROCEDURE generate_testdata (start INTEGER, stop INTEGER, prefix TEXT)
+	LANGUAGE plpgsql
+AS $$
+BEGIN
+	INSERT INTO advisory_import (
+			advisory,
+			reference,
+			package,
+			attr
+	)
+	SELECT 
+		ROW(prefix||'-'||to_char(n, 'FM00000'), now(), 'summary', 'description', 'http://example.com', 'low', 'Low')::matcher_v2_import.advisory,
+		ARRAY[ROW(prefix, to_char(n, 'FM00000'), ARRAY['http://example.com'])]::matcher_v2_import.reference[],
+		ARRAY[ROW('hello', 'binary', ARRAY['amd64'], VersionMultiRange(VersionRange(NULL, ARRAY[to_char(n, 'FM0000000000'), NULL], '[)')), ARRAY['<'||n], 'int', NULL, NULL)]::matcher_v2_import.package[],
+		ARRAY[ROW('application/vnd.claircore.'||prefix, jsonb_build_object('seqence_number', n))]::matcher_v2_import.attr[]
+	FROM
+		generate_series(start, stop) AS n;
+END;
+$$;
+
+CREATE OR REPLACE PROCEDURE check_count (tablename TEXT, want INTEGER, msg TEXT)
+	LANGUAGE plpgsql
+	AS $proc$
+DECLARE
+	got INTEGER;
+BEGIN
+	EXECUTE format('SELECT COUNT(*) FROM "matcher_v2".%I', tablename) INTO got;
+	IF got <> want THEN
+		RAISE 'unexpected number of % rows; got: %, want: % (message: %)', tablename, got, want, msg;
+	END IF;
+END;
+$proc$;
+
+CREATE OR REPLACE PROCEDURE reset_tables ()
+	LANGUAGE SQL
+AS $proc$
+	-- Omit the log table.
+	TRUNCATE matcher_v2_meta.config RESTART IDENTITY CASCADE;
+	TRUNCATE
+		matcher_v2.updater,
+		matcher_v2.run,
+		matcher_v2.updater_run,
+		matcher_v2.advisory,
+		matcher_v2.advisory_meta,
+		matcher_v2.reference,
+		matcher_v2.advisory_reference,
+		matcher_v2.package,
+		matcher_v2.attr,
+		matcher_v2.package_name,
+		matcher_v2.mediatype,
+		matcher_v2.advisory_attr
+	RESTART IDENTITY
+	CASCADE;
+$proc$;
+-- Import --
+SET search_path TO "$user",matcher_v2_import,matcher_v2,public;
+SET plpgsql.extra_errors TO 'all';
+SET plpgsql.extra_warnings TO 'all';
+
+DO LANGUAGE plpgsql $$
+DECLARE
+	updater_name TEXT := 'test.00';
+	run_ref UUID := 'fd49a914-2606-43b8-8363-8c151db15436';
+	upd_run_ref UUID := '196a69a2-193f-4574-9445-be94a3806afb';
+
+	run_id BIGINT;
+	upd_id BIGINT;
+	upd_run_id BIGINT;
+BEGIN
+	CALL matcher_v2_meta.emit_log('test', 'whole-db start');
+	SELECT updater_id(updater_name) INTO upd_id;
+	INSERT INTO run (ref) VALUES (run_ref) RETURNING id INTO run_id;
+	INSERT INTO updater_run (ref, updater, run) VALUES (upd_run_ref, upd_id, run_id)
+		RETURNING id INTO upd_run_id;
+	UPDATE updater_run SET fingerprint = '{}', error = NULL WHERE ref = upd_run_ref;
+	CALL stage();
+	CALL generate_testdata (1, 31000, 'TEST');
+	CALL matcher_v2_meta.emit_log('test', 'inserted rows');
+	CALL commit_add(run_id, upd_id, upd_run_id);
+	CALL finish(run_id, upd_id, upd_run_id);
+	CALL matcher_v2_meta.emit_log('test', 'whole-db done');
+END;
+$$;
+
+CALL check_count ('updater', 1, 'create updater');
+CALL check_count ('run', 1, 'create run');
+CALL check_count ('updater_run', 1, 'create updater_run');
+CALL check_count ('advisory', 31000, 'import advisories');
+
+DO LANGUAGE plpgsql $$
+DECLARE
+	updater_name TEXT := 'test.00';
+	run_ref UUID := 'fd49a914-2606-43b8-8363-8c151db15437';
+	upd_run_ref UUID := '196a69a2-193f-4574-9445-be94a3806afc';
+
+	run_id BIGINT;
+	upd_id BIGINT;
+	upd_run_id BIGINT;
+BEGIN
+	CALL matcher_v2_meta.emit_log('test', 'incremental start');
+	SELECT updater_id(updater_name) INTO upd_id;
+	INSERT INTO run (ref) VALUES (run_ref) RETURNING id INTO run_id;
+	INSERT INTO updater_run (ref, updater, run) VALUES (upd_run_ref, upd_id, run_id)
+		RETURNING id INTO upd_run_id;
+	UPDATE updater_run SET fingerprint = '{}', error = NULL WHERE ref = upd_run_ref;
+	CALL stage();
+	CALL commit_snapshot(run_id, upd_id, upd_run_id);
+	CALL generate_testdata(31000, 31010, 'TEST');
+	CALL commit_add(run_id, upd_id, upd_run_id);
+	CALL finish(run_id, upd_id, upd_run_id);
+	CALL matcher_v2_meta.emit_log('test', 'incremental done');
+END;
+$$;
+
+CALL check_count ('updater', 1, 'select updater');
+CALL check_count ('run', 2, 'create run');
+CALL check_count ('updater_run', 2, 'create updater_run');
+CALL check_count ('advisory', 31010, 'import advisories');
+CALL check_count ('package_name', 1, 'package names');
+CALL check_count ('mediatype', 1, 'mediatypes');
+
+CALL reset_tables();
+-- ImportGC --
+SET search_path TO "$user",matcher_v2_import,matcher_v2,public;
+SET plpgsql.extra_errors TO 'all';
+SET plpgsql.extra_warnings TO 'all';
+
+DO LANGUAGE plpgsql $$
+DECLARE
+	updater_name TEXT := 'test.00';
+	run_ref UUID := 'fd49a914-2606-43b8-8363-8c151db15437';
+	upd_run_ref UUID := '196a69a2-193f-4574-9445-be94a3806afc';
+
+	run_id BIGINT;
+	upd_id BIGINT;
+	upd_run_id BIGINT;
+	i INTEGER;
+BEGIN
+	CALL matcher_v2_meta.emit_log('test', 'import start');
+	FOR i IN 1..3 LOOP
+		CALL matcher_v2_meta.emit_log('test', format('run %s start', i));
+
+		SELECT updater_id(updater_name) INTO upd_id;
+		INSERT INTO run (ref) VALUES (gen_random_uuid()) RETURNING id INTO run_id;
+		INSERT INTO updater_run (ref, updater, run) VALUES (gen_random_uuid(), upd_id, run_id)
+			RETURNING id INTO upd_run_id;
+		UPDATE updater_run SET fingerprint = jsonb_build_object('loop', i), error = NULL WHERE id = upd_run_id;
+
+		CALL stage();
+		CALL generate_testdata (1, 1000, 'LOOP'||i);
+		CALL commit_add(run_id, upd_id, upd_run_id);
+		CALL finish(run_id, upd_id, upd_run_id);
+
+		CALL matcher_v2_meta.emit_log('test', format('run %s done', i));
+	END LOOP;
+	CALL matcher_v2_meta.emit_log('test', 'import done');
+END;
+$$;
+
+CALL check_count ('package_name', 1, 'package names');
+CALL check_count ('mediatype', 3, 'mediatypes');
+
+CALL matcher_v2_meta.emit_log('test', 'gc start');
+CALL matcher_v2.run_gc();
+CALL matcher_v2_meta.emit_log('test', 'gc done');
+
+CALL check_count ('package_name', 1, 'package names');
+CALL check_count ('mediatype', 1, 'mediatypes');
+
+CALL reset_tables();

--- a/datastore/postgres/migrations/migrations.go
+++ b/datastore/postgres/migrations/migrations.go
@@ -1,111 +1,78 @@
+// Package migrations contains database migrations.
+//
+// It's expected that github.com/remind101/migrate will be used to apply these,
+// but it's possible to do this manually if the user needs something specific.
 package migrations
 
 import (
 	"database/sql"
 	"embed"
+	"fmt"
+	"io"
+	"io/fs"
+	"path"
+	"strings"
 
 	"github.com/remind101/migrate"
 )
 
+// Canonical names for the table containing migration metadata.
 const (
 	IndexerMigrationTable = "libindex_migrations"
 	MatcherMigrationTable = "libvuln_migrations"
 )
 
+// Slices containing the database migrations.
+var (
+	IndexerMigrations []migrate.Migration
+	MatcherMigrations []migrate.Migration
+)
+
+func init() {
+	IndexerMigrations = loadMigrations(`indexer`)
+	MatcherMigrations = loadMigrations(`matcher`)
+}
+
 //go:embed */*.sql
-var fs embed.FS
+var sys embed.FS
 
-func runFile(n string) func(*sql.Tx) error {
-	b, err := fs.ReadFile(n)
-	return func(tx *sql.Tx) error {
-		if err != nil {
-			return err
-		}
-		if _, err := tx.Exec(string(b)); err != nil {
-			return err
-		}
-		return nil
+func loadMigrations(dir string) []migrate.Migration {
+	ents, err := fs.ReadDir(sys, dir)
+	if err != nil {
+		panic(fmt.Errorf("programmer error: unable to read embed: %w", err))
 	}
-}
 
-var IndexerMigrations = []migrate.Migration{
-	{
-		ID: 1,
-		Up: runFile("indexer/01-init.sql"),
-	},
-	{
-		ID: 2,
-		Up: runFile("indexer/02-digests.sql"),
-	},
-	{
-		ID: 3,
-		Up: runFile("indexer/03-unique-manifest_index.sql"),
-	},
-	{
-		ID: 4,
-		Up: runFile("indexer/04-foreign-key-cascades.sql"),
-	},
-	{
-		ID: 5,
-		Up: runFile("indexer/05-delete-manifest-index-index.sql"),
-	},
-	{
-		ID: 6,
-		Up: runFile("indexer/06-file-artifacts.sql"),
-	},
-	{
-		ID: 7,
-		Up: runFile("indexer/07-index-manifest_index.sql"),
-	},
-}
+	ms := make([]migrate.Migration, 0, len(ents))
+	id := 1
+	for _, ent := range ents {
+		if path.Ext(ent.Name()) != ".sql" {
+			continue
+		}
+		if !ent.Type().IsRegular() {
+			continue
+		}
 
-var MatcherMigrations = []migrate.Migration{
-	{
-		ID: 1,
-		Up: runFile("matcher/01-init.sql"),
-	},
-	{
-		ID: 2,
-		Up: runFile("matcher/02-indexes.sql"),
-	},
-	{
-		ID: 3,
-		Up: runFile("matcher/03-pyup-fingerprint.sql"),
-	},
-	{
-		ID: 4,
-		Up: runFile("matcher/04-enrichments.sql"),
-	},
-	{
-		ID: 5,
-		Up: runFile("matcher/05-uo_enrich-fkey.sql"),
-	},
-	{
-		ID: 6,
-		Up: runFile("matcher/06-delete-debian-update_operation.sql"),
-	},
-	{
-		ID: 7,
-		Up: runFile("matcher/07-force-alpine-update.sql"),
-	},
-	{
-		ID: 8,
-		Up: runFile("matcher/08-updater-status.sql"),
-	},
-	{
-		ID: 9,
-		Up: runFile("matcher/09-delete-pyupio.sql"),
-	},
-	{
-		ID: 10,
-		Up: runFile("matcher/10-delete-osv.sql"),
-	},
-	{
-		ID: 11,
-		Up: runFile("matcher/11-add-update_operation-mv.sql"),
-	},
-	{
-		ID: 12,
-		Up: runFile("matcher/12-add-latest_update_operation-index.sql"),
-	},
+		p := path.Join(dir, ent.Name())
+		ms = append(ms, migrate.Migration{
+			ID: id,
+			Up: func(tx *sql.Tx) error {
+				f, err := sys.Open(p)
+				if err != nil {
+					return fmt.Errorf("unable to open migration %q: %v", p, err)
+				}
+				defer f.Close()
+				var b strings.Builder
+				if _, err := io.Copy(&b, f); err != nil {
+					return fmt.Errorf("unable to read migration %q: %v", p, err)
+				}
+				if _, err := tx.Exec(b.String()); err != nil {
+					return fmt.Errorf("unable to exec migration %q: %v", p, err)
+				}
+				return nil
+			},
+		})
+		id++
+	}
+
+	return ms
 }

--- a/test/postgres/db_common.go
+++ b/test/postgres/db_common.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"os"
 	"path"
+	"strconv"
 	"testing"
 
 	"github.com/jackc/pgx/v4"
@@ -18,6 +19,9 @@ import (
 	"github.com/quay/claircore/datastore/postgres/migrations"
 	"github.com/quay/claircore/test/integration"
 )
+
+// MinVersion is minimum needed PostgreSQL version, in the integer format.
+const MinVersion uint64 = 150000
 
 // TestMatcherDB returns a [pgxpool.Pool] connected to a started and configured
 // for a Matcher database.
@@ -35,10 +39,18 @@ func TestIndexerDB(ctx context.Context, t testing.TB) *pgxpool.Pool {
 	return testDB(ctx, t, dbIndexer)
 }
 
+// TestDB returns a [pgxpool.Pool] connected to a started and configured
+// database that has not had any migrations run.
+//
+// If any errors are encountered, the test is failed and exited.
+func TestDB(ctx context.Context, t testing.TB) *pgxpool.Pool {
+	return testDB(ctx, t, dbNone)
+}
+
 type dbFlavor uint
 
 const (
-	_ dbFlavor = iota
+	dbNone dbFlavor = iota
 	dbMatcher
 	dbIndexer
 )
@@ -56,6 +68,8 @@ func testDB(ctx context.Context, t testing.TB, which dbFlavor) *pgxpool.Pool {
 	if err != nil {
 		t.Fatalf("failed to connect: %v", err)
 	}
+	checkVersion(ctx, t, pool)
+
 	mdb := stdlib.OpenDB(*cfg.ConnConfig)
 	defer mdb.Close()
 	// run migrations
@@ -67,6 +81,9 @@ func testDB(ctx context.Context, t testing.TB, which dbFlavor) *pgxpool.Pool {
 	case dbIndexer:
 		migrator.Table = migrations.IndexerMigrationTable
 		err = migrator.Exec(migrate.Up, migrations.IndexerMigrations...)
+	case dbNone:
+	default:
+		err = fmt.Errorf("unknown flavor: %v", which)
 	}
 	if err != nil {
 		t.Fatalf("failed to perform migrations: %v", err)
@@ -82,6 +99,23 @@ func testDB(ctx context.Context, t testing.TB, which dbFlavor) *pgxpool.Pool {
 		db.Close(ctx, t)
 	})
 	return pool
+}
+
+func checkVersion(ctx context.Context, t testing.TB, pool *pgxpool.Pool) {
+	t.Helper()
+	var vs string
+	err := pool.QueryRow(ctx, `SELECT current_setting('server_version_num');`).Scan(&vs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, err := strconv.ParseUint(vs, 10, 64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v < MinVersion {
+		t.Fatalf("PostgreSQL version too old: %d < %d", v, MinVersion)
+	}
+	t.Logf("PostgreSQL version: %d", v)
 }
 
 //go:embed sql


### PR DESCRIPTION
This is a new database schema for the `matcher` subsystem, focused on:

1. enabling queries across ecosystem silos
2. reducing write traffic during an update
3. trusting identifiers in the data instead of using client-side hashing schemes
4. bulk load via `COPY`

Explicit non-goals:

1. maintaining backwards compatibility
2. `JOIN` avoidance

TODO for this PR:

- [x] exercise GC down to `attr` and the "name" tables
- [x] benchmark a likely query, perhaps add a relevant `VIEW`