### PR TITLE
chore: align go version with docs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,22 +62,7 @@ jobs:
       - name: mdBook Build
         run: mdbook build
 
-  current-go-version:
-    name: Get go.mod version
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.parse-mod.outputs.version }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - id: parse-mod
-        run: |
-          go_mod_file="go.mod"
-          while IFS= read -r line; do if [[ $line =~ ^go\ (.*)$ ]]; then go_ver="${BASH_REMATCH[1]}"; fi; done < $go_mod_file
-          echo "version=$go_ver" >> $GITHUB_OUTPUT
-
   tests:
-    needs: current-go-version
     name: Tests
     runs-on: ubuntu-latest
     strategy:
@@ -86,7 +71,6 @@ jobs:
         go:
           - 'stable'
           - 'oldstable'
-          - '${{ needs.current-go-version.outputs.version }}'
     steps:
       - name: Check for Previous Run
         id: previous

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/quay/claircore
 
-go 1.22.7
+go 1.22
 
 require (
 	github.com/Masterminds/semver v1.5.0

--- a/toolkit/go.mod
+++ b/toolkit/go.mod
@@ -1,5 +1,5 @@
 module github.com/quay/claircore/toolkit
 
-go 1.22.7
+go 1.22
 
 require github.com/google/go-cmp v0.6.0

--- a/updater/driver/go.mod
+++ b/updater/driver/go.mod
@@ -1,6 +1,6 @@
 module github.com/quay/claircore/updater/driver
 
-go 1.22.7
+go 1.22
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
Updating to go1.22.7 which is/was the latest patch is not in-line with our own documentation https://github.com/crozzy/claircore/blob/main/docs/contributor/go_version.md.