### PR TITLE
docs: fix code blocks in mdbook-godoc preprocessor 

### DIFF
--- a/internal/cmd/mdbook-godoc/main.go
+++ b/internal/cmd/mdbook-godoc/main.go
@@ -57,7 +57,7 @@ func newProc(ctx context.Context, cfg *mdbook.Context) (*mdbook.Proc, error) {
 					ret = err
 					return sub
 				}
-				b.WriteString("\n```")
+				b.WriteString("\n```\n")
 				return b.String()
 			})
 			return ret


### PR DESCRIPTION
| Before | After |
|--------|--------|
| ![quay github io_claircore_reference_coalescer html](https://github.com/user-attachments/assets/2c9e3fcd-f8c7-4d26-96fb-e4f592032eb8) | ![localhost_3000_reference_coalescer html](https://github.com/user-attachments/assets/551ec266-6b16-42d8-bb83-f8f236a1f3cf) | 
| ![quay github io_claircore_reference_configurable_scanner html](https://github.com/user-attachments/assets/97c88637-99ab-415d-8b3a-407bd8ed3a70) | ![localhost_3000_reference_configurable_scanner html](https://github.com/user-attachments/assets/79b1fdec-06c2-4430-9af5-241d01391ac7) | 

Closes https://github.com/quay/claircore/issues/1574.