### PR TITLE
cvss: v3: fix scope multiplication placement

### DIFF
--- a/toolkit/types/cvss/cvss_v3_score.go
+++ b/toolkit/types/cvss/cvss_v3_score.go
@@ -128,7 +128,7 @@ func (v *V3) Score() float64 {
 	if impact <= 0 {
 		return 0
 	}
-	base := round(scopeMod * math.Min(impact+exploitability, 10))
+	base := round(math.Min(scopeMod*(impact+exploitability), 10))
 	// This is the "Temporal" score, which should be fine to do unconditionally
 	// because the "Not Defined" weight is the multiplicative identity.
 	score := round(base * vals[V3ExploitMaturity] * vals[V3RemediationLevel] * vals[V3ReportConfidence])

--- a/toolkit/types/cvss/cvss_v3_test.go
+++ b/toolkit/types/cvss/cvss_v3_test.go
@@ -94,6 +94,8 @@ func TestV3(t *testing.T) {
 				{Vector: "CVSS:3.0/AV:P/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H", Score: 7.6}, // CVE-2018-3652
 				{Vector: "CVSS:3.0/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H", Score: 7.5}, // CVE-2019-0884 (IE)
 				{Vector: "CVSS:3.0/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:N", Score: 4.2}, // CVE-2019-0884 (Edge)
+
+				{Vector: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H", Score: 10.0}, // made up
 			}
 			Score[V3, V3Metric, *V3](t, tcs)
 		})
@@ -135,6 +137,7 @@ func TestV3(t *testing.T) {
 
 				{Vector: "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:L/I:L/A:N/E:F/RL:X", Score: 3.7},       // From spec example
 				{Vector: "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:L/I:L/A:N/CR:H/IR:H/AR:H", Score: 4.8}, // made up
+				{Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H", Score: 10.0},               // made up
 			}
 			Score[V3, V3Metric, *V3](t, tcs)
 		})


### PR DESCRIPTION
Prior to this change, the test CVSS I added was given a score of 10.8, which is too high