### PR TITLE
gobin: always report the main version in Package.Version

### DIFF
--- a/gobin/gobin.go
+++ b/gobin/gobin.go
@@ -3,13 +3,11 @@
 //
 // # Main module versioning
 //
-// The go toolchain currently only fills in version information for modules
+// The go toolchain before go1.24 only fills in version information for modules
 // obtained as a module. Most go executables are built from source checkouts,
-// meaning they are not in module form. See [issue 50603] for details on why and
-// what's being explored to provide this information. Accordingly, claircore
-// cannot report advisories for main modules.
-//
-// [issue 50603]: https://golang.org/issues/50603
+// meaning they are not in module form pre-go1.24. Accordingly, claircore cannot
+// report advisories for main modules built pre-go1.24. See relevant go commit:
+// https://cs.opensource.google/go/go/+/8aa2eed8fb90303c0876e51e097105eca7299734
 package gobin
 
 import (

--- a/gobin/gobin_test.go
+++ b/gobin/gobin_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"testing"
 
@@ -159,7 +158,7 @@ func TestScanner(t *testing.T) {
 		case v.Kind != claircore.BINARY:
 		case v.PackageDB != "go:bin/bisect":
 			t.Errorf("unexpected package DB: %s: %q", v.Name, v.PackageDB)
-		case !verRegexp.MatchString(v.Version):
+		case !versionRegex.MatchString(v.Version):
 			t.Errorf("unexpected version: %s: %q", v.Name, v.Version)
 		case !strings.Contains(v.Name, "/"):
 			t.Errorf("unexpected module name: %q", v.Name)
@@ -169,5 +168,3 @@ func TestScanner(t *testing.T) {
 		t.Errorf("unexpected entry: %v", v)
 	}
 }
-
-var verRegexp = regexp.MustCompile(`^v([0-9]+\.){2}[0-9]+(-[.0-9]+-[0-9a-f]+)?(\+incompatible)?$`)


### PR DESCRIPTION
Go 1.24 changes the way in which the main module's version is reported when the module is build via `go build`. What used to be just reported as `(devel)` will now be reported as the version + revision info (+dirty if status is uncommitted) unless the -buildvcs=false is set. All this means that the unit tests failed as the expected `(devel)` version wasn't found and instead "" was reported because the gobin detector doesn't set any Version if the main module's version was parseable (this isn't a big deal because the matching always works of NormalizedVersion which is always set). This change always adds the Version and the test checks the Version with the same regex `ParseVersion` uses.