### PR TITLE
libindex: add complimentary build constraint

### DIFF
--- a/libindex/tempdir_unix.go
+++ b/libindex/tempdir_unix.go
@@ -1,3 +1,5 @@
+//go:build unix
+
 package libindex
 
 import (


### PR DESCRIPTION
Noticed that this was preventing building on Windows.