### PR TITLE
enrichment: don't consider vulnerability.Description for enrichments

### DIFF
--- a/enricher/cvss/cvss.go
+++ b/enricher/cvss/cvss.go
@@ -267,7 +267,6 @@ func (e *Enricher) Enrich(ctx context.Context, g driver.EnrichmentGetter, r *cla
 		ctx := zlog.ContextWithValues(ctx,
 			"vuln", v.Name)
 		for _, elem := range []string{
-			v.Description,
 			v.Name,
 			v.Links,
 		} {

--- a/enricher/cvss/cvss_test.go
+++ b/enricher/cvss/cvss_test.go
@@ -298,16 +298,21 @@ func TestEnrich(t *testing.T) {
 	r := &claircore.VulnerabilityReport{
 		Vulnerabilities: map[string]*claircore.Vulnerability{
 			"-1": {
-				Description: "This is a fake vulnerability that doesn't have a CVE.",
+				// Not a CVE
+				Name: "GO-007",
 			},
 			"1": {
-				Description: "This is a fake vulnerability that looks like CVE-2016-2781.",
+				// Legitimate CVE
+				Name: "CVE-2016-2781",
 			},
 			"6004": {
-				Description: "CVE-2016-0001 was unassigned",
+				// Unassigned CVE
+				Name: "CVE-2016-0001",
 			},
 			"6005": {
-				Description: "CVE-2016-3674 duplicate",
+				//  Check description isn't considered
+				Name:        "CVE-2016-3674",
+				Description: "CVE-2016-2781 duplicate",
 			},
 		},
 	}

--- a/enricher/epss/epss.go
+++ b/enricher/epss/epss.go
@@ -283,7 +283,6 @@ func (e *Enricher) Enrich(ctx context.Context, g driver.EnrichmentGetter, r *cla
 		ctx := zlog.ContextWithValues(ctx, "vuln", v.Name)
 
 		for _, elem := range []string{
-			v.Description,
 			v.Name,
 			v.Links,
 		} {

--- a/enricher/epss/epss_test.go
+++ b/enricher/epss/epss_test.go
@@ -330,16 +330,17 @@ func TestEnrich(t *testing.T) {
 	r := &claircore.VulnerabilityReport{
 		Vulnerabilities: map[string]*claircore.Vulnerability{
 			"-1": {
-				Description: "This is a fake vulnerability that doesn't have a CVE.",
+				Name: "GO-123123",
 			},
 			"1": {
-				Description: "This is a fake vulnerability that looks like CVE-2022-34667.",
+				Name:  "GO-123123.",
+				Links: "https://example.com/CVE-2022-34667",
 			},
 			"6004": {
-				Description: "CVE-2024-9972 is here",
+				Name: "CVE-2024-9972",
 			},
 			"6005": {
-				Description: "CVE-2024-9986 is awesome",
+				Name: "CVE-2024-9986",
 			},
 		},
 	}

--- a/enricher/kev/kev.go
+++ b/enricher/kev/kev.go
@@ -206,7 +206,6 @@ func (e *Enricher) Enrich(ctx context.Context, g driver.EnrichmentGetter, r *cla
 		ctx := zlog.ContextWithValues(ctx, "vuln", v.Name)
 
 		for _, elem := range []string{
-			v.Description,
 			v.Name,
 			v.Links,
 		} {

--- a/enricher/kev/kev_test.go
+++ b/enricher/kev/kev_test.go
@@ -366,14 +366,16 @@ func TestEnrich(t *testing.T) {
 	r := &claircore.VulnerabilityReport{
 		Vulnerabilities: map[string]*claircore.Vulnerability{
 			"-1": {
-				Description: "This is a fake vulnerability that doesn't have a CVE.",
+				// Not a CVE
+				Name: "GO-007",
 			},
 			"6004": {
-				Description: "CVE-2021-44228 is here",
+				// Legitimate CVE
+				Name: "CVE-2021-44228 is here",
 			},
 			"6005": {
-				Description: "CVE-2017-3066 is awesome",
-				Links:       "CVE-2017-3066.com",
+				Name:  "GO-123123",
+				Links: "CVE-2017-3066.com",
 			},
 		},
 	}


### PR DESCRIPTION
Descriptions can often refer to different CVEs or multiple CVEs to the actual CVE that is associated to the vulnerability leading to erroneous scores. We should only consider the Name and Links fields.