### PR TITLE
release: allow for branch protection in release steps

### DIFF
--- a/.github/scripts/prepare-release
+++ b/.github/scripts/prepare-release
@@ -38,6 +38,7 @@ gh run watch "${id}"
 cat <<.
 Now, to merge and release:
 
+	go to github and approve the PR titled "${VERSION} Changelog Bump" and wait for it to be merged.
 	git checkout ${BRANCH}
 	git fetch ${REMOTE}
 	git merge --ff-only ${REMOTE}/ready-${VERSION}


### PR DESCRIPTION
Since the introduction of the branch protection rule to stop users pushing directly to `main` the previous release steps started failing. This changes the instructions to require the user merges the changelog update before tagging the release.