### PR TITLE
test: discount packages without source information in rpm-manifest

### DIFF
--- a/test/rpmtest/manifest.go
+++ b/test/rpmtest/manifest.go
@@ -45,6 +45,12 @@ func PackagesFromManifest(t *testing.T, items iter.Seq[catalog.RpmsItems]) iter.
 				t.Errorf("#%03d: (%#v) unable to determine version: %v", n, it, err)
 				continue
 			}
+
+			if it.SrpmName == "" && it.SrpmNEVRA == "" {
+				// This is a binary package with no source information. This can be discounted.
+				continue
+			}
+
 			// Newer images produced from Konflux shove all the source information
 			// into the SourceName and omit the SourceNEVRA. Try both.
 			//


### PR DESCRIPTION
/api/containers/v1/images/id/{img_id}/rpm-manifest now returns a lot of packages in the response for different architectures. These packages don't have any source information. This was causing test errors when trying to convert them into `claircore.Package`s. This patch ignores pacakges that don't contain full source information.