### PR TITLE
docs: update README to remove non-existent commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,26 @@
 ![](https://github.com/quay/claircore/workflows/CI/badge.svg)
-# ClairCore
+# Claircore
 
-ClairCore provides a set of go modules which handle scanning container layers for installed packages and reporting any discovered vulnerabilities.  
-ClairCore is designed to be embedded into a service wrapper.  
+Claircore provides a set of go modules which handle scanning container layers for installed packages and reporting any discovered vulnerabilities.
+Claircore is designed to be embedded into a service wrapper.
 
-For a full overview see: [ClairCore Book](https://quay.github.io/claircore)
+For a full overview see: [Claircore Book](https://quay.github.io/claircore)
 
-# Local development and testing
+# Testing
 
-The following targets start and stop a local development environment  
-```
-make local-dev-up
-make local-dev-down
-```
-
-If you modify libvuln or libindex code the following make targets will restart the services with your changes  
-```
-make libindexhttp-restart
-make libvulnhttp-restart
-```
-
-With the local development environment up the following make target runs all tests including integration  
-```
-make integration
-```
-
-The following make target runs unit tests which do not require a database or local development environment  
-```
+The following make target runs unit tests which do not require a database or local development environment.
+```sh
 make unit
+# or make unit-v for verbose output
+```
+
+With the local development environment up the following make target runs all tests including integration.
+```sh
+make integration
+# or integration-v for verbose output
+```
+
+With the local development environment up the following make target runs all tests including integration with full benchmark results.
+```sh
+make bench
 ```


### PR DESCRIPTION
Refresh the README to be more in-line with the commands that exist in the Makefile. Also, bring the casing of Claircore in-line with convention (Claircore == good in prose, claircore == good in code, ClairCore == bad).