### PR TITLE
gobin: ignore flags in stdlib version

### DIFF
--- a/gobin/gobin.go
+++ b/gobin/gobin.go
@@ -35,7 +35,7 @@ type Detector struct{}
 
 const (
 	detectorName    = `gobin`
-	detectorVersion = `5`
+	detectorVersion = `6`
 	detectorKind    = `package`
 )
 


### PR DESCRIPTION
I pulled the binary from an OpenShift image (`/usr/bin/openshift-controller-manager`) and ran `TestBin` in `gobin/exe_test.go`:

```
stdlib@1.20.12 / 1.20.12
```

This is what I expected to see.

Previously, it was:

```
stdlib@go1.20.12 X:strictfipsruntime / 0
```

`gobin`'s matcher relies on PostgreSQL to handle the version comparison based on the `NormalizedVersion`. In this case, it'll be `1.20.12`, which is what we'd want/expect.

Note: This will change the package's version by removing the `X` flags, as they are not used at this time. The unique index for the `package` table is based on `(name, version, kind, module, arch)`. So, if we do not change the version, then instances of Clair which upgrade to a version with this change will not have the package's table modified to account for these changes. A solution would be to have a DB migration to potentially wipe any Go-related packages, but that seemed like overkill, as we do not utilize knowledge of the flags at this time. We will consider re-adding them at a later time should they be needed then.