### PR TITLE
fix(postgres): remove hardcoded public. schema prefix from GetEnrichment query

### DIFF
--- a/datastore/postgres/enrichment.go
+++ b/datastore/postgres/enrichment.go
@@ -235,7 +235,7 @@ select
 	tags,
 	data
 from
-	public.enrichment
+	enrichment
 where
 	tags && $2::text[] )
 select
@@ -243,9 +243,9 @@ select
 	e.data
 from
 	e
-join public.uo_enrich uo on
+join uo_enrich uo on
 	uo.enrich = e.id
-join public.latest_update_operations l on
+join latest_update_operations l on
 	l.id = uo.uo
 where
 	l.updater = $1


### PR DESCRIPTION
The GetEnrichment query in datastore/postgres/enrichment.go explicitly references public.enrichment, public.uo_enrich, and public.latest_update_operations, bypassing PostgreSQL's search_path resolution.

  All other queries in the same file use unqualified table names. This inconsistency causes SQLSTATE 42P01 errors when tables reside in a non-default schema (e.g. when search_path is configured at the database or role level).

  This change removes the public. prefix from the three table references, making GetEnrichment consistent with the rest of the codebase.

```
   -public.enrichment
   +enrichment

   -join public.uo_enrich uo on
   +join uo_enrich uo on

   -join public.latest_update_operations l on
   +join latest_update_operations l on
```

  Fixes issue #1777 