### PR TITLE
vex: allow timeout to pull down VEX archive to be configurable

### DIFF
--- a/duration.go
+++ b/duration.go
@@ -1,0 +1,27 @@
+package claircore
+
+import (
+	"errors"
+	"time"
+)
+
+// Duration is a serializeable [time.Duration].
+type Duration time.Duration
+
+// UnmarshalText implements [encoding.TextUnmarshaler].
+func (d *Duration) UnmarshalText(b []byte) error {
+	dur, err := time.ParseDuration(string(b))
+	if err != nil {
+		return err
+	}
+	*d = Duration(dur)
+	return nil
+}
+
+// MarshalText implements [encoding.TextMarshaler].
+func (d *Duration) MarshalText() ([]byte, error) {
+	if d == nil {
+		return nil, errors.New("cannot marshal nil duration")
+	}
+	return []byte(time.Duration(*d).String()), nil
+}

--- a/rhel/vex/fetcher.go
+++ b/rhel/vex/fetcher.go
@@ -27,9 +27,8 @@ import (
 )
 
 var (
-	compressedFileTimeout = 2 * time.Minute
-	deletedTemplate       = `{"document":{"tracking":{"id":"%s","status":"deleted"}}}`
-	cvePathRegex          = regexp.MustCompile(`^\d{4}/(cve-\d{4}-\d{4,}).json$`)
+	deletedTemplate = `{"document":{"tracking":{"id":"%s","status":"deleted"}}}`
+	cvePathRegex    = regexp.MustCompile(`^\d{4}/(cve-\d{4}-\d{4,}).json$`)
 )
 
 // Fetch pulls data down from the Red Hat VEX endpoints. The order of operations is:
@@ -107,7 +106,7 @@ func (u *Updater) Fetch(ctx context.Context, hint driver.Fingerprint) (io.ReadCl
 	}
 
 	if processArchive {
-		rctx, cancel := context.WithTimeout(ctx, compressedFileTimeout)
+		rctx, cancel := context.WithTimeout(ctx, u.compressedFileTimeout)
 		defer cancel()
 
 		if compressedURL == nil {


### PR DESCRIPTION
The timeout was hardcoded to 2m, this remains the default value but users have the option to configure it to a different value using `updaters.config.rhel-vex.compressed_file_timeout`.