### PR TITLE
rpm: prefix PackageDB with kind

### DIFF
--- a/internal/rpm/find.go
+++ b/internal/rpm/find.go
@@ -172,7 +172,7 @@ func OpenDB(ctx context.Context, sys fs.FS, found FoundDB) (*Database, error) {
 
 	cleanup := &databaseCleanup{}
 	db := Database{
-		pkgdb:   found.path,
+		pkgdb:   found.String(),
 		cleanup: cleanup,
 	}
 


### PR DESCRIPTION
Prior to https://github.com/quay/claircore/pull/869, the PackageDB for RPMs were prefixed with the DB kind (sqlite, bdb, or ndb). With that change, the prefix was removed. I believe this was an accident. This PR adds it back