### PR TITLE
chore: remove reviews from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    reviewers:
-      - "quay/babysitters"
     commit-message:
       prefix: "chore"
       include: "scope"
@@ -15,8 +13,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    reviewers:
-      - "quay/babysitters"
     commit-message:
       prefix: "chore"
       include: "scope"
@@ -31,8 +27,6 @@ updates:
     directory: "/toolkit"
     schedule:
       interval: "weekly"
-    reviewers:
-      - "quay/babysitters"
     commit-message:
       prefix: "chore"
       include: "scope"
@@ -47,8 +41,6 @@ updates:
     directory: "/updater/driver"
     schedule:
       interval: "weekly"
-    reviewers:
-      - "quay/babysitters"
     commit-message:
       prefix: "chore"
       include: "scope"


### PR DESCRIPTION
This option is being removed in favor of looking at the CODEOWNERS file, https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/