### PR TITLE
rhel: don't add repo id to environment if repo isn't valid

### DIFF
--- a/rhel/coalescer.go
+++ b/rhel/coalescer.go
@@ -127,7 +127,9 @@ func (*Coalescer) Coalesce(ctx context.Context, artifacts []*indexer.LayerArtifa
 				}
 				v, _ := url.ParseQuery(pkg.RepositoryHint)
 				if id := v.Get("repoid"); id != "" {
-					environment.RepositoryIDs = v["repoid"]
+					if _, ok := ir.Repositories[id]; ok {
+						environment.RepositoryIDs = v["repoid"]
+					}
 				} else {
 					environment.RepositoryIDs = make([]string, len(layerArtifacts.Repos))
 					for i := range layerArtifacts.Repos {


### PR DESCRIPTION
There is a case where the repository information in the layer isn't valid and the repoid in the DNF DB doesn't refer to a valid Red Hat repo. In this case we don't associate the package to any repository. Previously this case would have meant the package would be associated to all repositories.