### PR TITLE
datastore: gc enrichments

### DIFF
--- a/datastore/postgres/migrations/matcher/15-enrichment-indexes.sql
+++ b/datastore/postgres/migrations/matcher/15-enrichment-indexes.sql
@@ -1,0 +1,3 @@
+CREATE INDEX IF NOT EXISTS uo_enrich_enrich_idx ON uo_enrich (enrich);
+CREATE INDEX IF NOT EXISTS uo_enrich_uo_idx ON uo_enrich (uo);
+CREATE INDEX IF NOT EXISTS enrichment_updater_idx ON enrichment (updater);

--- a/datastore/postgres/migrations/migrations.go
+++ b/datastore/postgres/migrations/migrations.go
@@ -120,4 +120,8 @@ var MatcherMigrations = []migrate.Migration{
 		ID: 14,
 		Up: runFile("matcher/14-delete-rhcc-vulns.sql"),
 	},
+	{
+		ID: 15,
+		Up: runFile("matcher/15-enrichment-indexes.sql"),
+	},
 }


### PR DESCRIPTION
I have StackRox installed using Scanner V4, which is based on Claircore. Here's the `EXPLAIN ANALYZE` for the deletion queries:

```
# EXPLAIN ANALYZE DELETE FROM vuln v1 USING
vuln v2
LEFT JOIN uo_vuln uvl
ON v2.id = uvl.vuln
WHERE uvl.vuln IS NULL
AND v2.updater = 'rhel-vex'
AND v1.id = v2.id;
                                                                      QUERY PLAN                                                                       
-------------------------------------------------------------------------------------------------------------------------------------------------------
 Delete on vuln v1  (cost=1068367.20..1887805.36 rows=0 width=0) (actual time=18785.634..18785.638 rows=0 loops=1)
   ->  Hash Join  (cost=1068367.20..1887805.36 rows=407282 width=18) (actual time=18785.631..18785.635 rows=0 loops=1)
         Hash Cond: (v1.id = v2.id)
         ->  Seq Scan on vuln v1  (cost=0.00..795983.61 rows=5168461 width=14) (actual time=0.035..0.036 rows=1 loops=1)
         ->  Hash  (cost=1063276.18..1063276.18 rows=407282 width=20) (actual time=18784.195..18784.198 rows=0 loops=1)
               Buckets: 524288  Batches: 1  Memory Usage: 4096kB
               ->  Hash Anti Join  (cost=200433.67..1063276.18 rows=407282 width=20) (actual time=18784.194..18784.196 rows=0 loops=1)
                     Hash Cond: (v2.id = uvl.vuln)
                     ->  Seq Scan on vuln v2  (cost=0.00..808904.76 rows=1395657 width=14) (actual time=535.456..13101.478 rows=1387909 loops=1)
                           Filter: (updater = 'rhel-vex'::text)
                           Rows Removed by Filter: 3771885
                     ->  Hash  (cost=101633.63..101633.63 rows=5683763 width=14) (actual time=1862.736..1862.737 rows=6723341 loops=1)
                           Buckets: 1048576  Batches: 16  Memory Usage: 27863kB
                           ->  Seq Scan on uo_vuln uvl  (cost=0.00..101633.63 rows=5683763 width=14) (actual time=0.055..721.353 rows=6723341 loops=1)
 Planning Time: 2.595 ms
 Execution Time: 18785.752 ms
(16 rows)

# EXPLAIN ANALYZE DELETE FROM enrichment e1 USING
enrichment e2
LEFT JOIN uo_enrich uen
ON e2.id = uen.enrich
WHERE uen.enrich IS NULL
AND e2.updater = 'nvd'
AND e1.id = e2.id;
                                                                  QUERY PLAN                                                                   
-----------------------------------------------------------------------------------------------------------------------------------------------
 Delete on enrichment e1  (cost=24746.16..88408.00 rows=0 width=0) (actual time=1076.427..1076.434 rows=0 loops=1)
   ->  Nested Loop  (cost=24746.16..88408.00 rows=19071 width=18) (actual time=1076.423..1076.430 rows=0 loops=1)
         ->  Hash Anti Join  (cost=24745.74..68030.52 rows=19071 width=20) (actual time=1076.421..1076.427 rows=0 loops=1)
               Hash Cond: (e2.id = uen.enrich)
               ->  Seq Scan on enrichment e2  (cost=0.00..36912.85 rows=204714 width=14) (actual time=0.962..640.351 rows=196623 loops=1)
                     Filter: (updater = 'nvd'::text)
                     Rows Removed by Filter: 291609
               ->  Hash  (cost=12517.55..12517.55 rows=703455 width=14) (actual time=274.576..274.578 rows=700355 loops=1)
                     Buckets: 1048576  Batches: 2  Memory Usage: 24600kB
                     ->  Seq Scan on uo_enrich uen  (cost=0.00..12517.55 rows=703455 width=14) (actual time=0.018..89.865 rows=700355 loops=1)
         ->  Index Scan using enrichment_pkey on enrichment e1  (cost=0.42..1.07 rows=1 width=14) (never executed)
               Index Cond: (id = e2.id)
 Planning Time: 0.452 ms
 Execution Time: 1079.150 ms
(14 rows)
```

Tested on a local installation with nothing else running, and it took 6 - 8 minutes (sorry I forget). I had someone run this in an active cluster, and it took 7 minutes. All of these were on SSD. I ran it again on an inactive installation (ie one with no other activity happening) and it took 50 minutes on HDD.