### PR TITLE
httputil: add a ResponseChecker to be reused when making http calls

### DIFF
--- a/internal/httputil/responsechecker.go
+++ b/internal/httputil/responsechecker.go
@@ -1,0 +1,28 @@
+package httputil
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// CheckResponse takes a http.Response and a variadic of ints representing
+// acceptable http status codes. The error returned will attempt to include
+// some content from the server's response.
+func CheckResponse(resp *http.Response, acceptableCodes ...int) error {
+	acceptable := false
+	for _, code := range acceptableCodes {
+		if resp.StatusCode == code {
+			acceptable = true
+			break
+		}
+	}
+	if !acceptable {
+		limitBody, err := io.ReadAll(io.LimitReader(resp.Body, 256))
+		if err == nil {
+			return fmt.Errorf("unexpected status code: %s (body starts: %q)", resp.Status, limitBody)
+		}
+		return fmt.Errorf("unexpected status code: %s", resp.Status)
+	}
+	return nil
+}

--- a/internal/httputil/responsechecker_test.go
+++ b/internal/httputil/responsechecker_test.go
@@ -1,0 +1,30 @@
+package httputil
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+var respBody = `Sorry this resource isn't available at the moment, please try again later when the resource might be available`
+
+func TestLimitedReadResponse(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(respBody))
+	}))
+	defer svr.Close()
+
+	cl := svr.Client()
+	res, err := cl.Get(svr.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = CheckResponse(res, http.StatusOK)
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if err.Error() != "unexpected status code: 404 Not Found (body starts: \"Sorry this resource isn't available at the moment, please try again later when the resource might be available\")" {
+		t.Errorf("expected different error message but got: %s", err.Error())
+	}
+}


### PR DESCRIPTION
We were repeating this pattern in a few places in the code and it would be a good idea to include it in other http calls to get some context about an error without having to read the whole body.