### PR TITLE
migrations: SQL formatting

### DIFF
--- a/datastore/postgres/migrations/indexer/01-init.sql
+++ b/datastore/postgres/migrations/indexer/01-init.sql
@@ -1,157 +1,183 @@
 --- Layer
 --- an identity table consisting of a content addressable layer hash
-CREATE TABLE IF NOT EXISTS layer (
-	hash text PRIMARY KEY
-);
+CREATE TABLE IF NOT EXISTS layer (hash text PRIMARY KEY);
 
 --- Manifest
 --- an identity table consisting of a content addressable manifest hash
-CREATE TABLE IF NOT EXISTS manifest (
-	hash text PRIMARY KEY
-);
+CREATE TABLE IF NOT EXISTS manifest (hash text PRIMARY KEY);
 
 --- ManifestLayer
 --- a many to many link table identifying the layers which comprise a manifest
 --- and the layer's ordering within a manifest
 CREATE TABLE IF NOT EXISTS manifest_layer (
-	manifest_hash text REFERENCES manifest(hash),
-	layer_hash text REFERENCES layer(hash),
-	i bigint,
-	PRIMARY KEY(manifest_hash, layer_hash, i)
+  manifest_hash text REFERENCES manifest (hash),
+  layer_hash text REFERENCES layer (hash),
+  i bigint,
+  PRIMARY KEY (manifest_hash, layer_hash, i)
 );
 
 --- Scanner
 --- a unique versioned scanner which is responsible
 --- for finding packages and distributions in a layer
 CREATE TABLE IF NOT EXISTS scanner (
-	id BIGSERIAL PRIMARY KEY,
-	name text NOT NULL,
-	version text NOT NULL,
-	kind text NOT NULL
+  id BIGSERIAL PRIMARY KEY,
+  name text NOT NULL,
+  version text NOT NULL,
+  kind text NOT NULL
 );
+
 CREATE UNIQUE INDEX IF NOT EXISTS scanner_unique_idx ON scanner (name, kind, version);
 
 --- ScannedManifest
 --- a relation to identify if a manifest was successfully scanned by a particular
 --- scanner
 CREATE TABLE IF NOT EXISTS scanned_manifest (
-	manifest_hash text REFERENCES manifest(hash),
-	scanner_id bigint REFERENCES scanner(id),
-	PRIMARY KEY(manifest_hash, scanner_id)
+  manifest_hash text REFERENCES manifest (hash),
+  scanner_id bigint REFERENCES scanner (id),
+  PRIMARY KEY (manifest_hash, scanner_id)
 );
 
 --- ScannedLayer
 --- a relation to identify if a layer was successfully scanned by a particular scanner
 CREATE TABLE IF NOT EXISTS scanned_layer (
-	layer_hash text REFERENCES layer(hash),
-	scanner_id bigint REFERENCES scanner(id),
-	PRIMARY KEY(layer_hash, scanner_id)
+  layer_hash text REFERENCES layer (hash),
+  scanner_id bigint REFERENCES scanner (id),
+  PRIMARY KEY (layer_hash, scanner_id)
 );
 
 --- ScannerList
 --- a relation informing us if a manifest hash has
 --- been scanned by a particular scanner
 CREATE TABLE IF NOT EXISTS scannerlist (
-	id BIGSERIAL PRIMARY KEY,
-	manifest_hash text,
-	scanner_id bigint REFERENCES scanner(id)
+  id BIGSERIAL PRIMARY KEY,
+  manifest_hash text,
+  scanner_id bigint REFERENCES scanner (id)
 );
+
 CREATE INDEX IF NOT EXISTS scannerlist_manifest_hash_idx ON scannerlist (manifest_hash);
 
 --- IndexReport
 --- the jsonb serialized result of a scan for a particular
 --- manifest
 CREATE TABLE IF NOT EXISTS indexreport (
-	manifest_hash text PRIMARY KEY REFERENCES manifest(hash),
-	state text,
-	scan_result jsonb
+  manifest_hash text PRIMARY KEY REFERENCES manifest (hash),
+  state text,
+  scan_result jsonb
 );
 
 -- Distribution
 --- a unique distribution discovered by a scanner
 CREATE TABLE IF NOT EXISTS dist (
-	id BIGSERIAL PRIMARY KEY,
-	name text NOT NULL DEFAULT '',
-	did text NOT NULL DEFAULT '', -- os-release id field
-	version text NOT NULL DEFAULT '',
-	version_code_name text NOT NULL DEFAULT '',
-	version_id text NOT NULL DEFAULT '',
-	arch text NOT NULL DEFAULT '',
-	cpe text NOT NULL DEFAULT '',
-	pretty_name text NOT NULL DEFAULT ''
+  id BIGSERIAL PRIMARY KEY,
+  name text NOT NULL DEFAULT '',
+  did text NOT NULL DEFAULT '', -- os-release id field
+  version text NOT NULL DEFAULT '',
+  version_code_name text NOT NULL DEFAULT '',
+  version_id text NOT NULL DEFAULT '',
+  arch text NOT NULL DEFAULT '',
+  cpe text NOT NULL DEFAULT '',
+  pretty_name text NOT NULL DEFAULT ''
 );
-CREATE UNIQUE INDEX IF NOT EXISTS dist_unique_idx ON dist (name, did, version, version_code_name, version_id, arch, cpe, pretty_name);
+
+CREATE UNIQUE INDEX IF NOT EXISTS dist_unique_idx ON dist (
+  name,
+  did,
+  version,
+  version_code_name,
+  version_id,
+  arch,
+  cpe,
+  pretty_name
+);
 
 --- DistributionScanArtifact
 --- A relation linking discovered distributions to a layer
 CREATE TABLE IF NOT EXISTS dist_scanartifact (
-	  dist_id bigint REFERENCES dist(id),
-	  scanner_id bigint REFERENCES scanner(id),
-	  layer_hash text REFERENCES layer(hash),
-	  PRIMARY KEY(dist_id, scanner_id, layer_hash)
+  dist_id bigint REFERENCES dist (id),
+  scanner_id bigint REFERENCES scanner (id),
+  layer_hash text REFERENCES layer (hash),
+  PRIMARY KEY (dist_id, scanner_id, layer_hash)
 );
-CREATE INDEX IF NOT EXISTS dist_scanartifact_lookup_idx ON dist_scanartifact(layer_hash);
+
+CREATE INDEX IF NOT EXISTS dist_scanartifact_lookup_idx ON dist_scanartifact (layer_hash);
 
 --- Package
 --- a unique package discovered by a scanner
 CREATE TABLE IF NOT EXISTS package (
-	id BIGSERIAL PRIMARY KEY,
-	name text NOT NULL,
-	kind text NOT NULL DEFAULT '',
-	version text NOT NULL DEFAULT '',
-	norm_kind text,
-	norm_version integer[10],
-	module text NOT NULL DEFAULT '',
-	arch text NOT NULL DEFAULT ''
+  id BIGSERIAL PRIMARY KEY,
+  name text NOT NULL,
+  kind text NOT NULL DEFAULT '',
+  version text NOT NULL DEFAULT '',
+  norm_kind text,
+  norm_version integer[10],
+  module text NOT NULL DEFAULT '',
+  arch text NOT NULL DEFAULT ''
 );
+
 CREATE UNIQUE INDEX IF NOT EXISTS package_unique_idx ON package (name, version, kind, module, arch);
 
 --- PackageScanArtifact
 --- A relation linking discovered packages with the
 --- layer hash it was found
 CREATE TABLE IF NOT EXISTS package_scanartifact (
-	   layer_hash text REFERENCES layer(hash),
-	   package_id bigint REFERENCES package(id),
-	   source_id bigint REFERENCES package(id),
-	   scanner_id bigint REFERENCES scanner(id),
-	   package_db text,
-	   repository_hint text,
-	   PRIMARY KEY(layer_hash, package_id, source_id, scanner_id, package_db, repository_hint)
+  layer_hash text REFERENCES layer (hash),
+  package_id bigint REFERENCES package (id),
+  source_id bigint REFERENCES package (id),
+  scanner_id bigint REFERENCES scanner (id),
+  package_db text,
+  repository_hint text,
+  PRIMARY KEY (
+    layer_hash,
+    package_id,
+    source_id,
+    scanner_id,
+    package_db,
+    repository_hint
+  )
 );
