### PR TITLE
rpm: update package detector versions

### DIFF
--- a/gobin/gobin.go
+++ b/gobin/gobin.go
@@ -34,7 +34,7 @@ type Detector struct{}
 
 const (
 	detectorName    = `gobin`
-	detectorVersion = `6`
+	detectorVersion = `7`
 	detectorKind    = `package`
 )
 

--- a/nodejs/packagescanner.go
+++ b/nodejs/packagescanner.go
@@ -12,9 +12,9 @@ import (
 	"runtime/trace"
 	"strings"
 
+	"github.com/Masterminds/semver"
 	"github.com/quay/zlog"
 
-	"github.com/Masterminds/semver"
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/indexer"
 	"github.com/quay/claircore/rpm"
@@ -45,7 +45,7 @@ type Scanner struct{}
 func (*Scanner) Name() string { return "nodejs" }
 
 // Version implements scanner.VersionedScanner.
-func (*Scanner) Version() string { return "2" }
+func (*Scanner) Version() string { return "3" }
 
 // Kind implements scanner.VersionedScanner.
 func (*Scanner) Kind() string { return "package" }

--- a/python/packagescanner.go
+++ b/python/packagescanner.go
@@ -47,7 +47,7 @@ type Scanner struct{}
 func (*Scanner) Name() string { return "python" }
 
 // Version implements scanner.VersionedScanner.
-func (*Scanner) Version() string { return "4" }
+func (*Scanner) Version() string { return "5" }
 
 // Kind implements scanner.VersionedScanner.
 func (*Scanner) Kind() string { return "package" }

--- a/ruby/packagescanner.go
+++ b/ruby/packagescanner.go
@@ -71,7 +71,7 @@ type Scanner struct{}
 func (*Scanner) Name() string { return "ruby" }
 
 // Version implements scanner.VersionedScanner.
-func (*Scanner) Version() string { return "2" }
+func (*Scanner) Version() string { return "3" }
 
 // Kind implements scanner.VersionedScanner.
 func (*Scanner) Kind() string { return "package" }


### PR DESCRIPTION
After merging 1a72e8e2ab846a4ef08a4e4ba7829161db466be0 the package detector versions should have iterated, this commit corrects that. (Java omitted as it has been updated since).