### PR TITLE
dnf: close sqlite resources on the error path

### DIFF
--- a/internal/dnf/dnf.go
+++ b/internal/dnf/dnf.go
@@ -180,7 +180,10 @@ Stat:
 		return nil, fmt.Errorf("internal/dnf: error reading sqlite db: %w", err)
 	}
 	if err := db.PingContext(ctx); err != nil {
-		return nil, fmt.Errorf("internal/dnf: error reading sqlite db: %w", err)
+		if err := db.Close(); err != nil {
+			zlog.Warn(ctx).Err(err).Msg("unable to close sqlite db")
+		}
+		return nil, fmt.Errorf("internal/dnf: error pinging sqlite db: %w", err)
 	}
 	queries, err := pickQueries(ctx, db)
 	if err != nil {


### PR DESCRIPTION
It was observed in production that there was a goroutine leak, this was traced back to a database/sql.(*DB).connectionOpener+0x86 call and the dnf sqlite support. There is a case where the DB is open and the PingContext() fails. This means there is no Close() issued and no finalizer supported added, so it's not caught in a panic.
<a data-ca-tag href="https://codeapprove.com/pr/quay/claircore/1696"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>