### PR TITLE
chore: update mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,23 +1,35 @@
-Louis DeLosSantos <ldelossa@redhat.com> 
-Louis DeLosSantos <ldelossa@redhat.com> <ldelossa.ld@gmail.com>
-Louis DeLosSantos <ldelossa@redhat.com> <ldelossa@gmail.com>
-Louis DeLosSantos <ldelossa@redhat.com> <ldelossa@users.noreply.github.com>
-Louis DeLosSantos <ldelossa@redhat.com> <ldelossa@localhost.localdomain>
-Hank Donnay <hdonnay@redhat.com>
-Hank Donnay <hdonnay@redhat.com> <hdonnay@gmail.com>
-Hank Donnay <hdonnay@redhat.com> <hdonnay@users.noreply.github.com>
-Joseph Crosland <jcroslan@redhat.com>
-Joseph Crosland <jcroslan@redhat.com> <joseph.crosland@gmail.com>
-Joseph Crosland <jcroslan@redhat.com> <crozzy@users.noreply.github.com>
 Aleš Raszka <araszka@redhat.com>
 Aleš Raszka <araszka@redhat.com> <ales.raszka@gmail.com>
 Aleš Raszka <araszka@redhat.com> <Allda@users.noreply.github.com>
-Ross Tannenbaum <rtannenb@redhat.com>
-Ross Tannenbaum <rtannenb@redhat.com> <ross@stackrox.com>
-Yi Li <yli3@redhat.com>
-Paul Aldridge <paulaldridge@uk.ibm.com>
-Jamie Schenker <jamie.schenker@deutschebahn.com> <s_schenker@stud.hwr-berlin.de>
 Arunprasad Rajkumar <arajkuma@redhat.com>
 Arunprasad Rajkumar <arajkuma@redhat.com> <ar.arunprasad@gmail.com>
+Ashwin Hiranniah <ashwin-h@users.noreply.github.com>
+Ashwin Hiranniah <ashwin-h@users.noreply.github.com> <44602975+ashwin-h@users.noreply.github.com>
+Brad Lugo <blugo@redhat.com>
+Brad Lugo <blugo@redhat.com> <brad@bradlugo.com>
 dependabot[bot] <dependabot[bot]@users.noreply.github.com>
 dependabot[bot] <dependabot[bot]@users.noreply.github.com> <49699333+dependabot[bot]@users.noreply.github.com>
+Guspan Tanadi <guspan-tanadi@users.noreply.github.com>
+Guspan Tanadi <guspan-tanadi@users.noreply.github.com> <36249910+guspan-tanadi@users.noreply.github.com>
+Hank Donnay <hdonnay@redhat.com>
+Hank Donnay <hdonnay@redhat.com> <242672+hdonnay@users.noreply.github.com>
+Hank Donnay <hdonnay@redhat.com> <hdonnay@gmail.com>
+Hank Donnay <hdonnay@redhat.com> <hdonnay@users.noreply.github.com>
+Jamie Schenker <jamie.schenker@deutschebahn.com> <s_schenker@stud.hwr-berlin.de>
+Joseph Crosland <jcroslan@redhat.com>
+Joseph Crosland <jcroslan@redhat.com> <1027041+crozzy@users.noreply.github.com>
+Joseph Crosland <jcroslan@redhat.com> <crozzy@users.noreply.github.com>
+Joseph Crosland <jcroslan@redhat.com> <joseph.crosland@gmail.com>
+Louis DeLosSantos <ldelossa@redhat.com> 
+Louis DeLosSantos <ldelossa@redhat.com> <ldelossa@gmail.com>
+Louis DeLosSantos <ldelossa@redhat.com> <ldelossa.ld@gmail.com>
+Louis DeLosSantos <ldelossa@redhat.com> <ldelossa@localhost.localdomain>
+Louis DeLosSantos <ldelossa@redhat.com> <ldelossa@users.noreply.github.com>
+Mayur Waghmode <mayurwaghmode@users.noreply.github.com>
+Mayur Waghmode <mayurwaghmode@users.noreply.github.com> <42777188+mayurwaghmode@users.noreply.github.com>
+Paul Aldridge <paulaldridge@uk.ibm.com>
+Ross Tannenbaum <rtannenb@redhat.com>
+Ross Tannenbaum <rtannenb@redhat.com> <ross@stackrox.com>
+Sofya Tavrovskaya <stavrovska@mirantis.com>
+Yi Li <yli3@redhat.com>
+Yi Li <yli3@redhat.com> <liyi64125837@gmail.com>


### PR DESCRIPTION
I noticed the `git shortlog -sne` output was looking a little shaggy, so this fixes some duplicates and then sorts the whole file.
<a data-ca-tag href="https://codeapprove.com/pr/quay/claircore/1693"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>