### PR TITLE
rhel: account for the rpmmod being included in the component's PURL

### DIFF
--- a/rhel/vex/parser.go
+++ b/rhel/vex/parser.go
@@ -338,6 +338,11 @@ func (c *creator) knownAffectedVulnerabilities(ctx context.Context, v csaf.Vulne
 				pkgName = pn
 			}
 
+			if mn, ok := purl.Qualifiers.Map()["rpmmod"]; ok {
+				// It is possible to have a module name in the purl, not in the relationship.
+				modName = mn
+			}
+
 			if purl.Type == packageurl.TypeOCI {
 				vuln.Repo = c.rc.Get(wfn, rhcc.RepositoryKey)
 				vuln.Range, err = ranger.add(pkgName, vuln.FixedInVersion)
@@ -535,6 +540,11 @@ func (c *creator) fixedVulnerabilities(ctx context.Context, v csaf.Vulnerability
 				Msg("error extracting package name from pURL")
 			continue
 		}
+		if mn, ok := purl.Qualifiers.Map()["rpmmod"]; ok {
+			// It is possible to have a module name in the purl, not in the relationship.
+			modName = mn
+		}
+
 		vulnKey := createPackageKey(repoName, modName, purl.Name, fixedIn)
 		arch := extractArch(purl)
 		if vuln, ok := c.lookupVulnerability(vulnKey, protoVulnFunc); ok && arch != "" {

--- a/rhel/vex/testdata/cve-2024-24786-simple.json
+++ b/rhel/vex/testdata/cve-2024-24786-simple.json
@@ -1,0 +1,237 @@
+{
+    "document": {
+        "aggregate_severity": {
+            "namespace": "https://access.redhat.com/security/updates/classification/",
+            "text": "Moderate"
+        },
+        "category": "csaf_vex",
+        "csaf_version": "2.0",
+        "distribution": {
+            "text": "Copyright © Red Hat, Inc. All rights reserved.",
+            "tlp": {
+                "label": "WHITE",
+                "url": "https://www.first.org/tlp/"
+            }
+        },
+        "lang": "en",
+        "notes": [
+            {
+                "category": "legal_disclaimer",
+                "text": "This content is licensed under the Creative Commons Attribution 4.0 International License (https://creativecommons.org/licenses/by/4.0/). If you distribute this content, or a modified version of it, you must provide attribution to Red Hat Inc. and provide a link to the original.",
+                "title": "Terms of Use"
+            }
+        ],
+        "publisher": {
+            "category": "vendor",
+            "contact_details": "https://access.redhat.com/security/team/contact/",
+            "issuing_authority": "Red Hat Product Security is responsible for vulnerability handling across all Red Hat products and services.",
+            "name": "Red Hat Product Security",
+            "namespace": "https://www.redhat.com"
+        },
+        "references": [
+            {
+                "category": "self",
+                "summary": "Canonical URL",
+                "url": "https://security.access.redhat.com/data/csaf/v2/vex/2024/cve-2024-24786.json"
+            }
+        ],
+        "title": "golang-protobuf: encoding/protojson, internal/encoding/json: infinite loop in protojson.Unmarshal when unmarshaling certain forms of invalid JSON",
+        "tracking": {
+            "current_release_date": "2025-05-28T01:21:44+00:00",
+            "generator": {
+                "date": "2025-05-28T01:21:44+00:00",
+                "engine": {
+                    "name": "Red Hat SDEngine",
+                    "version": "4.6.0"
+                }
+            },
+            "id": "CVE-2024-24786",
+            "initial_release_date": "2024-03-05T00:00:00+00:00",
+            "revision_history": [
+                {
+                    "date": "2024-03-05T00:00:00+00:00",
+                    "number": "1",
+                    "summary": "Initial version"
+                },
+                {
+                    "date": "2025-05-13T12:17:36+00:00",
+                    "number": "2",
+                    "summary": "Current version"
+                },
+                {
+                    "date": "2025-05-28T01:21:44+00:00",
+                    "number": "3",
+                    "summary": "Last generated version"
+                }
+            ],
+            "status": "final",
+            "version": "3"
+        }
+    },
+    "product_tree": {
+        "branches": [
+            {
+                "branches": [
+                    {
+                        "branches": [
+                            {
+                                "category": "product_name",
+                                "name": "Red Hat Enterprise Linux 8",
+                                "product": {
+                                    "name": "Red Hat Enterprise Linux 8",
+                                    "product_id": "red_hat_enterprise_linux_8",
+                                    "product_identification_helper": {
+                                        "cpe": "cpe:/o:redhat:enterprise_linux:8"
+                                    }
+                                }
+                            }
+                        ],
+                        "category": "product_family",
+                        "name": "Red Hat Enterprise Linux 8"
+                    }
+                ],
+                "category": "vendor",
+                "name": "Red Hat"
+            },
+            {
+                "category": "product_version",
+                "name": "go-toolset:rhel8/go-toolset",
+                "product": {
+                    "name": "go-toolset:rhel8/go-toolset",
+                    "product_id": "go-toolset:rhel8/go-toolset",
+                    "product_identification_helper": {
+                        "purl": "pkg:rpm/redhat/go-toolset@rhel8?arch=src&rpmmod=go-toolset:rhel8"
+                    }
+                }
+            }
+        ],
+        "relationships": [
+            {
+                "category": "default_component_of",
+                "full_product_name": {
+                    "name": "go-toolset:rhel8/go-toolset as a component of Red Hat Enterprise Linux 8",
+                    "product_id": "red_hat_enterprise_linux_8:go-toolset:rhel8/go-toolset"
+                },
+                "product_reference": "go-toolset:rhel8/go-toolset",
+                "relates_to_product_reference": "red_hat_enterprise_linux_8"
+            }
+        ]
+    },
+    "vulnerabilities": [
+        {
+            "cve": "CVE-2024-24786",
+            "cwe": {
+                "id": "CWE-835",
+                "name": "Loop with Unreachable Exit Condition ('Infinite Loop')"
+            },
+            "discovery_date": "2024-03-06T00:00:00+00:00",
+            "flags": [
+                {
+                    "label": "vulnerable_code_not_present",
+                    "product_ids": []
+                }
+            ],
+            "ids": [
+                {
+                    "system_name": "Red Hat Bugzilla ID",
+                    "text": "2268046"
+                }
+            ],
+            "notes": [
+                {
+                    "category": "description",
+                    "text": "A flaw was found in Golang's protobuf module, where the unmarshal function can enter an infinite loop when processing certain invalid inputs. This issue occurs during unmarshaling into a message that includes a google.protobuf.Any or when the UnmarshalOptions.DiscardUnknown option is enabled. This flaw allows an attacker to craft malicious input tailored to trigger the identified flaw in the unmarshal function. By providing carefully constructed invalid inputs, they could potentially cause the function to enter an infinite loop, resulting in a denial of service condition or other unintended behaviors in the affected system.",
+                    "title": "Vulnerability description"
+                },
+                {
+                    "category": "summary",
+                    "text": "golang-protobuf: encoding/protojson, internal/encoding/json: infinite loop in protojson.Unmarshal when unmarshaling certain forms of invalid JSON",
+                    "title": "Vulnerability summary"
+                },
+                {
+                    "category": "general",
+                    "text": "The CVSS score(s) listed for this vulnerability do not reflect the associated product's status, and are included for informational purposes to better understand the severity of this vulnerability.",
+                    "title": "CVSS score applicability"
+                }
+            ],
+            "product_status": {
+                "fixed": [],
+                "known_affected": [
+                    "red_hat_enterprise_linux_8:go-toolset:rhel8/go-toolset"
+                ],
+                "known_not_affected": [],
+                "under_investigation": []
+            },
+            "references": [
+                {
+                    "category": "self",
+                    "summary": "Canonical URL",
+                    "url": "https://access.redhat.com/security/cve/CVE-2024-24786"
+                },
+                {
+                    "category": "external",
+                    "summary": "RHBZ#2268046",
+                    "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2268046"
+                },
+                {
+                    "category": "external",
+                    "summary": "https://www.cve.org/CVERecord?id=CVE-2024-24786",
+                    "url": "https://www.cve.org/CVERecord?id=CVE-2024-24786"
+                },
+                {
+                    "category": "external",
+                    "summary": "https://nvd.nist.gov/vuln/detail/CVE-2024-24786",
+                    "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-24786"
+                },
+                {
+                    "category": "external",
+                    "summary": "https://go.dev/cl/569356",
+                    "url": "https://go.dev/cl/569356"
+                },
+                {
+                    "category": "external",
+                    "summary": "https://groups.google.com/g/golang-announce/c/ArQ6CDgtEjY/",
+                    "url": "https://groups.google.com/g/golang-announce/c/ArQ6CDgtEjY/"
+                },
+                {
+                    "category": "external",
+                    "summary": "https://pkg.go.dev/vuln/GO-2024-2611",
+                    "url": "https://pkg.go.dev/vuln/GO-2024-2611"
+                }
+            ],
+            "release_date": "2024-03-05T00:00:00+00:00",
+            "remediations": [],
+            "scores": [
+                {
+                    "cvss_v3": {
+                        "attackComplexity": "HIGH",
+                        "attackVector": "NETWORK",
+                        "availabilityImpact": "HIGH",
+                        "baseScore": 5.9,
+                        "baseSeverity": "MEDIUM",
+                        "confidentialityImpact": "NONE",
+                        "integrityImpact": "NONE",
+                        "privilegesRequired": "NONE",
+                        "scope": "UNCHANGED",
+                        "userInteraction": "NONE",
+                        "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                        "version": "3.1"
+                    },
+                    "products": [
+                        "red_hat_enterprise_linux_8:go-toolset:rhel8/go-toolset"
+                    ]
+                }
+            ],
+            "threats": [
+                {
+                    "category": "impact",
+                    "details": "Moderate",
+                    "product_ids": [
+                        "red_hat_enterprise_linux_8:go-toolset:rhel8/go-toolset"
+                    ]
+                }
+            ],
+            "title": "golang-protobuf: encoding/protojson, internal/encoding/json: infinite loop in protojson.Unmarshal when unmarshaling certain forms of invalid JSON"
+        }
+    ]
+}


### PR DESCRIPTION
Red Hat prodsec have decided to move from declaring a component's RPM module in the VEX relationships to directly including the module string in the component's purl as a qualifier. This change accounts for that change (while still supporting the original logic path as it's currently split-brain).