### PR TITLE
libindex: fix fetcher leak

### DIFF
--- a/libindex/reopen_linux.go
+++ b/libindex/reopen_linux.go
@@ -1,0 +1,19 @@
+package libindex
+
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+func reopen(_ *os.Root, f *os.File) (*os.File, error) {
+	fd := int(f.Fd())
+	if fd == -1 {
+		return nil, errors.New("stale file descriptor")
+	}
+	p := fmt.Sprintf("/proc/self/fd/%d", fd)
+	// Need to use OpenFile so that the symlink is not dereferenced.
+	// There's some proc magic so that opening that symlink itself copies the
+	// description.
+	return os.OpenFile(p, os.O_RDONLY, 0o644)
+}

--- a/libindex/reopen_other.go
+++ b/libindex/reopen_other.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package libindex
+
+import "os"
+
+func reopen(dir *os.Root, f *os.File) (*os.File, error) {
+	return dir.OpenFile(f.Name(), os.O_RDONLY, 0o644)
+}

--- a/libindex/tempdir_unix.go
+++ b/libindex/tempdir_unix.go
@@ -3,6 +3,7 @@
 package libindex
 
 import (
+	"cmp"
 	"os"
 )
 
@@ -10,11 +11,5 @@ import (
 //
 // See [NewRemoteFetchArena].
 func fixTemp(dir string) string {
-	if dir != "" {
-		return dir
-	}
-	if d, ok := os.LookupEnv("TMPDIR"); ok && d != "" {
-		return d
-	}
-	return "/var/tmp"
+	return cmp.Or(dir, os.Getenv("TMPDIR"), "/var/tmp")
 }

--- a/libindex/tempfile.go
+++ b/libindex/tempfile.go
@@ -1,0 +1,10 @@
+package libindex
+
+import (
+	"fmt"
+	"math/rand/v2"
+)
+
+func fetchFilename() string {
+	return fmt.Sprintf("fetcher.%08x", rand.Uint32())
+}

--- a/libindex/tempfile_unix.go
+++ b/libindex/tempfile_unix.go
@@ -4,27 +4,25 @@ package libindex
 
 import (
 	"errors"
+	"io/fs"
 	"os"
+	"runtime"
 )
 
-type tempFile struct {
-	*os.File
-}
-
-func openTemp(dir string) (*tempFile, error) {
-	f, err := os.CreateTemp(dir, "*.fetch")
+func openTemp(dir *os.Root) (f *os.File, err error) {
+	const flag = os.O_WRONLY
+	for {
+		name := fetchFilename()
+		f, err = dir.OpenFile(name, flag, 0o644)
+		// NB This breaks out of the loop on any condition *except* an "exists"
+		// error.
+		if !errors.Is(err, fs.ErrExist) {
+			break
+		}
+	}
 	if err != nil {
 		return nil, err
 	}
-	return &tempFile{
-		File: f,
-	}, nil
-}
-
-func (t *tempFile) Reopen() (*os.File, error) {
-	return os.OpenFile(t.Name(), os.O_RDONLY, 0644)
-}
-
-func (t *tempFile) Close() error {
-	return errors.Join(os.Remove(t.Name()), t.File.Close())
+	runtime.AddCleanup(f, func(n string) { os.Remove(n) }, f.Name())
+	return f, nil
 }

--- a/libindex/tempfile_windows.go
+++ b/libindex/tempfile_windows.go
@@ -2,39 +2,27 @@ package libindex
 
 import (
 	"errors"
-	"fmt"
 	"io/fs"
-	"math/rand/v2"
 	"os"
-	"path/filepath"
 )
 
 // This is a very rough port of src/os/tempfile.go that adds the magic
 // autodelete flag.
 
-type tempFile struct {
-	*os.File
-}
-
-func openTemp(dir string) (*tempFile, error) {
+func openTemp(dir *os.Root) (f *os.File, err error) {
 	// Copied out of golang.org/x/sys/windows
 	const FILE_FLAG_DELETE_ON_CLOSE = 0x04000000
+	const flag = os.O_WRONLY | FILE_FLAG_DELETE_ON_CLOSE
 	for {
-		fn := fmt.Sprintf("fetch.%08x", rand.Uint32())
-		f, err := os.OpenFile(filepath.Join(dir, fn), os.O_WRONLY|FILE_FLAG_DELETE_ON_CLOSE, 0644)
+		name := fetchFilename()
+		f, err = dir.OpenFile(name, flag, 0o644)
 		switch {
 		case errors.Is(err, nil):
-			return &tempFile{
-				File: f,
-			}, nil
+			return f, nil
 		case errors.Is(err, fs.ErrExist):
 			// Continue
 		default:
 			return nil, err
 		}
 	}
-}
-
-func (t *tempFile) Reopen() (*os.File, error) {
-	return os.OpenFile(t.Name(), os.O_RDONLY, 0644)
 }


### PR DESCRIPTION
This is should fix a file descriptor (and file) leak when there's an error return while writing the file. This leak would result in the file descriptor hanging around until a GC cycle and the backing file not being deleted when not using `O_TMPFILE`.

Depends on: #1547