### PR TITLE
java: change search query

### DIFF
--- a/java/packagescanner.go
+++ b/java/packagescanner.go
@@ -306,7 +306,7 @@ func (s *Scanner) search(ctx context.Context, i *jar.Info, ck []byte) error {
 	v := req.URL.Query()
 	// 40 == 2 * sha1.Size. I don't there's a good way to keep it as
 	// a constant.
-	v.Set("q", fmt.Sprintf(`1:"%40x"`, ck))
+	v.Set("q", fmt.Sprintf(`1:%40x`, ck))
 	v.Set("wt", "json")
 	req.URL.RawQuery = v.Encode()
 	res, err := s.client.Do(req)


### PR DESCRIPTION
This change constructs the solr search as a string field instead of a text field. Other implementations of the Cental search API seem to like it this way instead of the other.

See-also: quay/claircore#1567