### PR TITLE
libindex: fix `os.Remove` calls

### DIFF
--- a/libindex/fetcher.go
+++ b/libindex/fetcher.go
@@ -154,7 +154,7 @@ func (f closeFunc) Close() error {
 // Because we know we're the only concurrent call that's dealing with this blob,
 // we can be a bit more lax.
 func (a *RemoteFetchArena) fetchFileForCache(ctx context.Context, desc *claircore.LayerDescription) (*os.File, error) {
-	log := slog.With("arena", a.root, "layer", desc.Digest, "uri", desc.URI)
+	log := slog.With("arena", a.root.Name(), "layer", desc.Digest, "uri", desc.URI)
 	ctx, span := tracer.Start(ctx, "RemoteFetchArena.fetchUnlinkedFile")
 	defer span.End()
 	span.SetStatus(codes.Error, "")

--- a/libindex/tempfile_linux.go
+++ b/libindex/tempfile_linux.go
@@ -64,7 +64,7 @@ Loop:
 	if !tmpOK && err == nil {
 		// This is just a best-effort action to keep files from accumulating.
 		// The correct way is to use the kernel feature for this: the O_TMPFILE flag.
-		_ = os.Remove(f.Name())
+		_ = dir.Remove(f.Name())
 	}
 
 	if err != nil {

--- a/libindex/tempfile_unix.go
+++ b/libindex/tempfile_unix.go
@@ -23,6 +23,6 @@ func openTemp(dir *os.Root) (f *os.File, err error) {
 	if err != nil {
 		return nil, err
 	}
-	runtime.AddCleanup(f, func(n string) { os.Remove(n) }, f.Name())
+	runtime.AddCleanup(f, func(n string) { dir.Remove(n) }, f.Name())
 	return f, nil
 }


### PR DESCRIPTION
While thinking about #1728, I noticed that these are wrong and will probably subtly break things.
<a data-ca-tag href="https://codeapprove.com/pr/quay/claircore/1732"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>