### PR TITLE
jsonblob: implement Load as documented

### DIFF
--- a/libvuln/jsonblob/jsonblob.go
+++ b/libvuln/jsonblob/jsonblob.go
@@ -257,8 +257,6 @@ type diskEntry struct {
 //
 // It is unsafe for modification because it does not return a copy of the map.
 func (s *Store) Entries() map[uuid.UUID]*Entry {
-	// BUG(hank) [Store.Entries] reports seemingly-empty entries when populated
-	// via [Store.UpdateVulnerabilities].
 	s.RLock()
 	defer s.RUnlock()
 	return s.entry
@@ -284,6 +282,7 @@ func (s *Store) UpdateVulnerabilities(ctx context.Context, updater string, finge
 	}
 
 	e := Entry{
+		Vuln:   vulns,
 		vulns:  buf,
 		vulnCt: len(vulns),
 	}
@@ -413,6 +412,7 @@ func (s *Store) UpdateEnrichments(ctx context.Context, kind string, fp driver.Fi
 	}
 
 	e := Entry{
+		Enrichment:   es,
 		enrichments:  buf,
 		enrichmentCt: len(es),
 	}

--- a/libvuln/jsonblob/loader.go
+++ b/libvuln/jsonblob/loader.go
@@ -1,0 +1,93 @@
+package jsonblob
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/google/uuid"
+	"io"
+
+	"github.com/quay/claircore"
+	"github.com/quay/claircore/libvuln/driver"
+)
+
+// NewLoader creates a new Loader from the provided [io.Reader].
+func NewLoader(r io.Reader) (*Loader, error) {
+	l := Loader{
+		dec: json.NewDecoder(r),
+		cur: uuid.Nil,
+	}
+	return &l, nil
+}
+
+// Loader is an iterator that returns a series of [Entry].
+//
+// Users should call [*Loader.Next] until it reports false, then check for
+// errors via [*Loader.Err].
+type Loader struct {
+	err error
+	e   *Entry
+
+	dec  *json.Decoder
+	next *Entry
+	de   diskEntry
+	cur  uuid.UUID
+}
+
+// Next reports whether there's an [Entry] to be processed.
+func (l *Loader) Next() bool {
+	if l.err != nil {
+		return false
+	}
+
+	for l.err = l.dec.Decode(&l.de); l.err == nil; l.err = l.dec.Decode(&l.de) {
+		id := l.de.Ref
+		// If we just hit a new Entry, promote the current one.
+		if id != l.cur {
+			l.e = l.next
+			l.next = &Entry{}
+			l.next.Updater = l.de.Updater
+			l.next.Fingerprint = l.de.Fingerprint
+			l.next.Date = l.de.Date
+		}
+		switch l.de.Kind {
+		case driver.VulnerabilityKind:
+			vuln := claircore.Vulnerability{}
+			if err := json.Unmarshal(l.de.Vuln.buf, &vuln); err != nil {
+				l.err = err
+				return false
+			}
+			l.next.Vuln = append(l.next.Vuln, &vuln)
+		case driver.EnrichmentKind:
+			en := driver.EnrichmentRecord{}
+			if err := json.Unmarshal(l.de.Enrichment.buf, &en); err != nil {
+				l.err = err
+				return false
+			}
+			l.next.Enrichment = append(l.next.Enrichment, en)
+		}
+		// If this was an initial diskEntry, promote the ref.
+		if id != l.cur {
+			l.cur = id
+			// If we have an Entry ready, report that.
+			if l.e != nil {
+				return true
+			}
+		}
+	}
+	l.e = l.next
+	return true
+}
+
+// Entry returns the latest loaded [Entry].
+func (l *Loader) Entry() *Entry {
+	return l.e
+}
+
+// Err is the latest encountered error.
+func (l *Loader) Err() error {
+	// Don't report EOF as an error.
+	if errors.Is(l.err, io.EOF) {
+		return nil
+	}
+	return l.err
+}

--- a/libvuln/jsonblob/loader_test.go
+++ b/libvuln/jsonblob/loader_test.go
@@ -1,0 +1,78 @@
+package jsonblob
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/quay/claircore"
+	"github.com/quay/claircore/libvuln/driver"
+	"github.com/quay/claircore/test"
+)
+
+func TestLoader(t *testing.T) {
+	ctx := context.Background()
+	a, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var want, got struct {
+		V []*claircore.Vulnerability
+		E []driver.EnrichmentRecord
+	}
+
+	want.V = test.GenUniqueVulnerabilities(10, "test")
+	ref, err := a.UpdateVulnerabilities(ctx, "test", "", want.V)
+	if err != nil {
+		t.Error(err)
+	}
+	t.Logf("ref: %v", ref)
+
+	want.E = test.GenEnrichments(15)
+	ref, err = a.UpdateEnrichments(ctx, "test", "", want.E)
+	if err != nil {
+		t.Error(err)
+	}
+	t.Logf("ref: %v", ref)
+
+	var buf bytes.Buffer
+	defer func() {
+		t.Logf("wrote:\n%s", buf.String())
+	}()
+	r, w := io.Pipe()
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() error { defer w.Close(); return a.Store(w) })
+	eg.Go(func() error {
+		l, err := NewLoader(io.TeeReader(r, &buf))
+		if err != nil {
+			return err
+		}
+		for l.Next() {
+			e := l.Entry()
+			if e.Vuln != nil && e.Enrichment != nil {
+				t.Error("expecting entry to have either vulnerability or enrichment, got both")
+			}
+			if e.Vuln != nil {
+				got.V = append(got.V, l.Entry().Vuln...)
+			}
+			if e.Enrichment != nil {
+				got.E = append(got.E, l.Entry().Enrichment...)
+			}
+		}
+		if err := l.Err(); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err := eg.Wait(); err != nil {
+		t.Error(err)
+	}
+	if !cmp.Equal(got, want) {
+		t.Error(cmp.Diff(got, want))
+	}
+}

--- a/libvuln/updates.go
+++ b/libvuln/updates.go
@@ -26,7 +26,7 @@ func OfflineImport(ctx context.Context, pool *pgxpool.Pool, in io.Reader) error 
 	ctx = zlog.ContextWithValues(ctx, "component", "libvuln/OfflineImporter")
 
 	s := postgres.NewMatcherStore(pool)
-	l, err := jsonblob.Load(ctx, in)
+	l, err := jsonblob.NewLoader(in)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Changes current `Load()` to `NewLoader()`
- Implements `Load()` as documented, i.e., will load provided `io.Reader` in a `Store`
- Moves `Loader` types and methods to a separate file
- Fixes a bug in `Store.UpdateEnrichments()` where `s.Enrichments` weren’t being set
- Fixes a bug in `Store.UpdateVulnerabilities()` where `s.Vuln` wasn’t being set