### PR TITLE
chore: update to go1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/quay/claircore
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/Masterminds/semver v1.5.0


### PR DESCRIPTION
According to the [Go Release policy](https://go.dev/doc/devel/release#policy) Go 1.22 is no longer supported, and things coming down the pipe will rely on 1.23's iterator support.