### PR TITLE
rhcc: account for labels.json file

### DIFF
--- a/internal/matcher/controller.go
+++ b/internal/matcher/controller.go
@@ -109,6 +109,9 @@ func (mc *Controller) dbFilter() (bool, bool) {
 func (mc *Controller) findInterested(records []*claircore.IndexRecord) []*claircore.IndexRecord {
 	out := []*claircore.IndexRecord{}
 	for _, record := range records {
+		if record.Package.NormalizedVersion.Kind == claircore.UnmatchableKind {
+			continue
+		}
 		if mc.m.Filter(record) {
 			out = append(out, record)
 		}

--- a/pkg/rhctag/version_test.go
+++ b/pkg/rhctag/version_test.go
@@ -118,6 +118,16 @@ func TestSimple(t *testing.T) {
 				Original: "4-22",
 			},
 		},
+		{
+			Name: "labels_epoch",
+			In:   "1742843776",
+			Err:  false,
+			Want: Version{
+				Major:    1742843776,
+				Minor:    0,
+				Original: "1742843776",
+			},
+		},
 	}
 
 	for _, tc := range tt {

--- a/rhel/matcher.go
+++ b/rhel/matcher.go
@@ -50,7 +50,7 @@ func (m *Matcher) Query() []driver.MatchConstraint {
 //
 // TODO(crozzy) Remove once RH VEX data updates CPEs with standard matching
 // expressions.
-func isCPESubstringMatch(recordCPE cpe.WFN, vulnCPE cpe.WFN) bool {
+func IsCPESubstringMatch(recordCPE cpe.WFN, vulnCPE cpe.WFN) bool {
 	return strings.HasPrefix(recordCPE.String(), strings.TrimRight(vulnCPE.String(), ":*"))
 }
 
@@ -78,7 +78,7 @@ func (m *Matcher) Vulnerable(ctx context.Context, record *claircore.IndexRecord,
 			Msg("unable to unbind repo CPE")
 		return false, nil
 	}
-	if !cpe.Compare(vuln.Repo.CPE, record.Repository.CPE).IsSuperset() && !isCPESubstringMatch(record.Repository.CPE, vuln.Repo.CPE) {
+	if !cpe.Compare(vuln.Repo.CPE, record.Repository.CPE).IsSuperset() && !IsCPESubstringMatch(record.Repository.CPE, vuln.Repo.CPE) {
 		return false, nil
 	}
 

--- a/rhel/matcher_test.go
+++ b/rhel/matcher_test.go
@@ -290,7 +290,7 @@ func TestIsCPEStringSubsetMatch(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			tt := tc
-			matched := isCPESubstringMatch(tt.recordCPE, tt.vulnCPE)
+			matched := IsCPESubstringMatch(tt.recordCPE, tt.vulnCPE)
 			if matched != tt.match {
 				t.Errorf("unexpected matching %s and %s", tt.recordCPE, tt.vulnCPE)
 			}

--- a/rhel/rhcc/coalescer_test.go
+++ b/rhel/rhcc/coalescer_test.go
@@ -2,7 +2,7 @@ package rhcc
 
 import (
 	"context"
-	"strconv"
+	"encoding/json"
 	"testing"
 
 	"github.com/quay/zlog"
@@ -16,60 +16,97 @@ func TestCoalescer(t *testing.T) {
 	t.Parallel()
 	ctx := zlog.Test(context.Background(), t)
 	coalescer := &coalescer{}
-	pkgs := test.GenUniquePackages(6)
-	for _, p := range pkgs {
-		// Mark them as if they came from this package's package scanner
-		p.RepositoryHint = `rhcc`
-	}
 	repo := []*claircore.Repository{&GoldRepo}
+	repo[0].ID = "1" // Assign it an ID and check it later.
 	layerArtifacts := []*indexer.LayerArtifacts{
 		{
 			Hash: test.RandomSHA256Digest(t),
-			Pkgs: pkgs[:1],
 		},
 		{
 			Hash: test.RandomSHA256Digest(t),
-			Pkgs: pkgs[:2],
 		},
 		{
-			Hash:  test.RandomSHA256Digest(t),
-			Pkgs:  pkgs[:3],
+			Hash: test.RandomSHA256Digest(t),
+			Pkgs: []*claircore.Package{
+				{
+					ID:             "1",
+					Name:           "ubi8",
+					Version:        "8.4",
+					RepositoryHint: "rhcc",
+					Kind:           claircore.BINARY,
+					Arch:           "x86_64",
+					PackageDB:      "Dockerfile-rhacm",
+					Source: &claircore.Package{
+						ID:        "3",
+						Name:      "ubi8-container",
+						Version:   "8.10-1088",
+						Kind:      claircore.SOURCE,
+						Arch:      "x86_64",
+						PackageDB: "Dockerfile-rhacm",
+					},
+				},
+			},
 			Repos: repo,
 		},
 		{
 			Hash: test.RandomSHA256Digest(t),
-			Pkgs: pkgs[:4],
 		},
 		{
-			Hash:  test.RandomSHA256Digest(t),
-			Pkgs:  pkgs[:5],
+			Hash: test.RandomSHA256Digest(t),
+			Pkgs: []*claircore.Package{
+				{
+					ID:             "2",
+					Name:           "rhacm2/acm-grafana-rhel8",
+					Version:        "v2.9.5-8",
+					RepositoryHint: "rhcc",
+					Kind:           claircore.BINARY,
+					Arch:           "x86_64",
+					PackageDB:      "Dockerfile-rhacm",
+					Source: &claircore.Package{
+						ID:        "4",
+						Name:      "acm-grafana-container",
+						Version:   "v2.9.5-8",
+						Kind:      claircore.SOURCE,
+						Arch:      "x86_64",
+						PackageDB: "Dockerfile-rhacm",
+					},
+				},
+			},
 			Repos: repo,
 		},
 		{
 			Hash: test.RandomSHA256Digest(t),
-			Pkgs: pkgs,
 		},
 	}
 	ir, err := coalescer.Coalesce(ctx, layerArtifacts)
 	if err != nil {
 		t.Fatalf("received error from coalesce method: %v", err)
 	}
-	// Expect 0-5 to have gotten associated with the repository.
-	for i := range pkgs {
-		es, ok := ir.Environments[strconv.Itoa(i)]
-		if !ok && i == 5 {
-			// Left out the last package.
-			continue
-		}
-		e := es[0]
-		if len(e.RepositoryIDs) == 0 {
-			t.Error("expected some repositories")
-		}
-		for _, id := range e.RepositoryIDs {
-			r := ir.Repositories[id]
-			if got, want := r.Name, GoldRepo.Name; got != want {
-				t.Errorf("got: %q, want: %q", got, want)
-			}
+	report, err := json.MarshalIndent(ir, "", "  ")
+	if err != nil {
+		t.Fatalf("failed to marshal index report: %v", err)
+	}
+	t.Log(string(report))
+	// Check that index report only has the package found in the last layer
+	// that has rhcc content.
+	if len(ir.Packages) != 2 {
+		t.Errorf("expected 1 package, got %d", len(ir.Packages))
+	}
+	if len(ir.Environments["2"]) != 1 {
+		t.Errorf("expected 1 environment, got %d", len(ir.Environments["2"]))
+	}
+	if len(ir.Environments["2"][0].RepositoryIDs) != 1 {
+		t.Errorf("expected 1 repository, got %d", len(ir.Environments["2"][0].RepositoryIDs))
+	}
+	if ir.Environments["2"][0].RepositoryIDs[0] != "1" {
+		t.Errorf("expected repository ID 1, got %s", ir.Environments["2"][0].RepositoryIDs[0])
+	}
+	if len(ir.Repositories) != 1 {
+		t.Errorf("expected 1 repository, got %d", len(ir.Repositories))
+	}
+	for _, repo := range ir.Repositories {
+		if repo.Key != RepositoryKey {
+			t.Errorf("expected repository key %s, got %s", RepositoryKey, repo.Key)
 		}
 	}
 }

--- a/rhel/rhcc/detector.go
+++ b/rhel/rhcc/detector.go
@@ -1,0 +1,176 @@
+package rhcc
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"strconv"
+	"time"
+
+	"github.com/quay/zlog"
+
+	"github.com/quay/claircore"
+	"github.com/quay/claircore/indexer"
+	"github.com/quay/claircore/pkg/rhctag"
+	"github.com/quay/claircore/toolkit/types/cpe"
+)
+
+var (
+	_ indexer.PackageScanner    = (*detector)(nil)
+	_ indexer.RepositoryScanner = (*repoDetector)(nil)
+
+	labelsFilepath = "root/buildinfo/labels.json"
+)
+
+type detector struct{}
+
+// Name implements [indexer.VersionedScanner].
+func (s *detector) Name() string { return "rhel_package_container_detector" }
+
+// Version implements [indexer.VersionedScanner].
+func (s *detector) Version() string { return "1" }
+
+// Kind implements [indexer.VersionedScanner].
+func (s *detector) Kind() string { return "package" }
+
+// Scan implements [indexer.PackageScanner].
+//
+// It performs a package scan on the given layer and returns all the RHEL
+// container identifying metadata by using the labels.json file.
+func (s *detector) Scan(ctx context.Context, l *claircore.Layer) ([]*claircore.Package, error) {
+	ctx = zlog.ContextWithValues(ctx, "component", "rhel/rhcc/detector.Scan")
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	sys, err := l.FS()
+	if err != nil {
+		return nil, fmt.Errorf("rhcc: unable to open layer: %w", err)
+	}
+
+	labels, err := findJSONLabels(ctx, sys)
+	switch {
+	case errors.Is(err, nil):
+	case errors.Is(err, errNotFound):
+		return nil, nil
+	default:
+		return nil, err
+	}
+
+	// Check if required fields are present
+	if labels.Name == "" || labels.Architecture == "" || labels.Created.IsZero() {
+		zlog.Warn(ctx).Msg("required labels not found in labels.json")
+		return nil, nil
+	}
+
+	vr := strconv.FormatInt(labels.Created.Unix(), 10)
+	rhctagVersion, err := rhctag.Parse(vr)
+	if err != nil {
+		// A unix timestamp should always parse, so this is unexpected.
+		zlog.Warn(ctx).Err(err).Str("version", vr).Msg("failed to parse rhctag version")
+		return nil, nil
+	}
+
+	normVer := rhctagVersion.Version(true)
+	src := claircore.Package{
+		Kind:              claircore.SOURCE,
+		Name:              labels.Name,
+		Version:           vr,
+		NormalizedVersion: normVer,
+		PackageDB:         labelsFilepath,
+		Arch:              labels.Architecture,
+		RepositoryHint:    `rhcc`,
+	}
+	pkgs := []*claircore.Package{&src}
+
+	pkgs = append(pkgs, &claircore.Package{
+		Kind:              claircore.BINARY,
+		Name:              labels.Name,
+		Version:           vr,
+		NormalizedVersion: normVer,
+		Source:            &src,
+		PackageDB:         labelsFilepath,
+		Arch:              labels.Architecture,
+		RepositoryHint:    `rhcc`,
+	})
+	return pkgs, nil
+}
+
+// findJSONLabels reads and parses root/buildinfo/labels.json file.
+// Schema: see testdata/labels.schema.json
+func findJSONLabels(ctx context.Context, sys fs.FS) (*labels, error) {
+	l, err := fs.ReadFile(sys, labelsFilepath)
+	switch {
+	case errors.Is(err, nil):
+	case errors.Is(err, fs.ErrNotExist):
+		return nil, errNotFound
+	default:
+		return nil, err
+	}
+	var labels labels
+	err = json.Unmarshal(l, &labels)
+	if err != nil {
+		return nil, err
+	}
+	return &labels, nil
+}
+
+type labels struct {
+	Created      time.Time `json:"org.opencontainers.image.created"`
+	Architecture string    `json:"architecture"`
+	Name         string    `json:"name"`
+	CPE          string    `json:"cpe"`
+}
+
+type repoDetector struct{}
+
+var _ indexer.RepositoryScanner = (*repoDetector)(nil)
+
+// Name implements [indexer.VersionedScanner].
+func (s *repoDetector) Name() string { return "rhel_repo_container_detector" }
+
+// Version implements [indexer.VersionedScanner].
+func (s *repoDetector) Version() string { return "1" }
+
+// Kind implements [indexer.VersionedScanner].
+func (s *repoDetector) Kind() string { return "repository" }
+
+// Scan implements [indexer.RepositoryScanner].
+//
+// It performs a repository scan on the given layer and returns all the RHEL
+// container identifying metadata by using the labels.json file.
+func (s *repoDetector) Scan(ctx context.Context, l *claircore.Layer) ([]*claircore.Repository, error) {
+	ctx = zlog.ContextWithValues(ctx, "component", "rhel/rhcc/repoDetector.Scan")
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	sys, err := l.FS()
+	if err != nil {
+		return nil, fmt.Errorf("rhcc: unable to open layer: %w", err)
+	}
+	labels, err := findJSONLabels(ctx, sys)
+	switch {
+	case errors.Is(err, nil):
+	case errors.Is(err, errNotFound):
+		return nil, nil
+	default:
+		return nil, err
+	}
+	if labels.CPE == "" {
+		return []*claircore.Repository{}, nil
+	}
+
+	wfn, err := cpe.Unbind(labels.CPE)
+	if err != nil {
+		return nil, err
+	}
+	return []*claircore.Repository{
+		{
+			CPE:  wfn,
+			Name: wfn.String(),
+			Key:  RepositoryKey,
+		},
+	}, nil
+
+}

--- a/rhel/rhcc/detector_test.go
+++ b/rhel/rhcc/detector_test.go
@@ -1,0 +1,199 @@
+package rhcc
+
+import (
+	"archive/tar"
+	"context"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/quay/zlog"
+
+	"github.com/quay/claircore"
+	"github.com/quay/claircore/test"
+	"github.com/quay/claircore/toolkit/types/cpe"
+)
+
+func TestPackageDetector(t *testing.T) {
+	t.Parallel()
+	ctx := zlog.Test(context.Background(), t)
+	gitopsSourceContainer := &claircore.Package{
+		Name:    "openshift-gitops-1/gitops-rhel8-operator",
+		Version: "1744596866",
+		NormalizedVersion: claircore.Version{
+			Kind: "rhctag",
+			V:    [10]int32{1744596866},
+		},
+		Kind:           claircore.SOURCE,
+		PackageDB:      "root/buildinfo/labels.json",
+		RepositoryHint: "rhcc",
+		Arch:           "x86_64",
+	}
+
+	type testcase struct {
+		Name       string
+		LabelsFile string
+		Want       []*claircore.Package
+	}
+	table := []testcase{
+		{
+			Name:       "PackageLabelsTest",
+			LabelsFile: "testdata/simple_labels.json",
+			Want: []*claircore.Package{
+				gitopsSourceContainer,
+				{
+					Name:    "openshift-gitops-1/gitops-rhel8-operator",
+					Version: "1744596866",
+					NormalizedVersion: claircore.Version{
+						Kind: "rhctag",
+						V:    [10]int32{1744596866},
+					},
+					Kind:           claircore.BINARY,
+					Source:         gitopsSourceContainer,
+					PackageDB:      "root/buildinfo/labels.json",
+					RepositoryHint: "rhcc",
+					Arch:           "x86_64",
+				},
+			},
+		},
+	}
+	var cd detector
+
+	a := test.NewCachedArena(t)
+	t.Cleanup(func() {
+		if err := a.Close(ctx); err != nil {
+			t.Error(err)
+		}
+	})
+	for _, tt := range table {
+		t.Run(tt.Name, func(t *testing.T) {
+			ctx := zlog.Test(ctx, t)
+			mod := test.Modtime(t, tt.LabelsFile)
+			a.GenerateLayer(t, tt.Name, mod, genLayerFunc(tt.LabelsFile, "root/buildinfo/labels.json"))
+
+			r := a.Realizer(ctx).(*test.CachedRealizer)
+			defer func() {
+				if err := r.Close(); err != nil {
+					t.Error(err)
+				}
+			}()
+			ls, err := r.RealizeDescriptions(ctx, []claircore.LayerDescription{{
+				Digest:    "sha256:" + strings.Repeat("beef", 16),
+				URI:       "file:" + tt.Name,
+				MediaType: test.MediaType,
+				Headers:   make(map[string][]string),
+			}})
+			if err != nil {
+				t.Error(err)
+			}
+
+			got, err := cd.Scan(ctx, &ls[0])
+			if err != nil {
+				t.Error(err)
+			}
+			t.Logf("found %d packages", len(got))
+			if !cmp.Equal(got, tt.Want) {
+				t.Error(cmp.Diff(got, tt.Want))
+			}
+		})
+	}
+}
+
+func TestRepositoryDetector(t *testing.T) {
+	t.Parallel()
+	ctx := zlog.Test(context.Background(), t)
+
+	type testcase struct {
+		Name       string
+		LabelsFile string
+		Want       []*claircore.Repository
+	}
+	table := []testcase{
+		{
+			Name:       "RepositoryLabelsTest",
+			LabelsFile: "testdata/simple_labels.json",
+			Want: []*claircore.Repository{
+				{
+					Name: "cpe:2.3:a:redhat:openshift_gitops:1.16:*:el8:*:*:*:*:*",
+					Key:  "rhcc-container-repository",
+					CPE:  cpe.MustUnbind("cpe:2.3:a:redhat:openshift_gitops:1.16:*:el8:*:*:*:*:*"),
+				},
+			},
+		},
+	}
+	var cd repoDetector
+
+	opt := cmp.Comparer(func(src, tgt cpe.WFN) bool {
+		return cpe.Compare(src, tgt).IsEqual()
+	})
+
+	a := test.NewCachedArena(t)
+	t.Cleanup(func() {
+		if err := a.Close(ctx); err != nil {
+			t.Error(err)
+		}
+	})
+	for _, tt := range table {
+		t.Run(tt.Name, func(t *testing.T) {
+			ctx := zlog.Test(ctx, t)
+			mod := test.Modtime(t, tt.LabelsFile)
+			a.GenerateLayer(t, tt.Name, mod, genLayerFunc(tt.LabelsFile, "root/buildinfo/labels.json"))
+
+			r := a.Realizer(ctx).(*test.CachedRealizer)
+			defer func() {
+				if err := r.Close(); err != nil {
+					t.Error(err)
+				}
+			}()
+			ls, err := r.RealizeDescriptions(ctx, []claircore.LayerDescription{{
+				Digest:    "sha256:" + strings.Repeat("beef", 16),
+				URI:       "file:" + tt.Name,
+				MediaType: test.MediaType,
+				Headers:   make(map[string][]string),
+			}})
+			if err != nil {
+				t.Error(err)
+			}
+
+			got, err := cd.Scan(ctx, &ls[0])
+			if err != nil {
+				t.Error(err)
+			}
+			t.Logf("found %d repositories", len(got))
+			if !cmp.Equal(got, tt.Want, opt) {
+				t.Error(cmp.Diff(got, tt.Want, opt))
+			}
+		})
+	}
+}
+
+func genLayerFunc(path string, imgPath string) func(t testing.TB, w *os.File) {
+	return func(t testing.TB, w *os.File) {
+		dockerfile, err := os.Open(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer dockerfile.Close()
+		fi, err := dockerfile.Stat()
+		if err != nil {
+			t.Fatal(err)
+		}
+		tw := tar.NewWriter(w)
+		hdr, err := tar.FileInfoHeader(fi, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		hdr.Name = imgPath
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Error(err)
+		}
+		if _, err := io.Copy(tw, dockerfile); err != nil {
+			t.Error(err)
+		}
+		if err := tw.Close(); err != nil {
+			t.Error(err)
+		}
+	}
+}

--- a/rhel/rhcc/ecosystem.go
+++ b/rhel/rhcc/ecosystem.go
@@ -10,13 +10,13 @@ import (
 func NewEcosystem(_ context.Context) *indexer.Ecosystem {
 	return &indexer.Ecosystem{
 		PackageScanners: func(_ context.Context) ([]indexer.PackageScanner, error) {
-			return []indexer.PackageScanner{&scanner{}}, nil
+			return []indexer.PackageScanner{&scanner{}, &detector{}}, nil
 		},
 		DistributionScanners: func(_ context.Context) ([]indexer.DistributionScanner, error) {
 			return nil, nil
 		},
 		RepositoryScanners: func(_ context.Context) ([]indexer.RepositoryScanner, error) {
-			return []indexer.RepositoryScanner{&reposcanner{}}, nil
+			return []indexer.RepositoryScanner{&reposcanner{}, &repoDetector{}}, nil
 		},
 		Coalescer: func(_ context.Context) (indexer.Coalescer, error) {
 			return &coalescer{}, nil

--- a/rhel/rhcc/matcher.go
+++ b/rhel/rhcc/matcher.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/libvuln/driver"
+	"github.com/quay/claircore/rhel"
+	"github.com/quay/claircore/toolkit/types/cpe"
 )
 
 // Matcher is an instance of the rhcc matcher. It's exported so it can be used
@@ -26,16 +28,31 @@ func (*matcher) Name() string { return "rhel-container-matcher" }
 // Filter implements [driver.Matcher].
 func (*matcher) Filter(r *claircore.IndexRecord) bool {
 	return r.Repository != nil &&
-		r.Repository.Name == GoldRepo.Name
+		r.Repository.Key == RepositoryKey
 }
 
 // Query implements [driver.Matcher].
 func (*matcher) Query() []driver.MatchConstraint {
-	return []driver.MatchConstraint{driver.RepositoryName}
+	return []driver.MatchConstraint{driver.RepositoryKey}
 }
 
 // Vulnerable implements [driver.Matcher].
 func (*matcher) Vulnerable(ctx context.Context, record *claircore.IndexRecord, vuln *claircore.Vulnerability) (bool, error) {
+	var err error
+	if record.Repository.Name != GoldRepo.Name {
+		// This is not a gold repo record, so we need to check if the CPE matches.
+		vuln.Repo.CPE, err = cpe.Unbind(vuln.Repo.Name)
+		if err != nil {
+			zlog.Warn(ctx).
+				Str("vulnerability name", vuln.Name).
+				Err(err).
+				Msg("unable to unbind repo CPE")
+			return false, nil
+		}
+		if !cpe.Compare(vuln.Repo.CPE, record.Repository.CPE).IsSuperset() && !rhel.IsCPESubstringMatch(record.Repository.CPE, vuln.Repo.CPE) {
+			return false, nil
+		}
+	}
 	pkgVer, fixedInVer := rpmVersion.NewVersion(record.Package.Version), rpmVersion.NewVersion(vuln.FixedInVersion)
 	zlog.Debug(ctx).
 		Str("record", record.Package.Version).

--- a/rhel/rhcc/rhcc.go
+++ b/rhel/rhcc/rhcc.go
@@ -5,12 +5,24 @@
 package rhcc
 
 import (
+	"errors"
+
 	"github.com/quay/claircore"
 )
 
-// GoldRepo is the claircore.Repository that every RHCC index record is associated with.
-// It is also the claircore.Repository that is associated with OCI VEX vulnerabilities.
-var GoldRepo = claircore.Repository{
-	Name: "Red Hat Container Catalog",
-	URI:  `https://catalog.redhat.com/software/containers/explore`,
-}
+// RepositoryKey should be used for every indexed repository coming from this package. It is
+// used when persisting Red Hat VEX data pertaining to container images and referenced in the
+// RHCC matching logic.
+const RepositoryKey = "rhcc-container-repository"
+
+var (
+	// GoldRepo is the claircore.Repository that RHCC index record are associated with when
+	// the image has been build via the legacy Red Hat build system. With newer images, reliable
+	// repository CPEs are available and can be used in lieu of the GoldRepo.
+	GoldRepo = claircore.Repository{
+		Name: "Red Hat Container Catalog",
+		URI:  `https://catalog.redhat.com/software/containers/explore`,
+		Key:  RepositoryKey,
+	}
+	errNotFound = errors.New("not found")
+)

--- a/rhel/rhcc/scanner.go
+++ b/rhel/rhcc/scanner.go
@@ -26,6 +26,8 @@ var (
 	_ indexer.RPCScanner     = (*scanner)(nil)
 )
 
+// Deprecated: scanner will be removed in a future releases as Red Hat images
+// produced from the legacy build system stop being produced / supported.
 type scanner struct {
 	upd    *common.Updater
 	client *http.Client
@@ -255,8 +257,6 @@ func findLabels(ctx context.Context, sys fs.FS) (map[string]string, string, erro
 	return labels, p, nil
 }
 
-var errNotFound = errors.New("not found")
-
 // GetVR extracts the version-release string from the provided string ending in
 // an NVR.
 //
@@ -270,6 +270,8 @@ func getVR(nvr string) string {
 	return nvr[i+1:]
 }
 
+// Deprecated: reposcanner will be removed in a future releases as Red Hat images
+// produced from the legacy build system stop being produced / supported.
 type reposcanner struct{}
 
 var _ indexer.RepositoryScanner = (*reposcanner)(nil)

--- a/rhel/rhcc/testdata/labels.schema.json
+++ b/rhel/rhcc/testdata/labels.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Red Hat Container Catalog Labels",
+  "description": "Schema for root/buildinfo/labels.json files in Red Hat container images",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Container image name"
+    },
+    "org.opencontainers.image.created": {
+      "type": "string",
+      "format": "date-time",
+      "description": "RFC3339 timestamp when the image was created"
+    },
+    "cpe": {
+      "type": "string",
+      "description": "Common Platform Enumeration identifier"
+    },
+    "architecture": {
+      "type": "string",
+      "description": "Target architecture (e.g., x86_64, aarch64)"
+    }
+  },
+  "required": ["name", "org.opencontainers.image.created", "cpe", "architecture"],
+  "additionalProperties": false
+} 

--- a/rhel/rhcc/testdata/simple_labels.json
+++ b/rhel/rhcc/testdata/simple_labels.json
@@ -1,0 +1,6 @@
+{
+    "name": "openshift-gitops-1/gitops-rhel8-operator",
+    "org.opencontainers.image.created": "2025-04-14T02:14:26Z",
+    "cpe": "cpe:/a:redhat:openshift_gitops:1.16::el8",
+    "architecture": "x86_64"
+}

--- a/rhel/vex/parser.go
+++ b/rhel/vex/parser.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"math"
 	"strings"
+	"unique"
 
 	"github.com/klauspost/compress/snappy"
 	"github.com/package-url/packageurl-go"
@@ -116,22 +117,31 @@ func (u *Updater) DeltaParse(ctx context.Context, contents io.ReadCloser) ([]*cl
 	return vulns, deleted, nil
 }
 
+// repoCacheKey is a unique identifier for a repository, it is made
+// to be used as a unique.Handle, hence the string fields.
+type repoCacheKey struct {
+	CPEString string
+	RepoKey   string
+}
+
 // repoCache keeps a cache of all seen claircore.Repository objects.
 type repoCache struct {
-	cache map[string]*claircore.Repository
+	cache map[unique.Handle[repoCacheKey]]*claircore.Repository
 }
 
 // NewRepoCache returns a repoCache with the backing map instantiated.
 func newRepoCache() *repoCache {
 	return &repoCache{
-		cache: make(map[string]*claircore.Repository),
+		cache: make(map[unique.Handle[repoCacheKey]]*claircore.Repository),
 	}
 }
 
-// Get attempts to find a repo in the cache identified by a WFN. If
-// it isn't found a repo is created and returned.
-func (rc *repoCache) Get(cpe cpe.WFN) *claircore.Repository {
-	if r, ok := rc.cache[cpe.String()]; ok {
+// Get attempts to find a repo in the cache identified by a WFN and
+// the repoKey. If it isn't found a repo is created and returned.
+func (rc *repoCache) Get(cpe cpe.WFN, repoKey string) *claircore.Repository {
+	rck := repoCacheKey{CPEString: cpe.String(), RepoKey: repoKey}
+	k := unique.Make(rck)
+	if r, ok := rc.cache[k]; ok {
 		return r
 	}
 	r := &claircore.Repository{
@@ -139,7 +149,7 @@ func (rc *repoCache) Get(cpe cpe.WFN) *claircore.Repository {
 		Name: cpe.String(),
 		Key:  repoKey,
 	}
-	rc.cache[cpe.String()] = r
+	rc.cache[k] = r
 	return r
 }
 
@@ -303,7 +313,7 @@ func (c *creator) knownAffectedVulnerabilities(ctx context.Context, v csaf.Vulne
 		if err != nil {
 			return nil, fmt.Errorf("could not unbind cpe: %s %w", ch, err)
 		}
-		vuln.Repo = c.rc.Get(wfn)
+		vuln.Repo = c.rc.Get(wfn, repoKey)
 		// It is possible that we will not find a pURL, in that case
 		// the package.Name will be reported as-is.
 		purlHelper, ok := compProd.IdentificationHelper["purl"]
@@ -329,8 +339,7 @@ func (c *creator) knownAffectedVulnerabilities(ctx context.Context, v csaf.Vulne
 			}
 
 			if purl.Type == packageurl.TypeOCI {
-				// Override repo if we're dealing with a container image
-				vuln.Repo = &rhcc.GoldRepo
+				vuln.Repo = c.rc.Get(wfn, rhcc.RepositoryKey)
 				vuln.Range, err = ranger.add(pkgName, vuln.FixedInVersion)
 				if err != nil {
 					zlog.Warn(ctx).
@@ -543,16 +552,17 @@ func (c *creator) fixedVulnerabilities(ctx context.Context, v csaf.Vulnerability
 				vuln.Package.Arch = arch
 				vuln.ArchOperation = claircore.OpPatternMatch
 			}
+			ch := escapeCPE(cpeHelper)
+			wfn, err := cpe.Unbind(ch)
+			if err != nil {
+				return nil, fmt.Errorf("could not unbind cpe: %s %w", cpeHelper, err)
+			}
+
 			switch purl.Type {
 			case packageurl.TypeRPM:
-				ch := escapeCPE(cpeHelper)
-				wfn, err := cpe.Unbind(ch)
-				if err != nil {
-					return nil, fmt.Errorf("could not unbind cpe: %s %w", cpeHelper, err)
-				}
-				vuln.Repo = c.rc.Get(wfn)
+				vuln.Repo = c.rc.Get(wfn, repoKey)
 			case packageurl.TypeOCI:
-				vuln.Repo = &rhcc.GoldRepo
+				vuln.Repo = c.rc.Get(wfn, rhcc.RepositoryKey)
 				vuln.Range, err = ranger.add(packageName, vuln.FixedInVersion)
 				if err != nil {
 					zlog.Warn(ctx).

--- a/rhel/vex/updater.go
+++ b/rhel/vex/updater.go
@@ -35,7 +35,7 @@ const (
 	deletionsFile                = "deletions.csv"
 	lookBackToYear               = 2014
 	repoKey                      = "rhel-cpe-repository"
-	updaterVersion               = "4"
+	updaterVersion               = "5"
 )
 
 // Factory creates an Updater to process all of the Red Hat VEX data.

--- a/test/rhel/rhcc_matcher_integration_test.go
+++ b/test/rhel/rhcc_matcher_integration_test.go
@@ -58,6 +58,12 @@ func TestMatcherIntegration(t *testing.T) {
 			cveID:       "CVE-2020-8565",
 			match:       false,
 		},
+		{
+			Name:        "Clair labels",
+			indexReport: "clair-rhel8-v3.5.5-4-labels",
+			cveID:       "CVE-2021-3762",
+			match:       true,
+		},
 	}
 
 	integration.NeedDB(t)

--- a/test/rhel/testdata/clair-rhel8-v3.5.5-4-labels-indexreport.json
+++ b/test/rhel/testdata/clair-rhel8-v3.5.5-4-labels-indexreport.json
@@ -74,15 +74,16 @@
   },
   "repository": {
     "1": {
-      "name": "Red Hat Container Catalog",
-      "uri": "https://catalog.redhat.com/software/containers/explore",
-      "key": "rhcc-container-repository"
+      "id": "1",
+      "name": "cpe:2.3:a:redhat:quay:3:*:el8:*:*:*:*:*",
+      "key": "rhcc-container-repository",
+      "cpe": "cpe:2.3:a:redhat:quay:3:*:el8:*:*:*:*:*"
     }
   },
   "environments": {
     "32": [
       {
-        "package_db": "root/buildinfo/Dockerfile-quay-clair-rhel8-v3.5.5-4",
+        "package_db": "root/buildinfo/labels.json",
         "introduced_in": "sha256:a5ac7bbd6645d6b98e41600a1510d7378d74e6b0b858622b57fce2a8a05a87e5",
         "repository_ids": [
           "1"
@@ -91,7 +92,7 @@
     ],
     "34": [
       {
-        "package_db": "root/buildinfo/Dockerfile-quay-clair-rhel8-v3.5.5-4",
+        "package_db": "root/buildinfo/labels.json",
         "introduced_in": "sha256:a5ac7bbd6645d6b98e41600a1510d7378d74e6b0b858622b57fce2a8a05a87e5",
         "repository_ids": [
           "1"
@@ -100,7 +101,7 @@
     ],
     "36": [
       {
-        "package_db": "root/buildinfo/Dockerfile-ubi8-8.4-206.1626828523",
+        "package_db": "root/buildinfo/labels.json",
         "introduced_in": "sha256:a50df8fd88fecefc26fd331f832672108deb08cf9d2b303a5b86156a7f51b5d8",
         "repository_ids": [
           "1"
@@ -109,7 +110,7 @@
     ],
     "38": [
       {
-        "package_db": "root/buildinfo/Dockerfile-ubi8-8.4-206.1626828523",
+        "package_db": "root/buildinfo/labels.json",
         "introduced_in": "sha256:a50df8fd88fecefc26fd331f832672108deb08cf9d2b303a5b86156a7f51b5d8",
         "repository_ids": [
           "1"

--- a/test/rhel/testdata/rook-ceph-operator-container-4.6-115.d1788e1.release_4.6-indexreport.json
+++ b/test/rhel/testdata/rook-ceph-operator-container-4.6-115.d1788e1.release_4.6-indexreport.json
@@ -41,7 +41,8 @@
   "repository": {
     "1": {
       "name": "Red Hat Container Catalog",
-      "uri": "https://catalog.redhat.com/software/containers/explore"
+      "uri": "https://catalog.redhat.com/software/containers/explore",
+      "key": "rhcc-container-repository"
     }
   },
   "environments": {

--- a/test/rhel/testdata/rook-ceph-operator-container-4.7-159.76b9b11.release_4.7-indexreport.json
+++ b/test/rhel/testdata/rook-ceph-operator-container-4.7-159.76b9b11.release_4.7-indexreport.json
@@ -41,7 +41,8 @@
   "repository": {
     "1": {
       "name": "Red Hat Container Catalog",
-      "uri": "https://catalog.redhat.com/software/containers/explore"
+      "uri": "https://catalog.redhat.com/software/containers/explore",
+      "key": "rhcc-container-repository"
     }
   },
   "environments": {

--- a/version.go
+++ b/version.go
@@ -17,6 +17,10 @@ type Version struct {
 	V    [10]int32
 }
 
+// UnmatchableKind is a version kind that is used to indicate a version that
+// should not be matched against.
+var UnmatchableKind = "unmatchable"
+
 // VersionSort returns a function suitable for passing to sort.Slice or
 // sort.SliceStable.
 func VersionSort(vs []Version) func(int, int) bool {


### PR DESCRIPTION
Red Hat's new container image builder system does not include a
dockerfile at a known path in the image, this is replaces with a file
called labels.json file at a known location that contains the
information that the rhcc package and repository scanners need. This
change adds another rhcc package and repository scanner that read this
labels.json file. The dockerfile versions still exist but will be
eventually deprecated and removed.