-CREATE INDEX IF NOT EXISTS package_scanartifact_lookup_idx ON package_scanartifact(layer_hash);
+
+CREATE INDEX IF NOT EXISTS package_scanartifact_lookup_idx ON package_scanartifact (layer_hash);
 
 --- Repository
 --- a unique package repository discovered by a scanner
 CREATE TABLE IF NOT EXISTS repo (
-	id BIGSERIAL PRIMARY KEY,
-	name text NOT NULL,
-	key text DEFAULT '',
-	uri text DEFAULT '',
-	cpe text DEFAULT ''
+  id BIGSERIAL PRIMARY KEY,
+  name text NOT NULL,
+  key text DEFAULT '',
+  uri text DEFAULT '',
+  cpe text DEFAULT ''
 );
+
 CREATE UNIQUE INDEX IF NOT EXISTS repo_unique_idx ON repo (name, key, uri);
 
 --- RepositoryScanArtifact
 --- A relation linking discovered distributions to a layer
 CREATE TABLE IF NOT EXISTS repo_scanartifact (
-	repo_id bigint REFERENCES repo(id),
-	scanner_id bigint REFERENCES scanner(id),
-	layer_hash text REFERENCES layer(hash),
-	PRIMARY KEY(repo_id, scanner_id, layer_hash)
+  repo_id bigint REFERENCES repo (id),
+  scanner_id bigint REFERENCES scanner (id),
+  layer_hash text REFERENCES layer (hash),
+  PRIMARY KEY (repo_id, scanner_id, layer_hash)
 );
-CREATE INDEX IF NOT EXISTS repo_scanartifact_lookup_idx ON repo_scanartifact(layer_hash);
+
+CREATE INDEX IF NOT EXISTS repo_scanartifact_lookup_idx ON repo_scanartifact (layer_hash);
 
 --- ManifestIndex
 --- A searchable index of a coalesced manifest's content.
 --- a package id is required.
 --- either a dist_id or a repo_id maybe null, but not both
