### PR TITLE
rpm: close sqlite resources on the error path

### DIFF
--- a/internal/rpm/find.go
+++ b/internal/rpm/find.go
@@ -218,6 +218,12 @@ func OpenDB(ctx context.Context, sys fs.FS, found FoundDB) (*Database, error) {
 	case kindSQLite:
 		sdb, err := sqlite.Open(spool.Name())
 		if err != nil {
+			if err := spool.Close(); err != nil {
+				zlog.Warn(ctx).Err(err).Msg("unable to close spool")
+			}
+			if err := os.Remove(spool.Name()); err != nil {
+				zlog.Warn(ctx).Err(err).Msg("unable to remove spool")
+			}
 			return nil, fmt.Errorf("internal/rpm: unable to open sqlite db: %w", err)
 		}
 		db.headers = sdb

--- a/internal/rpm/sqlite/sqlite.go
+++ b/internal/rpm/sqlite/sqlite.go
@@ -45,6 +45,7 @@ func Open(f string) (*RPMDB, error) {
 		return nil, err
 	}
 	if err := db.Ping(); err != nil {
+		db.Close()
 		return nil, err
 	}
 	rdb := RPMDB{db: db}


### PR DESCRIPTION
It was observed in production that there was a goroutine leak, this was traced back to a database/sql.(*DB).connectionOpener+0x86 call and the rpm sqlite support. There is a case where the DB is open and the Ping() fails. This means there is no Close() issued, no spool file clean up and no finalizer supported added, so it's not caught in a panic.
<a data-ca-tag href="https://codeapprove.com/pr/quay/claircore/1694"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>