### PR TITLE
suse: update OVAL source

### DIFF
--- a/suse/factory.go
+++ b/suse/factory.go
@@ -19,7 +19,7 @@ import (
 )
 
 //doc:url updater
-const base = `https://support.novell.com/security/oval/`
+const base = `https://ftp.suse.com/pub/projects/security/oval/`
 
 var (
 	reELFile = regexp.MustCompile(`suse.linux.enterprise.server.([1-9][1-9]).xml.gz`)

--- a/suse/factory_test.go
+++ b/suse/factory_test.go
@@ -20,6 +20,9 @@ func TestFactory(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if len(us.Updaters()) == 0 {
+		t.Error("expected at least one updater")
+	}
 	for _, u := range us.Updaters() {
 		t.Log(u.Name())
 	}


### PR DESCRIPTION
Updated the SUSE OVAL source after finding https://www.suse.com/support/security/oval/. The old source no longer contains gzip versions of the OVAL files, and the files do not seem current (ex: missing the latest openSUSE leap version).

See the [README](https://ftp.suse.com/pub/projects/security/oval/README) and [LICENSE](https://ftp.suse.com/pub/projects/security/oval/LICENSE) linked in this sentence.

~I'm not sure if the older OVAL files included unfixed vulnerabilities, so I just opted to use the OVAL files which include: fixed, unaffected, and unfixed. I can switch it to exclude unfixed vulnerabilities, if desired.~

Opted to use the feeds without unfixed vulnerabilities, as we have precedent of not using that in the past - https://github.com/quay/claircore/pull/1545