### PR TITLE
chore: add content writing permissions to GH workflows

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -17,7 +17,7 @@ jobs:
     name: Prepare Release
     runs-on: 'ubuntu-latest'
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
     steps:
       - name: Checkout

--- a/.github/workflows/update-clair.yml
+++ b/.github/workflows/update-clair.yml
@@ -9,7 +9,7 @@ jobs:
   send-pull-requests:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       id-token: write
       pull-requests: write
     steps:


### PR DESCRIPTION
The create-pull-request action will first push a branch to the remote before creating a PR, I believe that branch push requires contents: write permissions.