### PR TITLE
internal: cache package

### DIFF
--- a/internal/cache/doc.go
+++ b/internal/cache/doc.go
@@ -1,0 +1,7 @@
+// Package cache provides caching implementations for Go values.
+package cache
+
+import "context"
+
+// CreateFunc is the function type used to produce new values to cache.
+type CreateFunc[K comparable, V any] func(context.Context, K) (*V, error)

--- a/internal/cache/live.go
+++ b/internal/cache/live.go
@@ -1,0 +1,96 @@
+//go:build go1.24
+
+package cache
+
+import (
+	"context"
+	"runtime"
+	"sync"
+	"weak"
+
+	"github.com/quay/claircore/internal/singleflight"
+)
+
+// Live is a cache that keeps a cached copy as long as the go runtime determines
+// the value is live.
+//
+// The Create member can be populated to simplify a call site, ala
+// [sync.Pool.New].
+// The zero value is safe to use.
+//
+// See also: [weak.Pointer].
+type Live[K comparable, V any] struct {
+	Create CreateFunc[K, V]
+	m      sync.Map
+	sf     singleflight.Group[K, *V]
+}
+
+// Get returns a pointer to the value associated with the key, calling the
+// "Create" function if populated and the "create" argument is nil.
+//
+// This function will panic if neither function is provided.
+func (c *Live[K, V]) Get(ctx context.Context, key K, create CreateFunc[K, V]) (*V, error) {
+	var fn CreateFunc[K, V]
+	switch {
+	case create != nil:
+		fn = create
+	case c.Create != nil:
+		fn = c.Create
+	default:
+		panic("programmer error: missing create function")
+	}
+	for {
+		// Try to load an existing value out of the cache.
+		value, ok := c.m.Load(key)
+		if !ok {
+			// No value found. Create a new value.
+			fn := func() (*V, error) {
+				// Eagerly check the Context so that every create function
+				// doesn't need the preamble.
+				//
+				// Do this because this goroutine may have gone around the loop
+				// multiple times and found entries in the map that had
+				// invalidated weak pointers, so the context may have expired.
+				if ctx.Err() != nil {
+					return nil, context.Cause(ctx)
+				}
+				v, err := fn(ctx, key)
+				if err != nil {
+					return nil, err
+				}
+
+				wp := weak.Make(v)
+				c.m.Store(key, wp)
+				runtime.AddCleanup(v, func(key K) {
+					// Only delete if the weak pointer is equal. If it's not,
+					// someone else already deleted the entry and installed a
+					// new pointer.
+					c.m.CompareAndDelete(key, wp)
+				}, key)
+				return v, nil
+			}
+
+			ch := c.sf.DoChan(key, fn)
+			select {
+			case res := <-ch:
+				return res.Val, res.Err
+			case <-ctx.Done():
+				c.sf.Forget(key)
+				return nil, context.Cause(ctx)
+			}
+		}
+
+		// See if our cache entry is valid.
+		if v := value.(weak.Pointer[V]).Value(); v != nil {
+			return v, nil
+		}
+		// Discovered a nil entry awaiting cleanup. Eagerly delete it.
+		c.m.CompareAndDelete(key, value)
+	}
+}
+
+// Clear removes all cached entries.
+//
+// No additional calls are made for individual values; the cache simply drops
+// any references it has.
+func (c *Live[K, V]) Clear() { c.m.Clear() }

