### PR TITLE
rpm: optimize file checking operation

### DIFF
--- a/gobin/gobin.go
+++ b/gobin/gobin.go
@@ -84,6 +84,11 @@ func (Detector) Scan(ctx context.Context, l *claircore.Layer) ([]*claircore.Pack
 	//
 	// Only create a single spool file per call, re-use for every binary.
 	var spool spoolfile
+	fc, err := rpm.NewFileChecker(ctx, l)
+	if err != nil {
+		return nil, fmt.Errorf("gobin: unable to check RPM db: %w", err)
+	}
+
 	walk := func(p string, d fs.DirEntry, err error) error {
 		ctx := zlog.ContextWithValues(ctx, "filename", d.Name())
 
@@ -108,11 +113,7 @@ func (Detector) Scan(ctx context.Context, l *claircore.Layer) ([]*claircore.Pack
 			return nil
 		}
 
-		isRPM, err := rpm.FileInstalledByRPM(ctx, l, p)
-		if err != nil {
-			return err
-		}
-		if isRPM {
+		if fc.IsRPM(p) {
 			zlog.Debug(ctx).
 				Str("path", p).
 				Msg("file path determined to be of RPM origin")

--- a/java/packagescanner.go
+++ b/java/packagescanner.go
@@ -146,13 +146,13 @@ func (s *Scanner) Scan(ctx context.Context, layer *claircore.Layer) ([]*claircor
 	ck := make([]byte, sha1.Size)
 	doSearch := s.root != nil
 	defer putBuf(buf)
+	fc, err := rpm.NewFileChecker(ctx, layer)
+	if err != nil {
+		return nil, fmt.Errorf("java: unable to check RPM db: %w", err)
+	}
 	for _, n := range ars {
 		ctx := zlog.ContextWithValues(ctx, "file", n)
-		isRPM, err := rpm.FileInstalledByRPM(ctx, layer, n)
-		if err != nil {
-			return nil, err
-		}
-		if isRPM {
+		if fc.IsRPM(n) {
 			zlog.Debug(ctx).
 				Str("path", n).
 				Msg("file path determined to be of RPM origin")

--- a/nodejs/packagescanner.go
+++ b/nodejs/packagescanner.go
@@ -92,12 +92,13 @@ func (s *Scanner) Scan(ctx context.Context, layer *claircore.Layer) ([]*claircor
 
 	ret := make([]*claircore.Package, 0, len(pkgs))
 	var invalidPkgs []string
+	fc, err := rpm.NewFileChecker(ctx, layer)
+	if err != nil {
+		return nil, fmt.Errorf("nodejs: unable to check RPM db: %w", err)
+	}
+
 	for _, p := range pkgs {
-		isRPM, err := rpm.FileInstalledByRPM(ctx, layer, p)
-		if err != nil {
-			return nil, err
-		}
-		if isRPM {
+		if fc.IsRPM(p) {
 			zlog.Debug(ctx).
 				Str("path", p).
 				Msg("file path determined to be of RPM origin")

--- a/python/packagescanner.go
+++ b/python/packagescanner.go
@@ -79,12 +79,12 @@ func (ps *Scanner) Scan(ctx context.Context, layer *claircore.Layer) ([]*clairco
 		return nil, fmt.Errorf("python: failed to find delicious egg: %w", err)
 	}
 	var ret []*claircore.Package
+	fc, err := rpm.NewFileChecker(ctx, layer)
+	if err != nil {
+		return nil, fmt.Errorf("python: unable to check RPM db: %w", err)
+	}
 	for _, n := range ms {
-		isRPM, err := rpm.FileInstalledByRPM(ctx, layer, n)
-		if err != nil {
-			return nil, err
-		}
-		if isRPM {
+		if fc.IsRPM(n) {
 			zlog.Debug(ctx).
 				Str("path", n).
 				Msg("file path determined to be of RPM origin")

--- a/rpm/files_test.go
+++ b/rpm/files_test.go
@@ -82,10 +82,11 @@ func TestIsRPMFile(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(zlog.Test(context.Background(), t))
 			t.Parallel()
-			isRPM, err := FileInstalledByRPM(ctx, &realizedLayers[0], tt.filePath)
+			fc, err := NewFileChecker(ctx, &realizedLayers[0])
 			if err != nil {
 				t.Fatal(err)
 			}
+			isRPM := fc.IsRPM(tt.filePath)
 			if tt.isRPM != isRPM {
 				t.Errorf("expected isRPM: %t, got isRPM: %t", tt.isRPM, isRPM)
 			}

--- a/ruby/packagescanner.go
+++ b/ruby/packagescanner.go
@@ -103,12 +103,12 @@ func (ps *Scanner) Scan(ctx context.Context, layer *claircore.Layer) ([]*clairco
 	}
 
 	var ret []*claircore.Package
+	fc, err := rpm.NewFileChecker(ctx, layer)
+	if err != nil {
+		return nil, fmt.Errorf("ruby: unable to check RPM db: %w", err)
+	}
 	for _, g := range gs {
-		isRPM, err := rpm.FileInstalledByRPM(ctx, layer, g)
-		if err != nil {
-			return nil, fmt.Errorf("ruby: unable to check RPM db: %w", err)
-		}
-		if isRPM {
+		if fc.IsRPM(g) {
 			zlog.Debug(ctx).
 				Str("path", g).
 				Msg("file path determined to be of RPM origin")


### PR DESCRIPTION
While load testing the latest version it was found that the indexing latency was drastically increase (7x was observed). After some profile/blocking analysis it was found that the volume of calls to the `FileInstalledByRPM()` function were causing lock contention due to sheer number of paths the language detectors were checking. This change addresses that issue by creating `FileChecker` object before path iteration and then using it for the subsequent paths. After this change, no perceivable latency was added as a result of the RPM file checking.