### PR TITLE
[DO NOT MERGE]vex: temporarily increase the lookBackToYear

### DIFF
--- a/rhel/vex/updater.go
+++ b/rhel/vex/updater.go
@@ -33,7 +33,7 @@ const (
 	latestFile                   = "archive_latest.txt"
 	changesFile                  = "changes.csv"
 	deletionsFile                = "deletions.csv"
-	lookBackToYear               = 2014
+	lookBackToYear               = 2017
 	repoKey                      = "rhel-cpe-repository"
 	updaterVersion               = "4"
 )


### PR DESCRIPTION
With too many Vex files being updated recently, ACS is struggling to update the VEX data
Temporarily increase the lookBackToYear to decrease the load
This branch will only exist for a few days