--- a/internal/cache/live_test.go
+++ b/internal/cache/live_test.go
@@ -1,0 +1,63 @@
+//go:build go1.24
+
+package cache
+
+import (
+	"context"
+	"encoding/binary"
+	"runtime"
+	"testing"
+	"weak"
+)
+
+func TestLive(t *testing.T) {
+	var c Live[uint32, [4]byte]
+	c.Create = func(_ context.Context, key uint32) (*[4]byte, error) {
+		var v [4]byte
+		binary.LittleEndian.PutUint32(v[:], key)
+		return &v, nil
+	}
+	ctx := t.Context()
+
+	a, err := c.Get(ctx, 0xF000000F, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b, err := c.Get(ctx, 0xF000000F, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wp := weak.Make(b)
+
+	t.Logf("a: %p, b: %p", a, b)
+	if a != b {
+		t.Fail()
+	}
+	a, b = nil, nil
+
+	for range 2 { // Need two cycles:
+		runtime.GC()
+	}
+
+	found := false
+	c.m.Range(func(k, _ any) bool {
+		found = true
+		t.Logf("found: %v", k)
+		return true
+	})
+	if found {
+		t.Error("found values in the cache")
+	}
+	if wp.Value() != nil {
+		t.Error("weak pointer still has value")
+	}
+
+	n, err := c.Get(ctx, 0xF000000F, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if np := weak.Make(n); wp == np {
+		t.Error("expected different weak pointer values")
+	}
+}

--- a/internal/singleflight/singleflight.go
+++ b/internal/singleflight/singleflight.go
@@ -1,0 +1,209 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package singleflight provides a duplicate function call suppression
+// mechanism.
+//
+// This fork adds generics.
+//
+// Based on https://github.com/golang/sync/tree/22ba2078e183beec12908ea94f1d899c53dbf02c/singleflight/singleflight.go
+package singleflight // import "github.com/quay/claircore/internal/singleflight"
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"runtime"
+	"runtime/debug"
+	"sync"
+)
+
+// errGoexit indicates the runtime.Goexit was called in
+// the user given function.
+var errGoexit = errors.New("runtime.Goexit was called")
+
+// A panicError is an arbitrary value recovered from a panic
+// with the stack trace during the execution of given function.
+type panicError struct {
+	value any
+	stack []byte
+}
+
+// Error implements error interface.
+func (p *panicError) Error() string {
+	return fmt.Sprintf("%v\n\n%s", p.value, p.stack)
+}
+
+func newPanicError(v any) error {
+	stack := debug.Stack()
+
+	// The first line of the stack trace is of the form "goroutine N [status]:"
+	// but by the time the panic reaches Do the goroutine may no longer exist
+	// and its status will have changed. Trim out the misleading line.
+	if line := bytes.IndexByte(stack[:], '\n'); line >= 0 {
+		stack = stack[line+1:]
+	}
+	return &panicError{value: v, stack: stack}
+}
+
+// call is an in-flight or completed singleflight.Do call
+type call[V any] struct {
+	wg sync.WaitGroup
+
+	// These fields are written once before the WaitGroup is done
+	// and are only read after the WaitGroup is done.
+	val V
+	err error
+
+	// These fields are read and written with the singleflight
+	// mutex held before the WaitGroup is done, and are read but
+	// not written after the WaitGroup is done.
+	dups  int
+	chans []chan<- Result[V]
+}
+
+// Group represents a class of work and forms a namespace in
+// which units of work can be executed with duplicate suppression.
+type Group[K comparable, V any] struct {
+	mu sync.Mutex     // protects m
+	m  map[K]*call[V] // lazily initialized
+}
+
+// Result holds the results of Do, so they can be passed
+// on a channel.
+type Result[V any] struct {
+	Val    V
+	Err    error
+	Shared bool
+}
+
+// Do executes and returns the results of the given function, making
+// sure that only one execution is in-flight for a given key at a
+// time. If a duplicate comes in, the duplicate caller waits for the
+// original to complete and receives the same results.
+// The return value shared indicates whether v was given to multiple callers.
+func (g *Group[K, V]) Do(key K, fn func() (V, error)) (v V, err error, shared bool) {
+	g.mu.Lock()
+	if g.m == nil {
+		g.m = make(map[K]*call[V])
+	}
+	if c, ok := g.m[key]; ok {
+		c.dups++
+		g.mu.Unlock()
+		c.wg.Wait()
+
+		if e, ok := c.err.(*panicError); ok {
+			panic(e)
+		} else if c.err == errGoexit {
+			runtime.Goexit()
+		}
+		return c.val, c.err, true
+	}
+	c := new(call[V])
+	c.wg.Add(1)
+	g.m[key] = c
+	g.mu.Unlock()
+
+	g.doCall(c, key, fn)
+	return c.val, c.err, c.dups > 0
+}
+
+// DoChan is like Do but returns a channel that will receive the
+// results when they are ready.
+//
+// The returned channel will not be closed.
+func (g *Group[K, V]) DoChan(key K, fn func() (V, error)) <-chan Result[V] {
+	ch := make(chan Result[V], 1)
+	g.mu.Lock()
+	if g.m == nil {
+		g.m = make(map[K]*call[V])
+	}
+	if c, ok := g.m[key]; ok {
+		c.dups++
+		c.chans = append(c.chans, ch)
+		g.mu.Unlock()
+		return ch
+	}
+	c := &call[V]{chans: []chan<- Result[V]{ch}}
+	c.wg.Add(1)
+	g.m[key] = c
+	g.mu.Unlock()
+
+	go g.doCall(c, key, fn)
+
+	return ch
+}
+
+// doCall handles the single call for a key.
+func (g *Group[K, V]) doCall(c *call[V], key K, fn func() (V, error)) {
+	normalReturn := false
+	recovered := false
+
+	// use double-defer to distinguish panic from runtime.Goexit,
+	// more details see https://golang.org/cl/134395
+	defer func() {
+		// the given function invoked runtime.Goexit
+		if !normalReturn && !recovered {
+			c.err = errGoexit
+		}
+
+		g.mu.Lock()
+		defer g.mu.Unlock()
+		c.wg.Done()
+		if g.m[key] == c {
+			delete(g.m, key)
+		}
+
+		if e, ok := c.err.(*panicError); ok {
+			// In order to prevent the waiting channels from being blocked forever,
+			// needs to ensure that this panic cannot be recovered.
+			if len(c.chans) > 0 {
+				go panic(e)
+				select {} // Keep this goroutine around so that it will appear in the crash dump.
+			} else {
+				panic(e)
+			}
+		} else if c.err == errGoexit {
+			// Already in the process of goexit, no need to call again
+		} else {
+			// Normal return
+			for _, ch := range c.chans {
+				ch <- Result[V]{c.val, c.err, c.dups > 0}
+			}
+		}
+	}()
+
+	func() {
+		defer func() {
+			if !normalReturn {
+				// Ideally, we would wait to take a stack trace until we've determined
+				// whether this is a panic or a runtime.Goexit.
+				//
+				// Unfortunately, the only way we can distinguish the two is to see
+				// whether the recover stopped the goroutine from terminating, and by
+				// the time we know that, the part of the stack trace relevant to the
+				// panic has been discarded.
+				if r := recover(); r != nil {
+					c.err = newPanicError(r)
+				}
+			}
+		}()
+
+		c.val, c.err = fn()
+		normalReturn = true
+	}()
+
+	if !normalReturn {
+		recovered = true
+	}
+}
+
+// Forget tells the singleflight to forget about a key.  Future calls
+// to Do for this key will call the function rather than waiting for
+// an earlier call to complete.
+func (g *Group[K, V]) Forget(key K) {
+	g.mu.Lock()
+	delete(g.m, key)
+	g.mu.Unlock()
+}

--- a/internal/singleflight/singleflight_test.go
+++ b/internal/singleflight/singleflight_test.go
@@ -1,0 +1,424 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Based on https://github.com/golang/sync/commit/913fb63af28f446cd10c684ee847b5606cf328f7
+
+package singleflight
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"runtime/debug"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type errValue struct{}
+
+func (err *errValue) Error() string {
+	return "error value"
+}
+
+func TestPanicErrorUnwrap(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name             string
+		panicValue       interface{}
+		wrappedErrorType bool
+	}{
+		{
+			name:             "panicError wraps non-error type",
+			panicValue:       &panicError{value: "string value"},
+			wrappedErrorType: false,
+		},
+		{
+			name:             "panicError wraps error type",
+			panicValue:       &panicError{value: new(errValue)},
+			wrappedErrorType: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var recovered interface{}
+
+			group := &Group[string, any]{}
+
+			func() {
+				defer func() {
+					recovered = recover()
+					t.Logf("after panic(%#v) in group.Do, recovered %#v", tc.panicValue, recovered)
+				}()
+
+				_, _, _ = group.Do(tc.name, func() (interface{}, error) {
+					panic(tc.panicValue)
+				})
+			}()
+
+			if recovered == nil {
+				t.Fatal("expected a non-nil panic value")
+			}
+
+			err, ok := recovered.(error)
+			if !ok {
+				t.Fatalf("recovered non-error type: %T", recovered)
+			}
+
+			if !errors.Is(err, new(errValue)) && tc.wrappedErrorType {
+				t.Errorf("unexpected wrapped error type %T; want %T", err, new(errValue))
+			}
+		})
+	}
+}
+
+func TestDo(t *testing.T) {
+	var g Group[string, any]
+	v, err, _ := g.Do("key", func() (interface{}, error) {
+		return "bar", nil
+	})
+	if got, want := fmt.Sprintf("%v (%T)", v, v), "bar (string)"; got != want {
+		t.Errorf("Do = %v; want %v", got, want)
+	}
+	if err != nil {
+		t.Errorf("Do error = %v", err)
+	}
+}
+
+func TestDoErr(t *testing.T) {
+	var g Group[string, any]
+	someErr := errors.New("Some error")
+	v, err, _ := g.Do("key", func() (interface{}, error) {
+		return nil, someErr
+	})
+	if err != someErr {
+		t.Errorf("Do error = %v; want someErr %v", err, someErr)
+	}
+	if v != nil {
+		t.Errorf("unexpected non-nil value %#v", v)
+	}
+}
+
+func TestDoDupSuppress(t *testing.T) {
+	var g Group[string, any]
+	var wg1, wg2 sync.WaitGroup
+	c := make(chan string, 1)
+	var calls int32
+	fn := func() (interface{}, error) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			// First invocation.
+			wg1.Done()
+		}
+		v := <-c
+		c <- v // pump; make available for any future calls
+
+		time.Sleep(10 * time.Millisecond) // let more goroutines enter Do
+
+		return v, nil
+	}
+
+	const n = 10
+	wg1.Add(1)
+	for i := 0; i < n; i++ {
+		wg1.Add(1)
+		wg2.Add(1)
+		go func() {
+			defer wg2.Done()
+			wg1.Done()
+			v, err, _ := g.Do("key", fn)
+			if err != nil {
+				t.Errorf("Do error: %v", err)
+				return
+			}
+			if s, _ := v.(string); s != "bar" {
+				t.Errorf("Do = %T %v; want %q", v, v, "bar")
+			}
+		}()
+	}
+	wg1.Wait()
+	// At least one goroutine is in fn now and all of them have at
+	// least reached the line before the Do.
+	c <- "bar"
+	wg2.Wait()
+	if got := atomic.LoadInt32(&calls); got <= 0 || got >= n {
+		t.Errorf("number of calls = %d; want over 0 and less than %d", got, n)
+	}
+}
+
+// Test that singleflight behaves correctly after Forget called.
+// See https://github.com/golang/go/issues/31420
+func TestForget(t *testing.T) {
+	var g Group[string, any]
+
+	var (
+		firstStarted  = make(chan struct{})
+		unblockFirst  = make(chan struct{})
+		firstFinished = make(chan struct{})
+	)
+
+	go func() {
+		g.Do("key", func() (i interface{}, e error) {
+			close(firstStarted)
+			<-unblockFirst
+			close(firstFinished)
+			return
+		})
+	}()
+	<-firstStarted
+	g.Forget("key")
+
+	unblockSecond := make(chan struct{})
+	secondResult := g.DoChan("key", func() (i interface{}, e error) {
+		<-unblockSecond
+		return 2, nil
+	})
+
+	close(unblockFirst)
+	<-firstFinished
+
+	thirdResult := g.DoChan("key", func() (i interface{}, e error) {
+		return 3, nil
+	})
+
+	close(unblockSecond)
+	<-secondResult
+	r := <-thirdResult
+	if r.Val != 2 {
+		t.Errorf("We should receive result produced by second call, expected: 2, got %d", r.Val)
+	}
+}
+
+func TestDoChan(t *testing.T) {
+	var g Group[string, any]
+	ch := g.DoChan("key", func() (interface{}, error) {
+		return "bar", nil
+	})
+
+	res := <-ch
+	v := res.Val
+	err := res.Err
+	if got, want := fmt.Sprintf("%v (%T)", v, v), "bar (string)"; got != want {
+		t.Errorf("Do = %v; want %v", got, want)
+	}
+	if err != nil {
+		t.Errorf("Do error = %v", err)
+	}
+}
+
+// Test singleflight behaves correctly after Do panic.
+// See https://github.com/golang/go/issues/41133
+func TestPanicDo(t *testing.T) {
+	var g Group[string, any]
+	fn := func() (interface{}, error) {
+		panic("invalid memory address or nil pointer dereference")
+	}
+
+	const n = 5
+	waited := int32(n)
+	panicCount := int32(0)
+	done := make(chan struct{})
+	for i := 0; i < n; i++ {
+		go func() {
+			defer func() {
+				if err := recover(); err != nil {
+					t.Logf("Got panic: %v\n%s", err, debug.Stack())
+					atomic.AddInt32(&panicCount, 1)
+				}
+
+				if atomic.AddInt32(&waited, -1) == 0 {
+					close(done)
+				}
+			}()
+
+			g.Do("key", fn)
+		}()
+	}
+
+	select {
+	case <-done:
+		if panicCount != n {
+			t.Errorf("Expect %d panic, but got %d", n, panicCount)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("Do hangs")
+	}
+}
+
+func TestGoexitDo(t *testing.T) {
+	var g Group[string, any]
+	fn := func() (interface{}, error) {
+		runtime.Goexit()
+		return nil, nil
+	}
+
+	const n = 5
+	waited := int32(n)
+	done := make(chan struct{})
+	for i := 0; i < n; i++ {
+		go func() {
+			var err error
+			defer func() {
+				if err != nil {
+					t.Errorf("Error should be nil, but got: %v", err)
+				}
+				if atomic.AddInt32(&waited, -1) == 0 {
+					close(done)
+				}
+			}()
+			_, err, _ = g.Do("key", fn)
+		}()
+	}
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatalf("Do hangs")
+	}
+}
+
+func executable(t testing.TB) string {
+	exe, err := os.Executable()
+	if err != nil {
+		t.Skipf("skipping: test executable not found")
+	}
+
+	// Control case: check whether exec.Command works at all.
+	// (For example, it might fail with a permission error on iOS.)
+	cmd := exec.Command(exe, "-test.list=^$")
+	cmd.Env = []string{}
+	if err := cmd.Run(); err != nil {
+		t.Skipf("skipping: exec appears not to work on %s: %v", runtime.GOOS, err)
+	}
+
+	return exe
+}
+
+func TestPanicDoChan(t *testing.T) {
+	if os.Getenv("TEST_PANIC_DOCHAN") != "" {
+		defer func() {
+			recover()
+		}()
+
+		g := new(Group[string, any])
+		ch := g.DoChan("", func() (interface{}, error) {
+			panic("Panicking in DoChan")
+		})
+		<-ch
+		t.Fatalf("DoChan unexpectedly returned")
+	}
+
+	t.Parallel()
+
+	cmd := exec.Command(executable(t), "-test.run="+t.Name(), "-test.v")
+	cmd.Env = append(os.Environ(), "TEST_PANIC_DOCHAN=1")
+	out := new(bytes.Buffer)
+	cmd.Stdout = out
+	cmd.Stderr = out
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	err := cmd.Wait()
+	t.Logf("%s:\n%s", strings.Join(cmd.Args, " "), out)
+	if err == nil {
+		t.Errorf("Test subprocess passed; want a crash due to panic in DoChan")
+	}
+	if bytes.Contains(out.Bytes(), []byte("DoChan unexpectedly")) {
+		t.Errorf("Test subprocess failed with an unexpected failure mode.")
+	}
+	if !bytes.Contains(out.Bytes(), []byte("Panicking in DoChan")) {
+		t.Errorf("Test subprocess failed, but the crash isn't caused by panicking in DoChan")
+	}
+}
+
+func TestPanicDoSharedByDoChan(t *testing.T) {
+	if os.Getenv("TEST_PANIC_DOCHAN") != "" {
+		blocked := make(chan struct{})
+		unblock := make(chan struct{})
+
+		g := new(Group[string, any])
+		go func() {
+			defer func() {
+				recover()
+			}()
+			g.Do("", func() (interface{}, error) {
+				close(blocked)
+				<-unblock
+				panic("Panicking in Do")
+			})
+		}()
+
+		<-blocked
+		ch := g.DoChan("", func() (interface{}, error) {
+			panic("DoChan unexpectedly executed callback")
+		})
+		close(unblock)
+		<-ch
+		t.Fatalf("DoChan unexpectedly returned")
+	}
+
+	t.Parallel()
+
+	cmd := exec.Command(executable(t), "-test.run="+t.Name(), "-test.v")
+	cmd.Env = append(os.Environ(), "TEST_PANIC_DOCHAN=1")
+	out := new(bytes.Buffer)
+	cmd.Stdout = out
+	cmd.Stderr = out
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	err := cmd.Wait()
+	t.Logf("%s:\n%s", strings.Join(cmd.Args, " "), out)
+	if err == nil {
+		t.Errorf("Test subprocess passed; want a crash due to panic in Do shared by DoChan")
+	}
+	if bytes.Contains(out.Bytes(), []byte("DoChan unexpectedly")) {
+		t.Errorf("Test subprocess failed with an unexpected failure mode.")
+	}
+	if !bytes.Contains(out.Bytes(), []byte("Panicking in Do")) {
+		t.Errorf("Test subprocess failed, but the crash isn't caused by panicking in Do")
+	}
+}
+
+func ExampleGroup() {
+	g := new(Group[string, any])
+
+	block := make(chan struct{})
+	res1c := g.DoChan("key", func() (interface{}, error) {
+		<-block
+		return "func 1", nil
+	})
+	res2c := g.DoChan("key", func() (interface{}, error) {
+		<-block
+		return "func 2", nil
+	})
+	close(block)
+
+	res1 := <-res1c
+	res2 := <-res2c
+
+	// Results are shared by functions executed with duplicate keys.
+	fmt.Println("Shared:", res2.Shared)
+	// Only the first function is executed: it is registered and started with "key",
+	// and doesn't complete before the second function is registered with a duplicate key.
+	fmt.Println("Equal results:", res1.Val.(string) == res2.Val.(string))
+	fmt.Println("Result:", res1.Val)
+
+	// Output:
+	// Shared: true
+	// Equal results: true
+	// Result: func 1
+}


### PR DESCRIPTION
This is a generic'd version of the `rpm.PathSet` cache.

Once merged, that implementation and the refcounting scheme in the fetcher can be replaced with `cache.Live`.

The package is named `cache` because we may want different cache strategies in the future, so we can just add more types here (e.g. `S3Fifo`, `LRU`).