### PR TITLE
photon: reconstruct URL from release string

### DIFF
--- a/photon/photon.go
+++ b/photon/photon.go
@@ -3,6 +3,7 @@ package photon
 import (
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/quay/claircore/libvuln/driver"
 	"github.com/quay/claircore/pkg/ovalutil"
@@ -44,7 +45,7 @@ func NewUpdater(r Release, opts ...Option) (*Updater, error) {
 	}
 	if u.Fetcher.URL == nil {
 		var err error
-		u.Fetcher.URL, err = upstreamBase.Parse("com.vmware.phsa-" + string(u.release) + ".xml")
+		u.Fetcher.URL, err = upstreamBase.Parse("com.vmware.phsa-photon" + strings.TrimSuffix(string(u.release), ".0") + ".xml")
 		if err != nil {
 			return nil, err
 		}

--- a/photon/updaterset.go
+++ b/photon/updaterset.go
@@ -11,6 +11,8 @@ var photonReleases = []Release{
 	Photon1,
 	Photon2,
 	Photon3,
+	Photon4,
+	Photon5,
 }
 
 func UpdaterSet(_ context.Context) (driver.UpdaterSet, error) {


### PR DESCRIPTION
Using the raw release string wasn't yielding the correct updater URL, this change converts the release into the correct photon OVAL URL format.