### PR TITLE
chore: add CI lint for generated files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,16 @@ jobs:
           trap 'echo "::error file=go.mod,title=Tidy Check::Commit would leave go.mod untidy"' ERR
           go mod tidy
           git diff --exit-code
+      - name: Go Generate
+        if: ${{ !cancelled() && steps.checkout.conclusion == 'success' && steps.setupgo.conclusion == 'success' }}
+        run: | # Only run generation for deterministic data.
+          trap 'echo "::error Generate Check::Generated files are out of date. Run go generate and commit the changes"' ERR
+          find . -name .git -prune -o -name testdata -prune -o -name vendor -prune -o -name go.mod -printf '%h\n' |
+          while read -r dir; do (
+            cd "$dir"
+            go generate -run 'stringer|mockgen|sql-formatter' ./...
+          ); done
+          git diff --exit-code
 
   build-documentation:
     name: Build Docs

--- a/updater/driver/go.mod
+++ b/updater/driver/go.mod
@@ -1,6 +1,6 @@
 module github.com/quay/claircore/updater/driver
 
-go 1.22
+go 1.25.0
 
 require (
 	github.com/google/uuid v1.6.0

--- a/updater/driver/go.sum
+++ b/updater/driver/go.sum
@@ -1,4 +1,4 @@
-github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
-github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=


### PR DESCRIPTION
This should stop generated files becoming stale and should help generated code be included with its non-generated counterpart.