### PR TITLE
rpm: check more paths for rpm-installed files

### DIFF
--- a/internal/rpm/info.go
+++ b/internal/rpm/info.go
@@ -223,15 +223,16 @@ var (
 	// FilePatterns is a regular expression for *any* file that may need to be
 	// recorded alongside a package.
 	//
-	// The tested strings are absolute paths.
+	// The tested strings are paths relative to the rpm root (almost always "/").
 	filePatterns = sync.OnceValue(func() *regexp.Regexp {
 		pat := []string{
 			`^.*/[^/]+\.[ejw]ar$`,                         // Jar files
 			`^.*/site-packages/[^/]+\.egg-info/PKG-INFO$`, // Python packages
 			`^.*/package.json$`,                           // npm packages
 			`^.*/[^/]+\.gemspec$`,                         // ruby gems
-			`^/usr/s?bin/[^/]+$`,                          // any executable
-			`^/usr/libexec/[^/]+/[^/]+$`,                  // sometimes the executables are here too
+			`^usr/s?bin/[^/]+$`,                           // any executable
+			`^usr/libexec/[^/]+/[^/]+$`,                   // sometimes the executables are here too
+			`^usr/lib/golang/(?:[^/]+/)+[^/]+$`,           // golang executables are here for some RH layers
 		}
 		return regexp.MustCompile(strings.Join(pat, `|`))
 	})


### PR DESCRIPTION
The function that checks if files were installed via RPMs gates the paths it considers with a regex, this regex was missing some binary paths that (when evaluated) don't contain a preceding slash. This also adds a path where the golang binaries are installed in some RH images.
<a data-ca-tag href="https://codeapprove.com/pr/quay/claircore/1733"><img src="https://codeapprove.com/external/github-tag-allbg.png" alt="Review on CodeApprove" /></a>