### PR TITLE
csaf: add status to the document.tracking

### DIFF
--- a/toolkit/types/csaf/csaf.go
+++ b/toolkit/types/csaf/csaf.go
@@ -68,6 +68,7 @@ type Tracking struct {
 	ID                 string    `json:"id"`
 	CurrentReleaseDate time.Time `json:"current_release_date"`
 	InitialReleaseDate time.Time `json:"initial_release_date"`
+	Status             string    `json:"status"`
 }
 
 // Publisher provides information on the publishing entity.

--- a/toolkit/types/csaf/csaf_test.go
+++ b/toolkit/types/csaf/csaf_test.go
@@ -117,6 +117,9 @@ var testBattery = []struct {
 			},
 		},
 	},
+	{
+		path: "testdata/cve-1999-0001-deleted.json",
+	},
 }
 
 func TestAll(t *testing.T) {
@@ -130,6 +133,10 @@ func TestAll(t *testing.T) {
 			c, err := Parse(f)
 			if err != nil {
 				t.Fatalf("failed to parse CSAF JSON: %v", err)
+			}
+			if c.Document.Tracking.Status == "deleted" {
+				t.Log("advisory deleted", c.Document.Tracking.ID)
+				return
 			}
 			if got := c.ProductTree.FindProductByID(tc.product.ID); !cmp.Equal(tc.product, got) {
 				t.Error(cmp.Diff(tc.product, got))

--- a/toolkit/types/csaf/testdata/cve-1999-0001-deleted.json
+++ b/toolkit/types/csaf/testdata/cve-1999-0001-deleted.json
@@ -1,0 +1,1 @@
+{"document":{"tracking":{"id":"CVE-2023-0118","status":"deleted"}}}


### PR DESCRIPTION
Adding the status field to be able to reason with whether the advisory has been deleted.