### PR TITLE
Load latest repo2cpe/container mapping files prior to embedded

### DIFF
--- a/rhel/internal/common/updater.go
+++ b/rhel/internal/common/updater.go
@@ -38,10 +38,6 @@ func NewUpdater(url string, init interface{}) *Updater {
 		reqRate: rate.NewLimiter(interval, 1),
 	}
 	u.value.Store(init)
-	// If we were provided an initial value, pull the first token.
-	if !reflect.ValueOf(init).IsNil() {
-		u.reqRate.Allow()
-	}
 	return &u
 }
 


### PR DESCRIPTION
Currently ACS Scanner indexer will load the 'embedded' repository-to-cpe.json & container-name-repos-map.json and use them for 24 hours before attempting to pull the latest from Central/live URL.

This will lead to 'scanning discrepancies' when an indexer first starts up (such as when the HPA adds new replicas). 