### PR TITLE
chore: update changelog label check permissions

### DIFF
--- a/.github/workflows/changelog-label.yml
+++ b/.github/workflows/changelog-label.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      issues: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
The changelog label check updates the pull-request's labels so I think it needs pull-request write permissions.