### PR TITLE
datastore: deleteManifests only log errors if there are any

### DIFF
--- a/datastore/postgres/deletemanifests.go
+++ b/datastore/postgres/deletemanifests.go
@@ -160,8 +160,9 @@ func (s *IndexerStore) DeleteManifests(ctx context.Context, ds ...claircore.Dige
 	if len(deletedManifests) == 0 {
 		err = errors.Join(errs...)
 		return nil, err
-	} else {
-		zlog.Info(ctx).
+	}
+	if len(errs) > 0 {
+		zlog.Warn(ctx).
 			Errs("reason", errs).
 			Msg("unexpected errors")
 	}


### PR DESCRIPTION
Previously this was an Info log and it would log even if there wasn't any errors, now it's a Warn that only logs if there are errors.
<a data-ca-tag href="https://codeapprove.com/pr/quay/claircore/1692"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>