### PR TITLE
chore: account for all modules in go mod tidy check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,8 +48,9 @@ jobs:
       - name: Go Tidy
         if: ${{ !cancelled() && steps.checkout.conclusion == 'success' && steps.setupgo.conclusion == 'success' }}
         run: |
-          trap 'echo "::error file=go.mod,title=Tidy Check::Commit would leave go.mod untidy"' ERR
-          go mod tidy
+          trap 'echo "::error title=Tidy Check::Commit would leave go.mod/go.sum untidy"' ERR
+          find . -name .git -prune -o -name testdata -prune -o -name vendor -prune -o -name go.mod -printf '%h\n' |
+          while read -r dir; do (cd "$dir" && go mod tidy); done
           git diff --exit-code
       - name: Go Generate
         if: ${{ !cancelled() && steps.checkout.conclusion == 'success' && steps.setupgo.conclusion == 'success' }}


### PR DESCRIPTION
This will do `go mod tidy` for each module. This came up recently when the updater/driver's go.mod and go.sum had become stale.