-CREATE TABLE IF NOT EXISTS manifest_index
-(
-	id            bigserial PRIMARY KEY,
-	package_id    bigint NOT NULL REFERENCES package (id),
-	dist_id       bigint REFERENCES dist (id),
-	repo_id       bigint REFERENCES repo (id),
-	manifest_hash text REFERENCES manifest (hash)
+CREATE TABLE IF NOT EXISTS manifest_index (
+  id bigserial PRIMARY KEY,
+  package_id bigint NOT NULL REFERENCES package (id),
+  dist_id bigint REFERENCES dist (id),
+  repo_id bigint REFERENCES repo (id),
+  manifest_hash text REFERENCES manifest (hash)
 );
+
 CREATE INDEX IF NOT EXISTS manifest_index_hash_lookup_idx ON manifest_index (manifest_hash);
-CREATE UNIQUE INDEX manifest_index_unique ON manifest_index (package_id, COALESCE(dist_id, 0), COALESCE(repo_id, 0), manifest_hash);
+
+CREATE UNIQUE INDEX manifest_index_unique ON manifest_index (
+  package_id,
+  COALESCE(dist_id, 0),
+  COALESCE(repo_id, 0),
+  manifest_hash
+);

--- a/datastore/postgres/migrations/indexer/02-digests.sql
+++ b/datastore/postgres/migrations/indexer/02-digests.sql
@@ -1,98 +1,278 @@
 /* First lets drop all the foreign key constraints so we can
-   work with the manifest and layer tables without dependencies */
-ALTER TABLE dist_scanartifact DROP CONSTRAINT dist_scanartifact_layer_hash_fkey;
-ALTER TABLE indexreport DROP CONSTRAINT indexreport_manifest_hash_fkey;
-ALTER TABLE manifest_index DROP CONSTRAINT manifest_index_manifest_hash_fkey;
-ALTER TABLE manifest_layer DROP CONSTRAINT manifest_layer_layer_hash_fkey;
-ALTER TABLE manifest_layer DROP CONSTRAINT manifest_layer_manifest_hash_fkey;
-ALTER TABLE package_scanartifact DROP CONSTRAINT package_scanartifact_layer_hash_fkey;
-ALTER TABLE repo_scanartifact DROP CONSTRAINT repo_scanartifact_layer_hash_fkey;
-ALTER TABLE scanned_layer DROP CONSTRAINT scanned_layer_layer_hash_fkey;
-ALTER TABLE scanned_manifest DROP CONSTRAINT scanned_manifest_manifest_hash_fkey;
+work with the manifest and layer tables without dependencies */
+ALTER TABLE dist_scanartifact
+DROP CONSTRAINT dist_scanartifact_layer_hash_fkey;
 
+ALTER TABLE indexreport
+DROP CONSTRAINT indexreport_manifest_hash_fkey;
+
+ALTER TABLE manifest_index
+DROP CONSTRAINT manifest_index_manifest_hash_fkey;
+
+ALTER TABLE manifest_layer
+DROP CONSTRAINT manifest_layer_layer_hash_fkey;
+
+ALTER TABLE manifest_layer
+DROP CONSTRAINT manifest_layer_manifest_hash_fkey;
+
+ALTER TABLE package_scanartifact
+DROP CONSTRAINT package_scanartifact_layer_hash_fkey;
+
+ALTER TABLE repo_scanartifact
+DROP CONSTRAINT repo_scanartifact_layer_hash_fkey;
+
+ALTER TABLE scanned_layer
+DROP CONSTRAINT scanned_layer_layer_hash_fkey;
+
+ALTER TABLE scanned_manifest
+DROP CONSTRAINT scanned_manifest_manifest_hash_fkey;
 
 /* next lets alter the manifest and layer tables
-   - add bigserial id columns to layer and manifest tables
-   - drop existing primary key and add the id as primary key for both tables
-   - add unique constraints on hash so duplicate layers and manifest hashes are not allowed
- */
-ALTER TABLE manifest ADD COLUMN id bigserial;
-ALTER TABLE layer ADD COLUMN id bigserial;
+- add bigserial id columns to layer and manifest tables
+- drop existing primary key and add the id as primary key for both tables
+- add unique constraints on hash so duplicate layers and manifest hashes are not allowed
+*/
+ALTER TABLE manifest
+ADD COLUMN id bigserial;
 
-ALTER TABLE manifest DROP CONSTRAINT manifest_pkey;
-ALTER TABLE manifest ADD PRIMARY KEY (id);
-CREATE INDEX ON manifest(hash);
-ALTER TABLE layer DROP CONSTRAINT layer_pkey;
-ALTER TABLE layer ADD PRIMARY KEY (id);
-CREATE INDEX ON layer(hash);
+ALTER TABLE layer
+ADD COLUMN id bigserial;
 
-ALTER TABLE manifest ADD CONSTRAINT manifest_hash_unique UNIQUE (hash);
-ALTER TABLE layer ADD CONSTRAINT layer_hash_unique UNIQUE (hash);
+ALTER TABLE manifest
+DROP CONSTRAINT manifest_pkey;
+
+ALTER TABLE manifest
+ADD PRIMARY KEY (id);
+
+CREATE INDEX ON manifest (hash);
+
+ALTER TABLE layer
+DROP CONSTRAINT layer_pkey;
+
+ALTER TABLE layer
+ADD PRIMARY KEY (id);
+
+CREATE INDEX ON layer (hash);
+
+ALTER TABLE manifest
+ADD CONSTRAINT manifest_hash_unique UNIQUE (hash);
+
+ALTER TABLE layer
+ADD CONSTRAINT layer_hash_unique UNIQUE (hash);
 
 /* next for each table with a foreign key to layer or manifest table:
-   - create the layer or manifest id column
-   - create new foreign key relationships that replace the hash strings
-   - insert layer and manifest ids into new columns*/
-ALTER TABLE dist_scanartifact ADD COLUMN layer_id bigint;
-ALTER TABLE dist_scanartifact ADD FOREIGN KEY (layer_id) REFERENCES layer(id);
-UPDATE dist_scanartifact AS ds SET layer_id = (SELECT id FROM layer WHERE hash = ds.layer_hash);
+- create the layer or manifest id column
+- create new foreign key relationships that replace the hash strings
+- insert layer and manifest ids into new columns*/
+ALTER TABLE dist_scanartifact
+ADD COLUMN layer_id bigint;
 
-ALTER TABLE indexreport ADD COLUMN manifest_id bigint;
-ALTER TABLE indexreport ADD FOREIGN KEY (manifest_id) REFERENCES manifest(id);
-UPDATE indexreport AS ir SET manifest_id = (SELECT id FROM manifest WHERE hash = ir.manifest_hash);
+ALTER TABLE dist_scanartifact
+ADD FOREIGN KEY (layer_id) REFERENCES layer (id);
 
-ALTER TABLE manifest_index ADD COLUMN manifest_id bigint;
-ALTER TABLE manifest_index ADD FOREIGN KEY (manifest_id) REFERENCES manifest(id);
-UPDATE manifest_index AS r SET manifest_id = (SELECT id FROM manifest WHERE hash = r.manifest_hash);
+UPDATE dist_scanartifact AS ds
+SET
+  layer_id = (
+    SELECT
+      id
+    FROM
+      layer
+    WHERE
+      hash = ds.layer_hash
+  );
 
-ALTER TABLE manifest_layer ADD COLUMN manifest_id bigint;
-ALTER TABLE manifest_layer ADD FOREIGN KEY (manifest_id) REFERENCES manifest(id);
-UPDATE manifest_layer AS ml SET manifest_id = (SELECT id FROM manifest WHERE hash = ml.manifest_hash);
+ALTER TABLE indexreport
+ADD COLUMN manifest_id bigint;
 
-ALTER TABLE manifest_layer ADD COLUMN layer_id bigint;
-ALTER TABLE manifest_layer ADD FOREIGN KEY (layer_id) REFERENCES layer(id);
-UPDATE manifest_layer AS ml SET layer_id = (SELECT id FROM layer WHERE hash = ml.layer_hash);
+ALTER TABLE indexreport
+ADD FOREIGN KEY (manifest_id) REFERENCES manifest (id);
 
-ALTER TABLE package_scanartifact ADD COLUMN layer_id bigint;
-ALTER TABLE package_scanartifact ADD FOREIGN KEY (layer_id) REFERENCES layer(id);
-UPDATE package_scanartifact AS r SET layer_id = (SELECT id FROM layer WHERE hash = r.layer_hash);
+UPDATE indexreport AS ir
+SET
+  manifest_id = (
+    SELECT
+      id
+    FROM
+      manifest
+    WHERE
+      hash = ir.manifest_hash
+  );
 
-ALTER TABLE repo_scanartifact ADD COLUMN layer_id bigint;
-ALTER TABLE repo_scanartifact ADD FOREIGN KEY (layer_id) REFERENCES layer(id);
-UPDATE repo_scanartifact AS r SET layer_id = (SELECT id FROM layer WHERE hash = r.layer_hash);
+ALTER TABLE manifest_index
+ADD COLUMN manifest_id bigint;
 
-ALTER TABLE scanned_layer ADD COLUMN layer_id bigint;
-ALTER TABLE scanned_layer ADD FOREIGN KEY (layer_id) REFERENCES layer(id);
-UPDATE scanned_layer AS r SET layer_id = (SELECT id FROM layer WHERE hash = r.layer_hash);
+ALTER TABLE manifest_index
+ADD FOREIGN KEY (manifest_id) REFERENCES manifest (id);
 
-ALTER TABLE scanned_manifest ADD COLUMN manifest_id bigint;
-ALTER TABLE scanned_manifest ADD FOREIGN KEY (manifest_id) REFERENCES manifest(id);
-UPDATE scanned_manifest AS r SET manifest_id = (SELECT id FROM manifest WHERE hash = r.manifest_hash);
+UPDATE manifest_index AS r
+SET
+  manifest_id = (
+    SELECT
+      id
+    FROM
+      manifest
+    WHERE
+      hash = r.manifest_hash
+  );
+
+ALTER TABLE manifest_layer
+ADD COLUMN manifest_id bigint;
+
+ALTER TABLE manifest_layer
+ADD FOREIGN KEY (manifest_id) REFERENCES manifest (id);
+
+UPDATE manifest_layer AS ml
+SET
+  manifest_id = (
+    SELECT
+      id
+    FROM
+      manifest
+    WHERE
+      hash = ml.manifest_hash
+  );
+
+ALTER TABLE manifest_layer
+ADD COLUMN layer_id bigint;
+
+ALTER TABLE manifest_layer
+ADD FOREIGN KEY (layer_id) REFERENCES layer (id);
+
+UPDATE manifest_layer AS ml
+SET
+  layer_id = (
+    SELECT
+      id
+    FROM
+      layer
+    WHERE
+      hash = ml.layer_hash
+  );
+
+ALTER TABLE package_scanartifact
+ADD COLUMN layer_id bigint;
+
+ALTER TABLE package_scanartifact
+ADD FOREIGN KEY (layer_id) REFERENCES layer (id);
+
+UPDATE package_scanartifact AS r
+SET
+  layer_id = (
+    SELECT
+      id
+    FROM
+      layer
+    WHERE
+      hash = r.layer_hash
+  );
+
+ALTER TABLE repo_scanartifact
+ADD COLUMN layer_id bigint;
+
+ALTER TABLE repo_scanartifact
+ADD FOREIGN KEY (layer_id) REFERENCES layer (id);
+
+UPDATE repo_scanartifact AS r
+SET
+  layer_id = (
+    SELECT
+      id
+    FROM
+      layer
+    WHERE
+      hash = r.layer_hash
+  );
+
+ALTER TABLE scanned_layer
+ADD COLUMN layer_id bigint;
+
+ALTER TABLE scanned_layer
+ADD FOREIGN KEY (layer_id) REFERENCES layer (id);
+
+UPDATE scanned_layer AS r
+SET
+  layer_id = (
+    SELECT
+      id
+    FROM
+      layer
+    WHERE
+      hash = r.layer_hash
+  );
+
+ALTER TABLE scanned_manifest
+ADD COLUMN manifest_id bigint;
+
+ALTER TABLE scanned_manifest
+ADD FOREIGN KEY (manifest_id) REFERENCES manifest (id);
+
+UPDATE scanned_manifest AS r
+SET
+  manifest_id = (
+    SELECT
+      id
+    FROM
+      manifest
+    WHERE
+      hash = r.manifest_hash
+  );
 
 /* next for each table with with a manifest or layer hash column
-   - drop the string column
-   - optionally (re)create indexes */
-ALTER TABLE dist_scanartifact DROP COLUMN layer_hash;
-ALTER TABLE dist_scanartifact ADD PRIMARY KEY (layer_id, scanner_id, dist_id);
+- drop the string column
+- optionally (re)create indexes */
+ALTER TABLE dist_scanartifact
+DROP COLUMN layer_hash;
 
-ALTER TABLE indexreport DROP COLUMN manifest_hash;
-ALTER TABLE indexreport ADD PRIMARY KEY (manifest_id);
+ALTER TABLE dist_scanartifact
+ADD PRIMARY KEY (layer_id, scanner_id, dist_id);
 
-ALTER TABLE manifest_index DROP COLUMN manifest_hash;
-CREATE INDEX ON manifest_index(manifest_id, package_id, dist_id, repo_id);
+ALTER TABLE indexreport
+DROP COLUMN manifest_hash;
 
-ALTER TABLE manifest_layer DROP COLUMN manifest_hash;
-ALTER TABLE manifest_layer DROP COLUMN layer_hash;
-ALTER TABLE manifest_layer ADD PRIMARY KEY (manifest_id, layer_id, i);
+ALTER TABLE indexreport
+ADD PRIMARY KEY (manifest_id);
 
-ALTER TABLE package_scanartifact DROP COLUMN layer_hash;
-ALTER TABLE package_scanartifact ADD PRIMARY KEY (layer_id, package_id, source_id, scanner_id, package_db, repository_hint);
+ALTER TABLE manifest_index
+DROP COLUMN manifest_hash;
 
-ALTER TABLE repo_scanartifact DROP COLUMN layer_hash;
-ALTER TABLE repo_scanartifact ADD PRIMARY KEY (layer_id, repo_id, scanner_id);
+CREATE INDEX ON manifest_index (manifest_id, package_id, dist_id, repo_id);
 
-ALTER TABLE scanned_layer DROP COLUMN layer_hash;
-ALTER TABLE scanned_layer ADD PRIMARY KEY (layer_id, scanner_id);
+ALTER TABLE manifest_layer
+DROP COLUMN manifest_hash;
 
-ALTER TABLE scanned_manifest DROP COLUMN manifest_hash;
-ALTER TABLE scanned_manifest ADD PRIMARY KEY (manifest_id, scanner_id)
+ALTER TABLE manifest_layer
+DROP COLUMN layer_hash;
+
+ALTER TABLE manifest_layer
+ADD PRIMARY KEY (manifest_id, layer_id, i);
+
+ALTER TABLE package_scanartifact
+DROP COLUMN layer_hash;
+
+ALTER TABLE package_scanartifact
+ADD PRIMARY KEY (
+  layer_id,
+  package_id,
+  source_id,
+  scanner_id,
+  package_db,
+  repository_hint
+);
+
+ALTER TABLE repo_scanartifact
+DROP COLUMN layer_hash;
+
+ALTER TABLE repo_scanartifact
+ADD PRIMARY KEY (layer_id, repo_id, scanner_id);
+
+ALTER TABLE scanned_layer
+DROP COLUMN layer_hash;
+
+ALTER TABLE scanned_layer
+ADD PRIMARY KEY (layer_id, scanner_id);
+
+ALTER TABLE scanned_manifest
+DROP COLUMN manifest_hash;
+
+ALTER TABLE scanned_manifest
+ADD PRIMARY KEY (manifest_id, scanner_id)

--- a/datastore/postgres/migrations/indexer/03-unique-manifest_index.sql
+++ b/datastore/postgres/migrations/indexer/03-unique-manifest_index.sql
@@ -7,7 +7,16 @@
 --
 -- Index reports will still be served without a re-index being necessary.
 LOCK manifest_index;
+
 LOCK scanned_manifest;
+
 TRUNCATE manifest_index;
+
 TRUNCATE scanned_manifest;
-CREATE UNIQUE INDEX manifest_index_unique ON manifest_index (package_id, COALESCE(dist_id, 0), COALESCE(repo_id, 0), manifest_id);
+
+CREATE UNIQUE INDEX manifest_index_unique ON manifest_index (
+  package_id,
+  COALESCE(dist_id, 0),
+  COALESCE(repo_id, 0),
+  manifest_id
+);

--- a/datastore/postgres/migrations/indexer/04-foreign-key-cascades.sql
+++ b/datastore/postgres/migrations/indexer/04-foreign-key-cascades.sql
@@ -1,165 +1,133 @@
 -- Add CASADEs on all foreign-key relations.
 -- This makes deleting manifests and layers much simpler.
 ALTER TABLE indexreport
-	DROP CONSTRAINT indexreport_manifest_id_fkey;
+DROP CONSTRAINT indexreport_manifest_id_fkey;
+
 ALTER TABLE indexreport
-	ADD CONSTRAINT indexreport_manifest_id_fkey
-	FOREIGN KEY (manifest_id)
-	REFERENCES manifest(id)
-	ON DELETE CASCADE;
+ADD CONSTRAINT indexreport_manifest_id_fkey FOREIGN KEY (manifest_id) REFERENCES manifest (id) ON DELETE CASCADE;
 
 ALTER TABLE dist_scanartifact
-	DROP CONSTRAINT dist_scanartifact_dist_id_fkey;
+DROP CONSTRAINT dist_scanartifact_dist_id_fkey;
+
 ALTER TABLE dist_scanartifact
-	ADD CONSTRAINT dist_scanartifact_dist_id_fkey
-	FOREIGN KEY (dist_id)
-	REFERENCES dist(id)
-	ON DELETE CASCADE;
+ADD CONSTRAINT dist_scanartifact_dist_id_fkey FOREIGN KEY (dist_id) REFERENCES dist (id) ON DELETE CASCADE;
+
 ALTER TABLE dist_scanartifact
-	DROP CONSTRAINT dist_scanartifact_layer_id_fkey;
+DROP CONSTRAINT dist_scanartifact_layer_id_fkey;
+
 ALTER TABLE dist_scanartifact
-	ADD CONSTRAINT dist_scanartifact_layer_id_fkey
-	FOREIGN KEY (layer_id)
-	REFERENCES layer(id)
-	ON DELETE CASCADE;
+ADD CONSTRAINT dist_scanartifact_layer_id_fkey FOREIGN KEY (layer_id) REFERENCES layer (id) ON DELETE CASCADE;
+
 ALTER TABLE dist_scanartifact
-	DROP CONSTRAINT dist_scanartifact_scanner_id_fkey;
+DROP CONSTRAINT dist_scanartifact_scanner_id_fkey;
+
 ALTER TABLE dist_scanartifact
-	ADD CONSTRAINT dist_scanartifact_scanner_id_fkey
-	FOREIGN KEY (scanner_id)
-	REFERENCES scanner(id)
-	ON DELETE CASCADE;
+ADD CONSTRAINT dist_scanartifact_scanner_id_fkey FOREIGN KEY (scanner_id) REFERENCES scanner (id) ON DELETE CASCADE;
 
 ALTER TABLE manifest_index
-	DROP CONSTRAINT manifest_index_dist_id_fkey;
+DROP CONSTRAINT manifest_index_dist_id_fkey;
+
 ALTER TABLE manifest_index
-	ADD CONSTRAINT manifest_index_dist_id_fkey
-	FOREIGN KEY (dist_id)
-	REFERENCES dist(id)
-	ON DELETE CASCADE;
+ADD CONSTRAINT manifest_index_dist_id_fkey FOREIGN KEY (dist_id) REFERENCES dist (id) ON DELETE CASCADE;
+
 ALTER TABLE manifest_index
-	DROP CONSTRAINT manifest_index_manifest_id_fkey;
+DROP CONSTRAINT manifest_index_manifest_id_fkey;
+
 ALTER TABLE manifest_index
-	ADD CONSTRAINT manifest_index_manifest_id_fkey
-	FOREIGN KEY (manifest_id)
-	REFERENCES manifest(id)
-	ON DELETE CASCADE;
+ADD CONSTRAINT manifest_index_manifest_id_fkey FOREIGN KEY (manifest_id) REFERENCES manifest (id) ON DELETE CASCADE;
+
 ALTER TABLE manifest_index
-	DROP CONSTRAINT manifest_index_package_id_fkey;
+DROP CONSTRAINT manifest_index_package_id_fkey;
+
 ALTER TABLE manifest_index
-	ADD CONSTRAINT manifest_index_package_id_fkey
-	FOREIGN KEY (package_id)
-	REFERENCES package(id)
-	ON DELETE CASCADE;
+ADD CONSTRAINT manifest_index_package_id_fkey FOREIGN KEY (package_id) REFERENCES package (id) ON DELETE CASCADE;
+
 ALTER TABLE manifest_index
-	DROP CONSTRAINT manifest_index_repo_id_fkey;
+DROP CONSTRAINT manifest_index_repo_id_fkey;
+
 ALTER TABLE manifest_index
-	ADD CONSTRAINT manifest_index_repo_id_fkey
-	FOREIGN KEY (repo_id)
-	REFERENCES repo(id)
-	ON DELETE CASCADE;
+ADD CONSTRAINT manifest_index_repo_id_fkey FOREIGN KEY (repo_id) REFERENCES repo (id) ON DELETE CASCADE;
 
 ALTER TABLE manifest_layer
-	DROP CONSTRAINT manifest_layer_layer_id_fkey;
+DROP CONSTRAINT manifest_layer_layer_id_fkey;
+
 ALTER TABLE manifest_layer
-	ADD CONSTRAINT manifest_layer_layer_id_fkey
-	FOREIGN KEY (layer_id)
-	REFERENCES layer(id)
-	ON DELETE CASCADE;
+ADD CONSTRAINT manifest_layer_layer_id_fkey FOREIGN KEY (layer_id) REFERENCES layer (id) ON DELETE CASCADE;
+
 ALTER TABLE manifest_layer
-	DROP CONSTRAINT manifest_layer_manifest_id_fkey;
+DROP CONSTRAINT manifest_layer_manifest_id_fkey;
+
 ALTER TABLE manifest_layer
-	ADD CONSTRAINT manifest_layer_manifest_id_fkey
-	FOREIGN KEY (manifest_id)
-	REFERENCES manifest(id)
-	ON DELETE CASCADE;
+ADD CONSTRAINT manifest_layer_manifest_id_fkey FOREIGN KEY (manifest_id) REFERENCES manifest (id) ON DELETE CASCADE;
 
 ALTER TABLE package_scanartifact
-	DROP CONSTRAINT package_scanartifact_layer_id_fkey;
+DROP CONSTRAINT package_scanartifact_layer_id_fkey;
+
 ALTER TABLE package_scanartifact
-	ADD CONSTRAINT package_scanartifact_layer_id_fkey
-	FOREIGN KEY (layer_id)
-	REFERENCES layer(id)
-	ON DELETE CASCADE;
+ADD CONSTRAINT package_scanartifact_layer_id_fkey FOREIGN KEY (layer_id) REFERENCES layer (id) ON DELETE CASCADE;
+
 ALTER TABLE package_scanartifact
-	DROP CONSTRAINT package_scanartifact_package_id_fkey;
+DROP CONSTRAINT package_scanartifact_package_id_fkey;
+
 ALTER TABLE package_scanartifact
-	ADD CONSTRAINT package_scanartifact_package_id_fkey
-	FOREIGN KEY (package_id)
-	REFERENCES package(id)
-	ON DELETE CASCADE;
+ADD CONSTRAINT package_scanartifact_package_id_fkey FOREIGN KEY (package_id) REFERENCES package (id) ON DELETE CASCADE;
+
 ALTER TABLE package_scanartifact
-	DROP CONSTRAINT package_scanartifact_scanner_id_fkey;
+DROP CONSTRAINT package_scanartifact_scanner_id_fkey;
+
 ALTER TABLE package_scanartifact
-	ADD CONSTRAINT package_scanartifact_scanner_id_fkey
-	FOREIGN KEY (scanner_id)
-	REFERENCES scanner(id)
-	ON DELETE CASCADE;
+ADD CONSTRAINT package_scanartifact_scanner_id_fkey FOREIGN KEY (scanner_id) REFERENCES scanner (id) ON DELETE CASCADE;
+
 ALTER TABLE package_scanartifact
-	DROP CONSTRAINT package_scanartifact_source_id_fkey;
+DROP CONSTRAINT package_scanartifact_source_id_fkey;
+
 ALTER TABLE package_scanartifact
-	ADD CONSTRAINT package_scanartifact_source_id_fkey
-	FOREIGN KEY (package_id)
-	REFERENCES package(id)
-	ON DELETE CASCADE;
+ADD CONSTRAINT package_scanartifact_source_id_fkey FOREIGN KEY (package_id) REFERENCES package (id) ON DELETE CASCADE;
 
 ALTER TABLE repo_scanartifact
-	DROP CONSTRAINT repo_scanartifact_layer_id_fkey;
+DROP CONSTRAINT repo_scanartifact_layer_id_fkey;
+
 ALTER TABLE repo_scanartifact
-	ADD CONSTRAINT repo_scanartifact_layer_id_fkey
-	FOREIGN KEY (layer_id)
-	REFERENCES layer(id)
-	ON DELETE CASCADE;
+ADD CONSTRAINT repo_scanartifact_layer_id_fkey FOREIGN KEY (layer_id) REFERENCES layer (id) ON DELETE CASCADE;
+
 ALTER TABLE repo_scanartifact
-	DROP CONSTRAINT repo_scanartifact_repo_id_fkey;
+DROP CONSTRAINT repo_scanartifact_repo_id_fkey;
+
 ALTER TABLE repo_scanartifact
-	ADD CONSTRAINT repo_scanartifact_repo_id_fkey
-	FOREIGN KEY (repo_id)
-	REFERENCES repo(id)
-	ON DELETE CASCADE;
+ADD CONSTRAINT repo_scanartifact_repo_id_fkey FOREIGN KEY (repo_id) REFERENCES repo (id) ON DELETE CASCADE;
+
 ALTER TABLE repo_scanartifact
-	DROP CONSTRAINT repo_scanartifact_scanner_id_fkey;
+DROP CONSTRAINT repo_scanartifact_scanner_id_fkey;
+
 ALTER TABLE repo_scanartifact
-	ADD CONSTRAINT repo_scanartifact_scanner_id_fkey
-	FOREIGN KEY (scanner_id)
-	REFERENCES scanner(id)
-	ON DELETE CASCADE;
+ADD CONSTRAINT repo_scanartifact_scanner_id_fkey FOREIGN KEY (scanner_id) REFERENCES scanner (id) ON DELETE CASCADE;
 
 ALTER TABLE scanned_layer
-	DROP CONSTRAINT scanned_layer_layer_id_fkey;
+DROP CONSTRAINT scanned_layer_layer_id_fkey;
+
 ALTER TABLE scanned_layer
-	ADD CONSTRAINT scanned_layer_layer_id_fkey
-	FOREIGN KEY (layer_id)
-	REFERENCES layer(id)
-	ON DELETE CASCADE;
+ADD CONSTRAINT scanned_layer_layer_id_fkey FOREIGN KEY (layer_id) REFERENCES layer (id) ON DELETE CASCADE;
+
 ALTER TABLE scanned_layer
-	DROP CONSTRAINT scanned_layer_scanner_id_fkey;
+DROP CONSTRAINT scanned_layer_scanner_id_fkey;
+
 ALTER TABLE scanned_layer
-	ADD CONSTRAINT scanned_layer_scanner_id_fkey
-	FOREIGN KEY (scanner_id)
-	REFERENCES scanner(id)
-	ON DELETE CASCADE;
+ADD CONSTRAINT scanned_layer_scanner_id_fkey FOREIGN KEY (scanner_id) REFERENCES scanner (id) ON DELETE CASCADE;
 
 ALTER TABLE scanned_manifest
-	DROP CONSTRAINT scanned_manifest_manifest_id_fkey;
+DROP CONSTRAINT scanned_manifest_manifest_id_fkey;
+
 ALTER TABLE scanned_manifest
-	ADD CONSTRAINT scanned_manifest_manifest_id_fkey
-	FOREIGN KEY (manifest_id)
-	REFERENCES manifest(id)
-	ON DELETE CASCADE;
+ADD CONSTRAINT scanned_manifest_manifest_id_fkey FOREIGN KEY (manifest_id) REFERENCES manifest (id) ON DELETE CASCADE;
+
 ALTER TABLE scanned_manifest
-	DROP CONSTRAINT scanned_manifest_scanner_id_fkey;
+DROP CONSTRAINT scanned_manifest_scanner_id_fkey;
+
 ALTER TABLE scanned_manifest
-	ADD CONSTRAINT scanned_manifest_scanner_id_fkey
-	FOREIGN KEY (scanner_id)
-	REFERENCES scanner(id)
-	ON DELETE CASCADE;
+ADD CONSTRAINT scanned_manifest_scanner_id_fkey FOREIGN KEY (scanner_id) REFERENCES scanner (id) ON DELETE CASCADE;
 
 ALTER TABLE scannerlist
-	DROP CONSTRAINT scannerlist_scanner_id_fkey;
-ALTER TABLE scannerlist
-	ADD CONSTRAINT scannerlist_scanner_id_fkey
-	FOREIGN KEY (scanner_id)
-	REFERENCES scanner(id)
-	ON DELETE CASCADE;
+DROP CONSTRAINT scannerlist_scanner_id_fkey;
 
+ALTER TABLE scannerlist
+ADD CONSTRAINT scannerlist_scanner_id_fkey FOREIGN KEY (scanner_id) REFERENCES scanner (id) ON DELETE CASCADE;

--- a/datastore/postgres/migrations/indexer/06-file-artifacts.sql
+++ b/datastore/postgres/migrations/indexer/06-file-artifacts.sql
@@ -1,18 +1,20 @@
 -- file
 CREATE TABLE IF NOT EXISTS file (
-	id BIGSERIAL PRIMARY KEY,
-	path text NOT NULL,
-	kind text NOT NULL
+  id BIGSERIAL PRIMARY KEY,
+  path text NOT NULL,
+  kind text NOT NULL
 );
+
 CREATE UNIQUE INDEX IF NOT EXISTS file_unique_idx ON file (path, kind);
 
 -- FileScanArtifact
 -- A relation linking discovered file to a layer
 CREATE TABLE IF NOT EXISTS file_scanartifact (
-	  file_id bigint REFERENCES file(id) ON DELETE CASCADE,
-	  scanner_id bigint REFERENCES scanner(id) ON DELETE CASCADE,
-	  layer_id bigint REFERENCES layer(id) ON DELETE CASCADE,
-	  PRIMARY KEY(layer_id, scanner_id, file_id)
+  file_id bigint REFERENCES file (id) ON DELETE CASCADE,
+  scanner_id bigint REFERENCES scanner (id) ON DELETE CASCADE,
+  layer_id bigint REFERENCES layer (id) ON DELETE CASCADE,
+  PRIMARY KEY (layer_id, scanner_id, file_id)
 );
 
-ALTER TABLE package_scanartifact ADD COLUMN filepath text;
+ALTER TABLE package_scanartifact
+ADD COLUMN filepath text;

--- a/datastore/postgres/migrations/indexer/07-index-manifest_index.sql
+++ b/datastore/postgres/migrations/indexer/07-index-manifest_index.sql
@@ -1,4 +1,4 @@
 -- This index is needed when deleting manifests, the cascade will want
 -- to delete rows from manifest_index based on the manifest.id. Without
 -- this index things get slow.
-CREATE INDEX IF NOT EXISTS idx_manifest_index_manifest_id ON manifest_index(manifest_id);
+CREATE INDEX IF NOT EXISTS idx_manifest_index_manifest_id ON manifest_index (manifest_id);

--- a/datastore/postgres/migrations/matcher/01-init.sql
+++ b/datastore/postgres/migrations/matcher/01-init.sql
@@ -20,66 +20,80 @@ EXCEPTION WHEN OTHERS THEN
 		HINT = hint;
 END;
 $$ LANGUAGE plpgsql;
+
 -- Update_operation is a table keeping a log of updater runs.
 --
 -- Ref is used when a specific update_operation needs to be exposed to a
 -- client.
 CREATE TABLE IF NOT EXISTS update_operation (
-	id			BIGSERIAL PRIMARY KEY,
-	ref         uuid UNIQUE DEFAULT uuid_generate_v4(),
-	updater		TEXT NOT NULL,
-	fingerprint TEXT,
-	date		TIMESTAMP WITH TIME ZONE DEFAULT now()
+  id BIGSERIAL PRIMARY KEY,
+  ref uuid UNIQUE DEFAULT uuid_generate_v4 (),
+  updater TEXT NOT NULL,
+  fingerprint TEXT,
+  date TIMESTAMP WITH TIME ZONE DEFAULT now()
 );
+
 CREATE INDEX IF NOT EXISTS uo_updater_idx ON update_operation (updater);
+
 -- Create the type used as a column later.
-CREATE TYPE VersionRange AS RANGE ( SUBTYPE = integer[10]);
+CREATE TYPE VersionRange AS RANGE (SUBTYPE = integer[10]);
+
 -- Vuln is a write-once table of vulnerabilities.
 --
 -- Updaters should attempt to insert vulnerabilities and on success or
 -- collision, insert a row into ou_vuln.
 CREATE TABLE IF NOT EXISTS vuln (
-	id                     BIGSERIAL PRIMARY KEY,
-	hash_kind              TEXT NOT NULL,
-	hash                   BYTEA NOT NULL,
-	updater                TEXT,
-	name                   TEXT,
-	description            TEXT,
-	issued                 timestamptz,
-	links                  TEXT,
-	severity               TEXT,
-	normalized_severity    TEXT,
-	package_name           TEXT,
-	package_version        TEXT,
-	package_module         TEXT,
-	package_arch           TEXT,
-	package_kind           TEXT,
-	dist_id                TEXT,
-	dist_name              TEXT,
-	dist_version           TEXT,
-	dist_version_code_name TEXT,
-	dist_version_id        TEXT,
-	dist_arch              TEXT,
-	dist_cpe               TEXT,
-	dist_pretty_name       TEXT,
-	repo_name              TEXT,
-	repo_key               TEXT,
-	repo_uri               TEXT,
-	fixed_in_version       TEXT,
-	arch_operation         TEXT,
-	vulnerable_range       VersionRange NOT NULL DEFAULT VersionRange('{}', '{}', '()'),
-	version_kind           TEXT,
-	UNIQUE (hash_kind, hash)
+  id BIGSERIAL PRIMARY KEY,
+  hash_kind TEXT NOT NULL,
+  hash BYTEA NOT NULL,
+  updater TEXT,
+  name TEXT,
+  description TEXT,
+  issued timestamptz,
+  links TEXT,
+  severity TEXT,
+  normalized_severity TEXT,
+  package_name TEXT,
+  package_version TEXT,
+  package_module TEXT,
+  package_arch TEXT,
+  package_kind TEXT,
+  dist_id TEXT,
+  dist_name TEXT,
+  dist_version TEXT,
+  dist_version_code_name TEXT,
+  dist_version_id TEXT,
+  dist_arch TEXT,
+  dist_cpe TEXT,
+  dist_pretty_name TEXT,
+  repo_name TEXT,
+  repo_key TEXT,
+  repo_uri TEXT,
+  fixed_in_version TEXT,
+  arch_operation TEXT,
+  vulnerable_range VersionRange NOT NULL DEFAULT VersionRange ('{}', '{}', '()'),
+  version_kind TEXT,
+  UNIQUE (hash_kind, hash)
 );
+
 -- this index is tuned for the application. if you change this measure pre and post
 -- change query speeds when generating vulnerability reports.
-CREATE INDEX vuln_lookup_idx on vuln (package_name, dist_id,
-                                         dist_name, dist_pretty_name,
-                                         dist_version, dist_version_id,
-                                         package_module, dist_version_code_name,
-                                         repo_name, dist_arch,
-                                         dist_cpe, repo_key,
-                                         repo_uri);
+CREATE INDEX vuln_lookup_idx on vuln (
+  package_name,
+  dist_id,
+  dist_name,
+  dist_pretty_name,
+  dist_version,
+  dist_version_id,
+  package_module,
+  dist_version_code_name,
+  repo_name,
+  dist_arch,
+  dist_cpe,
+  repo_key,
+  repo_uri
+);
+
 -- Uo_vuln is the association table that does the many-many association
 -- between update operations and vulnerabilities.
 --
@@ -87,13 +101,24 @@ CREATE INDEX vuln_lookup_idx on vuln (package_name, dist_id,
 -- update_operation rows and having that cascade to this table, then
 -- remove vulnerabilities that are not referenced from this table.
 CREATE TABLE IF NOT EXISTS uo_vuln (
-	uo   bigint REFERENCES update_operation (id) ON DELETE CASCADE,
-	vuln bigint REFERENCES vuln             (id) ON DELETE CASCADE,
-	PRIMARY KEY (uo, vuln)
+  uo bigint REFERENCES update_operation (id) ON DELETE CASCADE,
+  vuln bigint REFERENCES vuln (id) ON DELETE CASCADE,
+  PRIMARY KEY (uo, vuln)
 );
+
 -- Latest_vuln is a helper view to get the current snapshot of the vuln database.
 CREATE OR REPLACE VIEW latest_vuln AS
-SELECT v.*
-FROM (SELECT DISTINCT ON (updater) id FROM update_operation ORDER BY updater, id DESC) uo
-	JOIN uo_vuln ON uo_vuln.uo = uo.id
-	JOIN vuln v ON uo_vuln.vuln = v.id;
+SELECT
+  v.*
+FROM
+  (
+    SELECT DISTINCT
+      ON (updater) id
+    FROM
+      update_operation
+    ORDER BY
+      updater,
+      id DESC
+  ) uo
+  JOIN uo_vuln ON uo_vuln.uo = uo.id
+  JOIN vuln v ON uo_vuln.vuln = v.id;

--- a/datastore/postgres/migrations/matcher/02-indexes.sql
+++ b/datastore/postgres/migrations/matcher/02-indexes.sql
@@ -1,4 +1,7 @@
 CREATE INDEX ON update_operation (updater);
+
 CREATE INDEX ON vuln (updater);
+
 CREATE INDEX ON uo_vuln (vuln);
+
 CREATE INDEX ON uo_vuln (uo);

--- a/datastore/postgres/migrations/matcher/03-pyup-fingerprint.sql
+++ b/datastore/postgres/migrations/matcher/03-pyup-fingerprint.sql
@@ -1,1 +1,5 @@
-UPDATE update_operation SET fingerprint = '' WHERE updater = 'pyupio';
+UPDATE update_operation
+SET
+  fingerprint = ''
+WHERE
+  updater = 'pyupio';

--- a/datastore/postgres/migrations/matcher/04-enrichments.sql
+++ b/datastore/postgres/migrations/matcher/04-enrichments.sql
@@ -1,29 +1,31 @@
 ALTER TABLE update_operation
-    ADD COLUMN kind text;
+ADD COLUMN kind text;
+
 CREATE INDEX on update_operation (kind);
 
 UPDATE update_operation
-SET kind = 'vulnerability';
+SET
+  kind = 'vulnerability';
 
-CREATE TABLE enrichment
-(
-    id        BIGSERIAL PRIMARY KEY,
-    hash_kind text,
-    hash      bytea,
-    updater   text,
-    tags      text[],
-    data      jsonb
+CREATE TABLE enrichment (
+  id BIGSERIAL PRIMARY KEY,
+  hash_kind text,
+  hash bytea,
+  updater text,
+  tags text[],
+  data jsonb
 );
+
 CREATE UNIQUE INDEX ON enrichment (hash_kind, hash);
+
 -- use inverted index for tags index
 CREATE INDEX ON enrichment USING gin (tags);
 
-CREATE TABLE uo_enrich
-(
-    uo          BIGINT REFERENCES update_operation (id),
-    enrich      BIGINT REFERENCES enrichment (id),
-    updater     text,
-    fingerprint text,
-    date        timestamptz,
-    PRIMARY KEY (uo, enrich)
+CREATE TABLE uo_enrich (
+  uo BIGINT REFERENCES update_operation (id),
+  enrich BIGINT REFERENCES enrichment (id),
+  updater text,
+  fingerprint text,
+  date timestamptz,
+  PRIMARY KEY (uo, enrich)
 );

--- a/datastore/postgres/migrations/matcher/06-delete-debian-update_operation.sql
+++ b/datastore/postgres/migrations/matcher/06-delete-debian-update_operation.sql
@@ -1,4 +1,9 @@
-DELETE FROM update_operation WHERE updater IN (
-	'debian-bullseye-updater', 'debian-buster-updater',
-	'debian-jessie-updater', 'debian-stretch-updater',
-	'debian-wheezy-updater');
+DELETE FROM update_operation
+WHERE
+  updater IN (
+    'debian-bullseye-updater',
+    'debian-buster-updater',
+    'debian-jessie-updater',
+    'debian-stretch-updater',
+    'debian-wheezy-updater'
+  );

--- a/datastore/postgres/migrations/matcher/07-force-alpine-update.sql
+++ b/datastore/postgres/migrations/matcher/07-force-alpine-update.sql
@@ -1,14 +1,29 @@
-DELETE FROM update_operation WHERE updater IN (
-	'alpine-community-v3.10-updater', 'alpine-community-v3.11-updater',
-	'alpine-community-v3.12-updater', 'alpine-community-v3.13-updater',
-	'alpine-community-v3.14-updater', 'alpine-community-v3.15-updater',
-	'alpine-community-v3.4-updater', 'alpine-community-v3.5-updater',
-	'alpine-community-v3.6-updater', 'alpine-community-v3.7-updater',
-	'alpine-community-v3.8-updater', 'alpine-community-v3.9-updater',
-	'alpine-main-v3.10-updater', 'alpine-main-v3.11-updater',
-	'alpine-main-v3.12-updater', 'alpine-main-v3.13-updater',
-	'alpine-main-v3.14-updater', 'alpine-main-v3.15-updater',
-	'alpine-main-v3.3-updater', 'alpine-main-v3.4-updater',
-	'alpine-main-v3.5-updater', 'alpine-main-v3.6-updater',
-	'alpine-main-v3.7-updater', 'alpine-main-v3.8-updater',
-	'alpine-main-v3.9-updater');
+DELETE FROM update_operation
+WHERE
+  updater IN (
+    'alpine-community-v3.10-updater',
+    'alpine-community-v3.11-updater',
+    'alpine-community-v3.12-updater',
+    'alpine-community-v3.13-updater',
+    'alpine-community-v3.14-updater',
+    'alpine-community-v3.15-updater',
+    'alpine-community-v3.4-updater',
+    'alpine-community-v3.5-updater',
+    'alpine-community-v3.6-updater',
+    'alpine-community-v3.7-updater',
+    'alpine-community-v3.8-updater',
+    'alpine-community-v3.9-updater',
+    'alpine-main-v3.10-updater',
+    'alpine-main-v3.11-updater',
+    'alpine-main-v3.12-updater',
+    'alpine-main-v3.13-updater',
+    'alpine-main-v3.14-updater',
+    'alpine-main-v3.15-updater',
+    'alpine-main-v3.3-updater',
+    'alpine-main-v3.4-updater',
+    'alpine-main-v3.5-updater',
+    'alpine-main-v3.6-updater',
+    'alpine-main-v3.7-updater',
+    'alpine-main-v3.8-updater',
+    'alpine-main-v3.9-updater'
+  );

--- a/datastore/postgres/migrations/matcher/08-updater-status.sql
+++ b/datastore/postgres/migrations/matcher/08-updater-status.sql
@@ -1,8 +1,8 @@
 CREATE TABLE IF NOT EXISTS updater_status (
-    updater_name text PRIMARY KEY,
-    last_attempt timestamp with time zone DEFAULT now(),
-    last_success timestamp with time zone,
-    last_run_succeeded bool,
-    last_attempt_fingerprint text,
-    last_error text
+  updater_name text PRIMARY KEY,
+  last_attempt timestamp with time zone DEFAULT now(),
+  last_success timestamp with time zone,
+  last_run_succeeded bool,
+  last_attempt_fingerprint text,
+  last_error text
 );

--- a/datastore/postgres/migrations/matcher/09-delete-pyupio.sql
+++ b/datastore/postgres/migrations/matcher/09-delete-pyupio.sql
@@ -1,10 +1,11 @@
 -- Delete all update_operations for pyupio to trigger pyupio vuln deletion
-DELETE FROM update_operation WHERE updater = 'pyupio';
+DELETE FROM update_operation
+WHERE
+  updater = 'pyupio';
 
-DELETE FROM vuln v1 USING
-	vuln v2
-	LEFT JOIN uo_vuln uvl
-		ON v2.id = uvl.vuln
-	WHERE uvl.vuln IS NULL
-	AND v2.updater = 'pyupio'
-AND v1.id = v2.id;
+DELETE FROM vuln v1 USING vuln v2
+LEFT JOIN uo_vuln uvl ON v2.id = uvl.vuln
+WHERE
+  uvl.vuln IS NULL
+  AND v2.updater = 'pyupio'
+  AND v1.id = v2.id;

--- a/datastore/postgres/migrations/matcher/10-delete-osv.sql
+++ b/datastore/postgres/migrations/matcher/10-delete-osv.sql
@@ -1,10 +1,11 @@
 -- Delete all update_operations for osv updater and vulns
-DELETE FROM update_operation WHERE updater = 'osv';
+DELETE FROM update_operation
+WHERE
+  updater = 'osv';
 
-DELETE FROM vuln v1 USING
-	vuln v2
-	LEFT JOIN uo_vuln uvl
-		ON v2.id = uvl.vuln
-	WHERE uvl.vuln IS NULL
-	AND v2.updater = 'osv'
-AND v1.id = v2.id;
+DELETE FROM vuln v1 USING vuln v2
+LEFT JOIN uo_vuln uvl ON v2.id = uvl.vuln
+WHERE
+  uvl.vuln IS NULL
+  AND v2.updater = 'osv'
+  AND v1.id = v2.id;

--- a/datastore/postgres/migrations/matcher/11-add-update_operation-mv.sql
+++ b/datastore/postgres/migrations/matcher/11-add-update_operation-mv.sql
@@ -1,3 +1,11 @@
 -- Create materialized view that maintains the lastest update_operation id per updater.
 CREATE MATERIALIZED VIEW IF NOT exists latest_update_operations AS
-SELECT DISTINCT ON (updater) id, kind, updater FROM update_operation ORDER BY updater, id DESC;
+SELECT DISTINCT
+  ON (updater) id,
+  kind,
+  updater
+FROM
+  update_operation
+ORDER BY
+  updater,
+  id DESC;

--- a/datastore/postgres/migrations/matcher/12-add-latest_update_operation-index.sql
+++ b/datastore/postgres/migrations/matcher/12-add-latest_update_operation-index.sql
@@ -1,2 +1,2 @@
 -- A unique index is needed on the materialized view to facilitate CONCURRENT refreshing.
-CREATE UNIQUE INDEX idx_updater_uniq ON latest_update_operations(updater);
+CREATE UNIQUE INDEX idx_updater_uniq ON latest_update_operations (updater);

--- a/datastore/postgres/migrations/matcher/13-delete-rhel-oval.sql
+++ b/datastore/postgres/migrations/matcher/13-delete-rhel-oval.sql
@@ -1,4 +1,9 @@
 -- The rhel-vex updater will now be responsible for RHEL advisories so we have
 -- to delete the existing rhel vulnerabilities.
-DELETE FROM update_operation WHERE updater ~ 'RHEL[5-9]-*';
-DELETE FROM vuln where updater ~ 'RHEL[5-9]-*';
+DELETE FROM update_operation
+WHERE
+  updater ~ 'RHEL[5-9]-*';
+
+DELETE FROM vuln
+where
+  updater ~ 'RHEL[5-9]-*';

--- a/datastore/postgres/migrations/matcher/14-delete-rhcc-vulns.sql
+++ b/datastore/postgres/migrations/matcher/14-delete-rhcc-vulns.sql
@@ -1,4 +1,9 @@
 -- The rhel-vex updater will now be responsible for RHCC advisories so we have
 -- to delete the existing RHCC vulnerabilities.
-DELETE FROM update_operation WHERE updater = 'rhel-container-updater';
-DELETE FROM vuln where updater = 'rhel-container-updater';
+DELETE FROM update_operation
+WHERE
+  updater = 'rhel-container-updater';
+
+DELETE FROM vuln
+where
+  updater = 'rhel-container-updater';

--- a/datastore/postgres/migrations/matcher/15-enrichment-indexes.sql
+++ b/datastore/postgres/migrations/matcher/15-enrichment-indexes.sql
@@ -1,3 +1,5 @@
 CREATE INDEX IF NOT EXISTS uo_enrich_enrich_idx ON uo_enrich (enrich);
+
 CREATE INDEX IF NOT EXISTS uo_enrich_uo_idx ON uo_enrich (uo);
+
 CREATE INDEX IF NOT EXISTS enrichment_updater_idx ON enrichment (updater);

--- a/datastore/postgres/migrations/matcher/16-delete-cvss-enrichments.sql
+++ b/datastore/postgres/migrations/matcher/16-delete-cvss-enrichments.sql
@@ -1,11 +1,13 @@
 -- Delete all update_operations for cvss enrichments to trigger cvss enrichment deletion
-DELETE FROM update_operation WHERE updater = 'clair.cvss' AND kind = 'enrichment';
+DELETE FROM update_operation
+WHERE
+  updater = 'clair.cvss'
+  AND kind = 'enrichment';
 
 -- Clean up any orphaned enrichment records
-DELETE FROM enrichment e1 USING
-    enrichment e2
-    LEFT JOIN uo_enrich ue
-        ON e2.id = ue.enrich
-    WHERE ue.enrich IS NULL
-    AND e2.updater = 'clair.cvss'
-    AND e1.id = e2.id;
+DELETE FROM enrichment e1 USING enrichment e2
+LEFT JOIN uo_enrich ue ON e2.id = ue.enrich
+WHERE
+  ue.enrich IS NULL
+  AND e2.updater = 'clair.cvss'
+  AND e1.id = e2.id;

--- a/datastore/postgres/migrations/migrations.go
+++ b/datastore/postgres/migrations/migrations.go
@@ -101,5 +101,6 @@ func runMigrations(ctx context.Context, cfg *pgx.ConnConfig, table pgx.Identifie
 	return nil
 }
 
+//go:generate find . -name *.sql -exec go run github.com/wasilibs/go-sql-formatter/v15/cmd/sql-formatter@latest --language postgresql --fix {} ;
 //go:embed */*.sql
 var sys embed.FS


### PR DESCRIPTION
This change adds a `generate` directive that runs an SQL formatter via `go run`. It also runs the formatter over the existing SQL.