### PR TITLE
replace pgtype with pgx/v5 version

### DIFF
--- a/datastore/postgres/affectedmanifest.go
+++ b/datastore/postgres/affectedmanifest.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/jackc/pgtype"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -289,8 +289,8 @@ func protoRecord(ctx context.Context, pool *pgxpool.Pool, v claircore.Vulnerabil
 		protoRecordCounter.WithLabelValues("selectDist").Add(1)
 		protoRecordDuration.WithLabelValues("selectDist").Observe(time.Since(start).Seconds())
 
-		if id.Status == pgtype.Present {
-			id := strconv.FormatInt(id.Int, 10)
+		if id.Valid {
+			id := strconv.FormatInt(id.Int64, 10)
 			protoRecord.Distribution = &claircore.Distribution{
 				ID:              id,
 				Arch:            v.Dist.Arch,
@@ -324,8 +324,8 @@ func protoRecord(ctx context.Context, pool *pgxpool.Pool, v claircore.Vulnerabil
 		protoRecordCounter.WithLabelValues("selectDist").Add(1)
 		protoRecordDuration.WithLabelValues("selectDist").Observe(time.Since(start).Seconds())
 
-		if id.Status == pgtype.Present {
-			id := strconv.FormatInt(id.Int, 10)
+		if id.Valid {
+			id := strconv.FormatInt(id.Int64, 10)
 			protoRecord.Repository = &claircore.Repository{
 				ID:   id,
 				Key:  v.Repo.Key,

--- a/datastore/postgres/digest.go
+++ b/datastore/postgres/digest.go
@@ -1,8 +1,6 @@
 package postgres
 
 import (
-	"github.com/jackc/pgtype"
-
 	"github.com/quay/claircore"
 )
 
@@ -10,7 +8,9 @@ import (
 // handling a slice of Digests.
 type digestSlice []claircore.Digest
 
-func (s digestSlice) EncodeText(_ *pgtype.ConnInfo, buf []byte) ([]byte, error) {
+// MarshalText implements encoding.TextMarshaler.
+func (s digestSlice) MarshalText() ([]byte, error) {
+	buf := make([]byte, 0, len(s)*75)
 	buf = append(buf, '{')
 	for i, d := range s {
 		if i != 0 {

--- a/datastore/postgres/digest_test.go
+++ b/datastore/postgres/digest_test.go
@@ -25,7 +25,7 @@ func TestDigestEncode(t *testing.T) {
 		`","sha256:` + strings.Repeat(`e`, 64) +
 		`","sha256:` + strings.Repeat(`f`, 64) +
 		`"}`
-	got, err := ds.EncodeText(nil, nil)
+	got, err := ds.MarshalText()
 	if err != nil {
 		t.Error(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgconn v1.14.3
-	github.com/jackc/pgtype v1.14.2
 	github.com/jackc/pgx/v4 v4.18.3
 	github.com/jackc/pgx/v5 v5.7.5
 	github.com/klauspost/compress v1.18.0
@@ -52,6 +51,7 @@ require (
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgproto3/v2 v2.3.3 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
+	github.com/jackc/pgtype v1.14.2 // indirect
 	github.com/jackc/puddle v1.3.0 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect


### PR DESCRIPTION
pgtype is part of pgx/v5 there is no need to use legacy version.

- https://github.com/jackc/pgtype/commit/045ef2b0119074dd010d0298cd3740114d4070c0
- https://github.com/quay/claircore/pull/1530