### PR TITLE
chore: consume layers in reverse order for rpm spotchecks

### DIFF
--- a/test/periodic/rpm_test.go
+++ b/test/periodic/rpm_test.go
@@ -223,7 +223,8 @@ func (doc hydraDoc) Run(dir string) func(*testing.T) {
 		s := &rpm.Scanner{}
 		pkgMap := map[string]*claircore.Package{}
 		var which claircore.Digest
-		for _, ld := range image.Data[0].Parsed.Layers {
+		for i := len(image.Data[0].Parsed.Layers) - 1; i >= 0; i-- {
+			ld := image.Data[0].Parsed.Layers[i]
 			// TODO(hank) Need a way to use the nicer API, but pass the
 			// Integration bypass.
 			n, err := fetch.Layer(ctx, t, doc.Registry, doc.Repository, ld, fetch.IgnoreIntegration)


### PR DESCRIPTION
It turns out that some images are now upgrading packages in subsequent layers, this meant our process of overwriting packages with the same name should have worked but it looks like the layers are ordered in reverse when returned via the api/containers/v1/repositories/registry API.