### PR TITLE
updates: fix panic in test logs

### DIFF
--- a/libvuln/updates/locks_test.go
+++ b/libvuln/updates/locks_test.go
@@ -8,103 +8,126 @@ import (
 	"testing"
 )
 
-func TestLocalLockUnlock(t *testing.T) {
-	ctx := context.Background()
-	l := NewLocalLockSource()
-
-	t.Log("lock")
-	c, done := l.Lock(ctx, t.Name())
-	if err := c.Err(); err != nil {
-		t.Error(err)
-	}
-	t.Log("unlock")
-	done()
-	if l.peek(t.Name()) {
-		t.Error("lock held")
-	}
-
-	t.Log("lock")
-	c, done = l.Lock(ctx, t.Name())
-	if err := c.Err(); err != nil {
-		t.Error(err)
-	}
-	t.Log("unlock")
-	done()
-	if l.peek(t.Name()) {
-		t.Error("lock held")
-	}
-}
-
-func TestLocalTryLock(t *testing.T) {
-	ctx := context.Background()
+func TestLocal(t *testing.T) {
 	locks := NewLocalLockSource()
-	locked := make(chan struct{})
-	unlock := make(chan struct{})
-	unlocked := make(chan struct{})
-	go func() {
-		ctx, done := locks.Lock(ctx, t.Name())
-		if err := ctx.Err(); err != nil {
-			t.Error(err)
-		}
-		defer func() {
+
+	t.Run("LockUnlock", func(t *testing.T) {
+		ctx := t.Context()
+		key := t.Name()
+
+		for range 2 {
+			t.Log("lock")
+			c, done := locks.Lock(ctx, key)
+			if err := c.Err(); err != nil {
+				t.Error(err)
+			}
+			t.Log("unlock")
 			done()
-			close(unlocked)
+			if locks.peek(key) {
+				t.Error("lock held")
+			}
+		}
+	})
+
+	t.Run("TryLock", func(t *testing.T) {
+		var wg sync.WaitGroup
+		ctx := t.Context()
+		key := t.Name()
+
+		doStart := make(chan struct{})
+		held := make(chan struct{})
+		doRelease := make(chan struct{})
+		released := make(chan struct{})
+		wg.Add(3)
+
+		// Initial lock.
+		go func() {
+			defer wg.Done()
+			<-doStart
+
+			ctx, done := locks.Lock(ctx, key)
+			if err := ctx.Err(); err != nil {
+				t.Error(err)
+				return
+			}
+			t.Log("lock held")
+			close(held)
+			<-doRelease
+			done()
+			close(released)
 			t.Log("lock released")
 		}()
-		t.Log("lock held")
-		close(locked)
-		<-unlock
-	}()
 
-	<-locked
-	lc, done := locks.TryLock(ctx, t.Name())
-	t.Logf("try: %v", lc.Err())
-	if !errors.Is(lc.Err(), context.Canceled) {
-		t.Error("wanted TryLock to fail")
-	}
-	done()
-	close(unlock)
-	<-unlocked
-	lc, done = locks.TryLock(ctx, t.Name())
-	t.Logf("try: %v", lc.Err())
-	if !errors.Is(lc.Err(), nil) {
-		t.Error("wanted TryLock to succeed")
-	}
-	done()
-	t.Log("unlocked")
-}
+		// Attempt to lock while the first goroutine holds it.
+		go func() {
+			defer wg.Done()
+			<-doStart
 
-func TestLocalLockSequential(t *testing.T) {
-	ctx := context.Background()
-	locks := NewLocalLockSource()
-	var wg sync.WaitGroup
-	wg.Add(2)
-	var ct uint64
-	_, d1 := locks.Lock(ctx, t.Name())
-	go func() {
-		_, d2 := locks.Lock(ctx, t.Name())
-		defer func() {
+			<-held
+			lc, done := locks.TryLock(ctx, key)
+			t.Logf("try: %v", lc.Err())
+			if !errors.Is(lc.Err(), context.Canceled) {
+				t.Error("wanted TryLock to fail")
+			}
+			done()
+			close(doRelease)
+		}()
+
+		// Attempt to lock after the first goroutine releases it.
+		go func() {
+			defer wg.Done()
+			<-doStart
+
+			<-released
+			lc, done := locks.TryLock(ctx, key)
+			t.Logf("try: %v", lc.Err())
+			if !errors.Is(lc.Err(), nil) {
+				t.Error("wanted TryLock to succeed")
+			}
+			done()
+			t.Log("lock released")
+		}()
+
+		close(doStart)
+		wg.Wait()
+	})
+
+	t.Run("LockSequential", func(t *testing.T) {
+		var wg sync.WaitGroup
+		ctx := t.Context()
+		key := t.Name()
+
+		wg.Add(2)
+		var ct uint64
+
+		// Take the lock first.
+		_, d1 := locks.Lock(ctx, key)
+
+		// Spawn the second writer.
+		go func() {
+			// This should block.
+			_, d2 := locks.Lock(ctx, key)
+			t.Log("1 → 2")
+			if !atomic.CompareAndSwapUint64(&ct, 1, 2) {
+				t.Error("ordering error")
+			}
 			d2()
 			wg.Done()
 		}()
-		t.Log("1 → 2")
-		if !atomic.CompareAndSwapUint64(&ct, 1, 2) {
-			t.Error("ordering error")
-		}
-	}()
-	go func() {
-		defer func() {
+
+		// Spawn the first writer
+		go func() {
+			t.Log("0 → 1")
+			if !atomic.CompareAndSwapUint64(&ct, 0, 1) {
+				t.Error("ordering error")
+			}
 			d1()
 			wg.Done()
 		}()
-		t.Log("0 → 1")
-		if !atomic.CompareAndSwapUint64(&ct, 0, 1) {
-			t.Error("ordering error")
-		}
-	}()
 
-	wg.Wait()
-	if got, want := ct, uint64(2); got != want {
-		t.Errorf("got: %d, want: %d", got, want)
-	}
+		wg.Wait()
+		if got, want := ct, uint64(2); got != want {
+			t.Errorf("got: %d, want: %d", got, want)
+		}
+	})
 }


### PR DESCRIPTION
I'm taking this opportunity to restructure the tests to make them (IMO) easier to follow.

This seems to only trigger a race on go1.25.1, but prints after tests are done are against the `testing.T` contract.

See also: https://github.com/quay/claircore/actions/runs/17627587190/job/50088118987#step:6:65