### PR TITLE
rhel: update security data url domain

### DIFF
--- a/rhel/repositoryscanner.go
+++ b/rhel/repositoryscanner.go
@@ -103,7 +103,7 @@ const (
 	// DefaultRepo2CPEMappingURL is default URL with a mapping file provided by Red Hat.
 	//
 	//doc:url indexer
-	DefaultRepo2CPEMappingURL = "https://access.redhat.com/security/data/metrics/repository-to-cpe.json"
+	DefaultRepo2CPEMappingURL = "https://security.access.redhat.com/data/metrics/repository-to-cpe.json"
 )
 
 // Name implements [indexer.VersionedScanner].

--- a/rhel/rhcc/scanner.go
+++ b/rhel/rhcc/scanner.go
@@ -56,7 +56,7 @@ type ScannerConfig struct {
 // Hat.
 //
 //doc:url indexer
-const DefaultName2ReposMappingURL = "https://access.redhat.com/security/data/metrics/container-name-repos-map.json"
+const DefaultName2ReposMappingURL = "https://security.access.redhat.com/data/metrics/container-name-repos-map.json"
 
 // Configure implements [indexer.RPCScanner].
 func (s *scanner) Configure(ctx context.Context, f indexer.ConfigDeserializer, c *http.Client) error {

--- a/rhel/rhcc/updater.go
+++ b/rhel/rhcc/updater.go
@@ -24,7 +24,7 @@ import (
 
 //doc:url updater
 const (
-	dbURL  = "https://access.redhat.com/security/data/metrics/cvemap.xml"
+	dbURL  = "https://security.access.redhat.com/data/metrics/cvemap.xml"
 	cveURL = "https://access.redhat.com/security/cve/"
 )
 

--- a/rhel/updaterset.go
+++ b/rhel/updaterset.go
@@ -18,7 +18,7 @@ import (
 // DefaultManifest is the url for the Red Hat OVAL pulp repository.
 //
 //doc:url updater
-const DefaultManifest = `https://access.redhat.com/security/data/oval/v2/PULP_MANIFEST`
+const DefaultManifest = `https://security.access.redhat.com/data/oval/v2/PULP_MANIFEST`
 
 // NewFactory creates a Factory making updaters based on the contents of the
 // provided pulp manifest.

--- a/rhel/vex/updater.go
+++ b/rhel/vex/updater.go
@@ -26,7 +26,7 @@ const (
 	// BaseURL is the base url for the Red Hat VEX security data.
 	//
 	//doc:url updater
-	BaseURL = "https://access.redhat.com/security/data/csaf/v2/vex/"
+	BaseURL = "https://security.access.redhat.com/data/csaf/v2/vex/"
 
 	latestFile     = "archive_latest.txt"
 	changesFile    = "changes.csv"


### PR DESCRIPTION
Red Hat security data is migrating over to the new location `https://security.access.redhat.com/data`, so this PR migrates all instances of `redhat.com/security/data` over to the new one.