### PR TITLE
internal/dnf: handle unknown arch from rpmver

### DIFF
--- a/internal/dnf/dnf.go
+++ b/internal/dnf/dnf.go
@@ -263,6 +263,13 @@ func (h *historyDB) AddRepoid(ctx context.Context, pkg *claircore.Package) error
 			Msg("unable to re-parse rpm version")
 		return nil
 	}
+	if ver.Architecture == nil {
+		zlog.Debug(ctx).
+			Err(err).
+			Str("version", v).
+			Msg("unable to parse architecture")
+		return nil
+	}
 
 	var id string
 	err = h.db.


### PR DESCRIPTION
Don't try to unref nil Architecture, write debug message and silently move to the next package.