### PR TITLE
rhel: Fix error swallowing in PackageScanner

### DIFF
--- a/rhel/packagescanner.go
+++ b/rhel/packagescanner.go
@@ -34,7 +34,7 @@ func (p PackageScanner) Version() string { return "1" }
 //
 // This implementation stores additional information needed to correlate with
 // [claircore.Repository] values in the "RepositoryHint" field.
-func (p PackageScanner) Scan(ctx context.Context, layer *claircore.Layer) ([]*claircore.Package, error) {
+func (p PackageScanner) Scan(ctx context.Context, layer *claircore.Layer) (out []*claircore.Package, err error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -59,7 +59,6 @@ func (p PackageScanner) Scan(ctx context.Context, layer *claircore.Layer) ([]*cl
 	}
 	doDNFWrap = cm == nil || cm.FromDNFHint
 
-	var out []*claircore.Package
 	found, errFunc := rpm.FindDBs(ctx, sys)
 	defer func() {
 		err = errors.Join(err, errFunc())
@@ -99,5 +98,5 @@ func (p PackageScanner) Scan(ctx context.Context, layer *claircore.Layer) ([]*cl
 		}
 	}
 
-	return out, nil
+	return
 }


### PR DESCRIPTION
## Description

This PR fixes a bug in `rhel.PackageScanner.Scan` where filesystem walk errors from `rpm.FindDBs` were silently swallowed, causing the function to return `([], nil)` instead of propagating errors.

### Details

The function used unnamed return parameters with a defer that attempted to modify the error return value, however the code was returning explicit `nil`.

When `rpm.FindDBs()` encounters filesystem errors (real example: when zombie processes exist in the system and `FindDBs` traverses `/proc`, see [ROX-32459](https://issues.redhat.com/browse/ROX-32459)), the walk terminates early but the error is lost. This causes scanners to silently skip packages instead of reporting the error.

### Solution

Changed the function signature to use named return parameters, matching [the pattern](https://github.com/quay/claircore/blob/55081fbf6f890a528e0efc5ec8aa596dd842d024/rpm/packagescanner.go#L53) in `rpm.Scanner.Scan`.

## Testing

Built Stackrox's [roxagent](https://github.com/stackrox/stackrox/tree/master/compliance/virtualmachines/roxagent) with these changes and verified that it throws an error when the DB cannot be found due to filesystem-related errors, rather than silently skipping it and generating empty reports:

```log
virtualmachines/roxagent/cmd: 2025/12/30 09:16:11.966437 cmd.go:56: Error: Running indexer: creating index report: failed to run package scanner: failed to invoke RHEL scanner: readdirent proc/4703/net: invalid argument
```

<a data-ca-tag href="https://codeapprove.com/pr/quay/claircore/1715"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>