### PR TITLE
libindex: simplify fetch arena with weak pointers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/quay/claircore
 
-go 1.23.0
+go 1.24.0
 
-toolchain go1.24.1
+toolchain go1.24.3
 
 require (
 	github.com/Masterminds/semver v1.5.0

--- a/libindex/tempfile_linux.go
+++ b/libindex/tempfile_linux.go
@@ -9,7 +9,11 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-var tmpMap sync.Map
+var (
+	tmpMap sync.Map
+
+	errStale = errors.New("stale file reference")
+)
 
 func canTmp(dir string) (ok, loaded bool) {
 	v, loaded := tmpMap.Load(dir)


### PR DESCRIPTION
Go 1.24 introduced [weak pointers](https://pkg.go.dev/weak). According to the docs as well as [this blog post](https://go.dev/blog/cleanups-and-weak), weak pointers will greatly simplify the Fetch Arena, as it eliminates the need to manually count references to each layer.

This PR replaces the manual ref counting with weak pointers and [`runtime.AddCleanup`](https://pkg.go.dev/runtime#AddCleanup).