### PR TITLE
cpe: avoid overwriting disjoint when using wildcards

### DIFF
--- a/toolkit/types/cpe/match.go
+++ b/toolkit/types/cpe/match.go
@@ -47,10 +47,11 @@ func Compare(src, tgt WFN) Relations {
 					// case insensitive glob compare
 					if !patCompare(sv.V, tv.V) {
 						m[i] = Disjoint
+					} else {
+						m[i] = Superset
 					}
-					m[i] = Superset
 				}
-				break
+				continue
 			}
 			switch tv.Kind {
 			case ValueAny, ValueUnset:


### PR DESCRIPTION
It was found that when comparing individual CPE attributes where the source contains a wildcard and the target should report a Disjoint, it was being overridden with a Superset.