### PR TITLE
oracle: inclusive year limit in updater

### DIFF
--- a/oracle/updaterset.go
+++ b/oracle/updaterset.go
@@ -10,7 +10,7 @@ import (
 
 func UpdaterSet(_ context.Context) (driver.UpdaterSet, error) {
 	us := driver.NewUpdaterSet()
-	for year, lim := 2007, time.Now().Year(); year != lim; year++ {
+	for year, lim := 2007, time.Now().Year(); year <= lim; year++ {
 		u, err := NewUpdater(year)
 		if err != nil {
 			return us, fmt.Errorf("unable to create oracle updater: %v", err)


### PR DESCRIPTION
Fixes the Oracle updater to include the current year.

Proof:
<details>
<summary>
main.go
</summary>

```go
package main

import (
        "fmt"
        "time"
)

func main() {
        fmt.Println("Current loop:")
        for year, lim := 2007, time.Now().Year(); year != lim; year++ {
                fmt.Println(year)
        }

        fmt.Println()

        fmt.Println("Fixed loop:")
        for year, lim := 2007, time.Now().Year(); year <= lim; year++ {
                fmt.Println(year)
        }
}
```
</details>

<details>
<summary>
output
</summary>

```
Current loop:
2007
2008
2009
2010
2011
2012
2013
2014
2015
2016
2017
2018
2019
2020
2021
2022
2023
2024

Fixed loop:
2007
2008
2009
2010
2011
2012
2013
2014
2015
2016
2017
2018
2019
2020
2021
2022
2023
2024
2025
```
</details>

Related to https://github.com/quay/claircore/issues/1419.