### PR TITLE
rhel: add repo_key matching constraint

### DIFF
--- a/datastore/postgres/querybuilder.go
+++ b/datastore/postgres/querybuilder.go
@@ -71,6 +71,8 @@ func buildGetQuery(record *claircore.IndexRecord, opts *datastore.GetOpts) (stri
 			ex = goqu.Ex{"dist_arch": record.Distribution.Arch}
 		case driver.RepositoryName:
 			ex = goqu.Ex{"repo_name": record.Repository.Name}
+		case driver.RepositoryKey:
+			ex = goqu.Ex{"repo_key": record.Repository.Key}
 		case driver.HasFixedInVersion:
 			ex = goqu.Ex{"fixed_in_version": goqu.Op{exp.NeqOp.String(): ""}}
 		default:

--- a/libvuln/driver/matcher.go
+++ b/libvuln/driver/matcher.go
@@ -41,6 +41,8 @@ const (
 	DistributionPrettyName
 	// should match claircore.Package.Repository.Name => claircore.Vulnerability.Package.Repository.Name
 	RepositoryName
+	// should match claircore.Package.Repository.Key => claircore.Vulnerability.Package.Repository.Key
+	RepositoryKey
 	// should match claircore.Vulnerability.FixedInVersion != ""
 	HasFixedInVersion
 )

--- a/rhel/matcher.go
+++ b/rhel/matcher.go
@@ -31,7 +31,7 @@ func (*Matcher) Filter(record *claircore.IndexRecord) bool {
 
 // Query implements driver.Matcher.
 func (m *Matcher) Query() []driver.MatchConstraint {
-	mcs := []driver.MatchConstraint{driver.PackageModule}
+	mcs := []driver.MatchConstraint{driver.PackageModule, driver.RepositoryKey}
 	if m.ignoreUnpatched {
 		mcs = append(mcs, driver.HasFixedInVersion)
 	}


### PR DESCRIPTION
As the matcher now no longer queries on repo name, it means the result set returned from the DB is a lot larger. This change limits the results to just those added by the RHEL updater (previously OVAL now VEX).