### PR TITLE
replace io.ReadCloser with io.Reader in Parse methods

### DIFF
--- a/alpine/parser.go
+++ b/alpine/parser.go
@@ -17,10 +17,9 @@ const (
 
 var _ driver.Parser = (*updater)(nil)
 
-func (u *updater) Parse(ctx context.Context, r io.ReadCloser) ([]*claircore.Vulnerability, error) {
+func (u *updater) Parse(ctx context.Context, r io.Reader) ([]*claircore.Vulnerability, error) {
 	ctx = zlog.ContextWithValues(ctx, "component", "alpine/Updater.Parse")
 	zlog.Info(ctx).Msg("starting parse")
-	defer r.Close()
 
 	var db SecurityDB
 	if err := json.NewDecoder(r).Decode(&db); err != nil {

--- a/aws/updater.go
+++ b/aws/updater.go
@@ -74,7 +74,7 @@ func (u *Updater) Fetch(ctx context.Context, fingerprint driver.Fingerprint) (io
 	return rc, driver.Fingerprint(updatesRepoMD.Checksum.Sum), nil
 }
 
-func (u *Updater) Parse(ctx context.Context, contents io.ReadCloser) ([]*claircore.Vulnerability, error) {
+func (u *Updater) Parse(ctx context.Context, contents io.Reader) ([]*claircore.Vulnerability, error) {
 	var updates alas.Updates
 	dec := xml.NewDecoder(contents)
 	dec.CharsetReader = xmlutil.CharsetReader

--- a/datastore/postgres/gc_test.go
+++ b/datastore/postgres/gc_test.go
@@ -22,7 +22,7 @@ import (
 type updaterMock struct {
 	_name  func() string
 	_fetch func(_ context.Context, _ driver.Fingerprint) (io.ReadCloser, driver.Fingerprint, error)
-	_parse func(ctx context.Context, contents io.ReadCloser) ([]*claircore.Vulnerability, error)
+	_parse func(ctx context.Context, contents io.Reader) ([]*claircore.Vulnerability, error)
 }
 
 func (u *updaterMock) Name() string {
@@ -33,7 +33,7 @@ func (u *updaterMock) Fetch(ctx context.Context, fp driver.Fingerprint) (io.Read
 	return u._fetch(ctx, fp)
 }
 
-func (u *updaterMock) Parse(ctx context.Context, contents io.ReadCloser) ([]*claircore.Vulnerability, error) {
+func (u *updaterMock) Parse(ctx context.Context, contents io.Reader) ([]*claircore.Vulnerability, error) {
 	return u._parse(ctx, contents)
 }
 
@@ -49,7 +49,7 @@ func TestGC(t *testing.T) {
 		_fetch: func(_ context.Context, _ driver.Fingerprint) (io.ReadCloser, driver.Fingerprint, error) {
 			return nil, "", nil
 		},
-		_parse: func(ctx context.Context, contents io.ReadCloser) ([]*claircore.Vulnerability, error) {
+		_parse: func(ctx context.Context, contents io.Reader) ([]*claircore.Vulnerability, error) {
 			return []*claircore.Vulnerability{
 				{
 					Name:    randString(t),

--- a/debian/parser.go
+++ b/debian/parser.go
@@ -33,10 +33,9 @@ type ReleaseData struct {
 }
 
 // Parse implements [driver.Parser].
-func (u *updater) Parse(ctx context.Context, r io.ReadCloser) ([]*claircore.Vulnerability, error) {
+func (u *updater) Parse(ctx context.Context, r io.Reader) ([]*claircore.Vulnerability, error) {
 	ctx = zlog.ContextWithValues(ctx, "component", "debian/Updater.Parse")
 	zlog.Info(ctx).Msg("starting parse")
-	defer r.Close()
 
 	var vulnsJSON JSONData
 	err := json.NewDecoder(r).Decode(&vulnsJSON)

--- a/enricher/cvss/cvss.go
+++ b/enricher/cvss/cvss.go
@@ -231,11 +231,10 @@ func (e *Enricher) FetchEnrichment(ctx context.Context, hint driver.Fingerprint)
 }
 
 // ParseEnrichment implements driver.EnrichmentUpdater.
-func (e *Enricher) ParseEnrichment(ctx context.Context, rc io.ReadCloser) ([]driver.EnrichmentRecord, error) {
+func (e *Enricher) ParseEnrichment(ctx context.Context, rc io.Reader) ([]driver.EnrichmentRecord, error) {
 	ctx = zlog.ContextWithValues(ctx, "component", "enricher/cvss/Enricher/ParseEnrichment")
 	// Our Fetch method actually has all the smarts w/r/t to constructing the
 	// records, so this is just decoding in a loop.
-	defer rc.Close()
 	var err error
 	dec := json.NewDecoder(rc)
 	ret := make([]driver.EnrichmentRecord, 0, 1024) // Wild guess at initial capacity.

--- a/enricher/epss/epss.go
+++ b/enricher/epss/epss.go
@@ -227,10 +227,8 @@ func (e *Enricher) FetchEnrichment(ctx context.Context, prevFingerprint driver.F
 }
 
 // ParseEnrichment implements driver.EnrichmentUpdater.
-func (e *Enricher) ParseEnrichment(ctx context.Context, rc io.ReadCloser) ([]driver.EnrichmentRecord, error) {
+func (e *Enricher) ParseEnrichment(ctx context.Context, rc io.Reader) ([]driver.EnrichmentRecord, error) {
 	ctx = zlog.ContextWithValues(ctx, "component", "enricher/epss/Enricher/ParseEnrichment")
-
-	defer rc.Close()
 
 	dec := json.NewDecoder(rc)
 	ret := make([]driver.EnrichmentRecord, 0, 250_000)

--- a/libvuln/driver/enrichment.go
+++ b/libvuln/driver/enrichment.go
@@ -51,7 +51,7 @@ func (u NoopUpdater) Fetch(_ context.Context, _ Fingerprint) (io.ReadCloser, Fin
 }
 
 // Parse implements Updater.
-func (u NoopUpdater) Parse(_ context.Context, _ io.ReadCloser) ([]*claircore.Vulnerability, error) {
+func (u NoopUpdater) Parse(_ context.Context, _ io.Reader) ([]*claircore.Vulnerability, error) {
 	return []*claircore.Vulnerability{}, nil
 }
 

--- a/libvuln/driver/enrichment.go
+++ b/libvuln/driver/enrichment.go
@@ -33,9 +33,9 @@ type EnrichmentUpdater interface {
 	//
 	// If there's no new data, the method should report Unchanged.
 	FetchEnrichment(context.Context, Fingerprint) (io.ReadCloser, Fingerprint, error)
-	// ParseEnrichment reads from the provided io.ReadCloser, parses its contents,
+	// ParseEnrichment reads from the provided io.Reader, parses its contents,
 	// and returns a slice of EnrichmentRecords or an error.
-	ParseEnrichment(context.Context, io.ReadCloser) ([]EnrichmentRecord, error)
+	ParseEnrichment(context.Context, io.Reader) ([]EnrichmentRecord, error)
 }
 
 // NoopUpdater is designed to be embedded into other Updater types so they can

--- a/libvuln/driver/updater.go
+++ b/libvuln/driver/updater.go
@@ -19,13 +19,13 @@ type Updater interface {
 
 // Parser is an interface which is embedded into the Updater interface.
 //
-// Parse should be called with an io.ReadCloser struct where the contents of a security
+// Parse should be called with an io.Reader struct where the contents of a security
 // advisory database can be read and parsed into an array of *claircore.Vulnerability
 type Parser interface {
-	// Parse should take an io.ReadCloser, read the contents, parse the contents
+	// Parse should take an io.Reader, read the contents, parse the contents
 	// into a list of claircore.Vulnerability structs and then return
 	// the list. Parse should assume contents are uncompressed and ready for parsing.
-	Parse(ctx context.Context, contents io.ReadCloser) ([]*claircore.Vulnerability, error)
+	Parse(ctx context.Context, contents io.Reader) ([]*claircore.Vulnerability, error)
 }
 
 // Fetcher is an interface which is embedded into the Updater interface.

--- a/libvuln/updates/manager_test.go
+++ b/libvuln/updates/manager_test.go
@@ -98,7 +98,7 @@ func (tu *testUpdater) Fetch(context.Context, driver.Fingerprint) (io.ReadCloser
 	return nil, "", nil
 }
 
-func (tu *testUpdater) Parse(ctx context.Context, vulnUpdates io.ReadCloser) ([]*claircore.Vulnerability, error) {
+func (tu *testUpdater) Parse(ctx context.Context, vulnUpdates io.Reader) ([]*claircore.Vulnerability, error) {
 	// NOOP
 	return nil, nil
 }

--- a/oracle/parser.go
+++ b/oracle/parser.go
@@ -34,10 +34,9 @@ var platformToDist = map[string]*claircore.Distribution{
 
 var _ driver.Parser = (*Updater)(nil)
 
-func (u *Updater) Parse(ctx context.Context, r io.ReadCloser) ([]*claircore.Vulnerability, error) {
+func (u *Updater) Parse(ctx context.Context, r io.Reader) ([]*claircore.Vulnerability, error) {
 	ctx = zlog.ContextWithValues(ctx, "component", "oracle/Updater.Parse")
 	zlog.Info(ctx).Msg("starting parse")
-	defer r.Close()
 	root := oval.Root{}
 	dec := xml.NewDecoder(r)
 	dec.CharsetReader = xmlutil.CharsetReader

--- a/photon/parser.go
+++ b/photon/parser.go
@@ -17,10 +17,9 @@ import (
 
 var _ driver.Parser = (*Updater)(nil)
 
-func (u *Updater) Parse(ctx context.Context, r io.ReadCloser) ([]*claircore.Vulnerability, error) {
+func (u *Updater) Parse(ctx context.Context, r io.Reader) ([]*claircore.Vulnerability, error) {
 	ctx = zlog.ContextWithValues(ctx, "component", "photon/Updater.Parse")
 	zlog.Info(ctx).Msg("starting parse")
-	defer r.Close()
 	root := oval.Root{}
 	dec := xml.NewDecoder(r)
 	dec.CharsetReader = xmlutil.CharsetReader

--- a/rhel/parser.go
+++ b/rhel/parser.go
@@ -22,10 +22,9 @@ import (
 // flavored OVAL XML. The distribution associated with vulnerabilities
 // is configured via the Updater. The repository associated with
 // vulnerabilies is based on the affected CPE list.
-func (u *Updater) Parse(ctx context.Context, r io.ReadCloser) ([]*claircore.Vulnerability, error) {
+func (u *Updater) Parse(ctx context.Context, r io.Reader) ([]*claircore.Vulnerability, error) {
 	ctx = zlog.ContextWithValues(ctx, "component", "rhel/Updater.Parse")
 	zlog.Info(ctx).Msg("starting parse")
-	defer r.Close()
 	root := oval.Root{}
 	dec := xml.NewDecoder(r)
 	dec.CharsetReader = xmlutil.CharsetReader

--- a/rhel/vex/parser.go
+++ b/rhel/vex/parser.go
@@ -24,7 +24,7 @@ import (
 )
 
 // Parse implements [driver.Updater].
-func (u *Updater) Parse(ctx context.Context, contents io.ReadCloser) ([]*claircore.Vulnerability, error) {
+func (u *Updater) Parse(ctx context.Context, contents io.Reader) ([]*claircore.Vulnerability, error) {
 	// NOOP
 	return nil, errors.ErrUnsupported
 }

--- a/suse/parser.go
+++ b/suse/parser.go
@@ -17,11 +17,10 @@ import (
 
 var _ driver.Parser = (*Updater)(nil)
 
-func (u *Updater) Parse(ctx context.Context, r io.ReadCloser) ([]*claircore.Vulnerability, error) {
+func (u *Updater) Parse(ctx context.Context, r io.Reader) ([]*claircore.Vulnerability, error) {
 	ctx = zlog.ContextWithValues(ctx,
 		"component", "suse/Updater.Parse")
 	zlog.Info(ctx).Msg("starting parse")
-	defer r.Close()
 	root := oval.Root{}
 	dec := xml.NewDecoder(r)
 	dec.CharsetReader = xmlutil.CharsetReader

--- a/ubuntu/updater.go
+++ b/ubuntu/updater.go
@@ -141,11 +141,10 @@ func (u *updater) Fetch(ctx context.Context, fingerprint driver.Fingerprint) (io
 }
 
 // Parse implements [driver.Updater].
-func (u *updater) Parse(ctx context.Context, r io.ReadCloser) ([]*claircore.Vulnerability, error) {
+func (u *updater) Parse(ctx context.Context, r io.Reader) ([]*claircore.Vulnerability, error) {
 	ctx = zlog.ContextWithValues(ctx,
 		"component", "ubuntu/Updater.Parse")
 	zlog.Info(ctx).Msg("starting parse")
-	defer r.Close()
 	root := oval.Root{}
 	dec := xml.NewDecoder(r)
 	dec.CharsetReader = xmlutil.CharsetReader

--- a/updater/osv/osv.go
+++ b/updater/osv/osv.go
@@ -328,7 +328,7 @@ func (u *updater) Fetch(ctx context.Context, fp driver.Fingerprint) (io.ReadClos
 }
 
 // Fetcher implements driver.Updater.
-func (u *updater) Parse(ctx context.Context, r io.ReadCloser) ([]*claircore.Vulnerability, error) {
+func (u *updater) Parse(ctx context.Context, r io.Reader) ([]*claircore.Vulnerability, error) {
 	ctx = zlog.ContextWithValues(ctx, "component", "updater/osv/updater.Parse")
 	ra, ok := r.(io.ReaderAt)
 	if !ok {


### PR DESCRIPTION
There is no reason that I can see why these methods must take in `io.ReadCloser`. The update manager already closes them, so might as well just pass in `io.Reader` instead.