### PR TITLE
internal/httputil: include URL in error

### DIFF
--- a/internal/httputil/responsechecker.go
+++ b/internal/httputil/responsechecker.go
@@ -15,9 +15,9 @@ func CheckResponse(resp *http.Response, acceptableCodes ...int) error {
 	if !acceptable {
 		limitBody, err := io.ReadAll(io.LimitReader(resp.Body, 256))
 		if err == nil {
-			return fmt.Errorf("unexpected status code: %s (body starts: %q)", resp.Status, limitBody)
+			return fmt.Errorf("unexpected status code: %q for %q (body starts: %q)", resp.Status, resp.Request.URL.Redacted(), limitBody)
 		}
-		return fmt.Errorf("unexpected status code: %s", resp.Status)
+		return fmt.Errorf("unexpected status code: %q for %q", resp.Status, resp.Request.URL.Redacted())
 	}
 	return nil
 }

--- a/internal/httputil/responsechecker_test.go
+++ b/internal/httputil/responsechecker_test.go
@@ -24,7 +24,8 @@ func TestLimitedReadResponse(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error")
 	}
-	if err.Error() != "unexpected status code: 404 Not Found (body starts: \"Sorry this resource isn't available at the moment, please try again later when the resource might be available\")" {
-		t.Errorf("expected different error message but got: %s", err.Error())
+	wantErrMsg := `unexpected status code: "404 Not Found" for "` + svr.URL + `" (body starts: "Sorry this resource isn't available at the moment, please try again later when the resource might be available")`
+	if err.Error() != wantErrMsg {
+		t.Errorf("expected different error message, got: %q, want %q", err.Error(), wantErrMsg)
 	}
 }


### PR DESCRIPTION
Include the URL when request fails with an unexpected status code to provide more diagnostics.

Recently the rhel-vex updater was failing, but unclear why/where as the updater manager just logged:
`rhel-vex: unexpected response: unexpected status code: 404 Not Found (body starts: "<!DOCTYPE html><html ...etc...`

<a data-ca-tag href="https://codeapprove.com/pr/quay/claircore/1727"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>