### PR TITLE
libvuln: implement DeltaUpdateVulnerabilities for jsonblob store

### DIFF
--- a/libvuln/jsonblob/jsonblob.go
+++ b/libvuln/jsonblob/jsonblob.go
@@ -450,9 +450,11 @@ func (s *Store) RecordUpdaterSetStatus(ctx context.Context, updaterSet string, u
 	return nil
 }
 
-// DeltaUpdateVulnerabilities is a noop
+// DeltaUpdateVulnerabilities just calls UpdateVulnerabilities. In the jsonblob flow it is assumed that
+// we're always starting from zero.
+// Note: deleted is ignored.
 func (s *Store) DeltaUpdateVulnerabilities(ctx context.Context, updater string, fingerprint driver.Fingerprint, vulns []*claircore.Vulnerability, deleted []string) (uuid.UUID, error) {
-	return uuid.Nil, nil
+	return s.UpdateVulnerabilities(ctx, updater, fingerprint, vulns)
 }
 
 // UpdateEnrichmentsIter is unimplemented.

--- a/libvuln/jsonblob/jsonblob_test.go
+++ b/libvuln/jsonblob/jsonblob_test.go
@@ -118,3 +118,32 @@ func TestEnrichments(t *testing.T) {
 	}
 	t.Logf("wrote:\n%s", buf.String())
 }
+
+func TestDeltaUpdaters(t *testing.T) {
+	s, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	numVulns := 10
+	vs := test.GenUniqueVulnerabilities(numVulns, "test")
+	ref, err := s.DeltaUpdateVulnerabilities(ctx, "test", "", vs, []string{})
+	if err != nil {
+		t.Error(err)
+	}
+	t.Logf("ref: %v", ref)
+
+	var buf bytes.Buffer
+	if err := s.Store(&buf); err != nil {
+		t.Error(err)
+	}
+	t.Logf("wrote:\n%s", buf.String())
+	lnCt := 0
+	for _, err := buf.ReadBytes('\n'); err == nil; _, err = buf.ReadBytes('\n') {
+		lnCt++
+	}
+	if lnCt != numVulns {
+		t.Errorf("expected %d vulns but got %d", numVulns, lnCt)
+	}
+}


### PR DESCRIPTION
This change ensures that any updaters that implement the delta update flow also have their vulnerabilities persisted in the jsonblob store.