### PR TITLE
csaf: read aggregate_severity

### DIFF
--- a/toolkit/types/csaf/csaf.go
+++ b/toolkit/types/csaf/csaf.go
@@ -46,10 +46,11 @@ type CSAF struct {
 //
 // https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#321-document-property
 type DocumentMetadata struct {
-	Title      string      `json:"title"`
-	Tracking   Tracking    `json:"tracking"`
-	References []Reference `json:"references"`
-	Publisher  Publisher   `json:"publisher"`
+	Title             string            `json:"title"`
+	Tracking          Tracking          `json:"tracking"`
+	References        []Reference       `json:"references"`
+	Publisher         Publisher         `json:"publisher"`
+	AggregateSeverity AggregateSeverity `json:"aggregate_severity"`
 }
 
 // Document references holds a list of references associated with the whole document.
@@ -80,6 +81,14 @@ type Publisher struct {
 	IssuingAuthority string `json:"issuing_authority"`
 	Name             string `json:"name"`
 	Namespace        string `json:"namespace"`
+}
+
+// AggregateSeverity provides information on the severity of one or more vulnerabilities in the document.
+//
+// https://docs.oasis-open.org/csaf/csaf/v2.0/os/csaf-v2.0-os.html#3212-document-property---aggregate-severity
+type AggregateSeverity struct {
+	Namespace string `json:"namespace"`
+	Text      string `json:"text"`
 }
 
 // Vulnerability contains information about a CVE and its associated threats.

--- a/toolkit/types/csaf/csaf_test.go
+++ b/toolkit/types/csaf/csaf_test.go
@@ -16,6 +16,7 @@ var testBattery = []struct {
 	remediation          *RemediationData
 	scoreProductID       string
 	score                *Score
+	severity             AggregateSeverity
 	prodIdentifier       *Product
 	threatProductID      string
 	threatData           *ThreatData
@@ -40,6 +41,10 @@ var testBattery = []struct {
 		},
 		remediation: nil, // no remediation data in this file
 		score:       nil, // no score data in this file
+		severity: AggregateSeverity{
+			Namespace: "https://access.redhat.com/security/updates/classification/",
+			Text:      "important",
+		},
 		prodIdentifier: &Product{
 			Name: "Red Hat Enterprise Linux 7",
 			ID:   "red_hat_enterprise_linux_7",
@@ -73,6 +78,10 @@ var testBattery = []struct {
 			URL:      "https://access.redhat.com/errata/RHSA-2022:0011",
 		},
 		score: nil, // no score for RHSAs
+		severity: AggregateSeverity{
+			Namespace: "https://access.redhat.com/security/updates/classification/",
+			Text:      "Important",
+		},
 		prodIdentifier: &Product{
 			Name: "Red Hat Enterprise Linux Server E4S (v. 7.6)",
 			ID:   "7Server-7.6.E4S",
@@ -111,6 +120,10 @@ var testBattery = []struct {
 			},
 			ProductIDs: []string{"red_hat_satellite_6:rubygem-audited"},
 		},
+		severity: AggregateSeverity{
+			Namespace: "https://access.redhat.com/security/updates/classification/",
+			Text:      "low",
+		},
 		threatProductID: "red_hat_satellite_6:rubygem-audited",
 		threatData: &ThreatData{
 			Category:   "impact",
@@ -145,6 +158,9 @@ func TestAll(t *testing.T) {
 			if c.Document.Tracking.Status == "deleted" {
 				t.Log("advisory deleted", c.Document.Tracking.ID)
 				return
+			}
+			if !cmp.Equal(tc.severity, c.Document.AggregateSeverity) {
+				t.Error(cmp.Diff(tc.severity, c.Document.AggregateSeverity))
 			}
 			if got := c.ProductTree.FindProductByID(tc.product.ID); !cmp.Equal(tc.product, got) {
 				t.Error(cmp.Diff(tc.product, got))


### PR DESCRIPTION
I am interested in obtaining the aggregate severity of a CSAF advisory. For example: https://security.access.redhat.com/data/csaf/v2/advisories/2024/rhsa-2024_0024.json

It has an aggregate severity of `Important`. Without this change, I'd have to look at the severity rating of each vulnerability and find the highest (assuming that's how the aggregate is determined 100% of the time). With this change, it's much simpler to obtain.