### PR TITLE
rpm: prevent sqlite WAL/SHM spool files from leaking on Close

### DIFF
--- a/internal/rpm/find.go
+++ b/internal/rpm/find.go
@@ -226,7 +226,7 @@ func OpenDB(ctx context.Context, sys fs.FS, found FoundDB) (*Database, error) {
 			return nil, fmt.Errorf("internal/rpm: unable to open sqlite db: %w", err)
 		}
 		db.headers = sdb
-		cleanup.close = sdb.Close
+		cleanup.close = sqliteCleanup(spool.Name(), sdb.Close)
 	case kindBDB:
 		var bpdb bdb.PackageDB
 		if err := bpdb.Parse(spool); err != nil {
@@ -259,16 +259,23 @@ type databaseCleanup struct {
 }
 
 func (c *databaseCleanup) Close() (err error) {
-	// Close the database handle before unlinking the spool. SQLite's shutdown
-	// sequence (WAL checkpoint, -wal/-shm removal) relies on the main DB file
-	// still being on disk; unlinking first leaks the side files on some
-	// platform/filesystem combinations.
 	if c.close != nil {
 		err = errors.Join(err, c.close())
 	}
 	if c.spool != nil {
 		name := c.spool.Name()
 		err = errors.Join(err, c.spool.Close(), os.Remove(name))
+	}
+	return err
+}
+
+func sqliteCleanup(name string, close func() error) func() error {
+	return func() (err error) {
+		// Close the SQLite handle while the spooled DB file still exists. WAL
+		// checkpointing and sidecar cleanup rely on the main DB pathname.
+		if close != nil {
+			err = errors.Join(err, close())
+		}
 		// Belt-and-suspenders: SQLite normally removes these during clean
 		// shutdown, but some driver versions leave them behind.
 		for _, suffix := range []string{"-wal", "-shm"} {
@@ -276,6 +283,6 @@ func (c *databaseCleanup) Close() (err error) {
 				err = errors.Join(err, rmErr)
 			}
 		}
+		return err
 	}
-	return err
 }

--- a/internal/rpm/find.go
+++ b/internal/rpm/find.go
@@ -259,11 +259,23 @@ type databaseCleanup struct {
 }
 
 func (c *databaseCleanup) Close() (err error) {
-	if c.spool != nil {
-		err = errors.Join(err, c.spool.Close(), os.Remove(c.spool.Name()))
-	}
+	// Close the database handle before unlinking the spool. SQLite's shutdown
+	// sequence (WAL checkpoint, -wal/-shm removal) relies on the main DB file
+	// still being on disk; unlinking first leaks the side files on some
+	// platform/filesystem combinations.
 	if c.close != nil {
 		err = errors.Join(err, c.close())
+	}
+	if c.spool != nil {
+		name := c.spool.Name()
+		err = errors.Join(err, c.spool.Close(), os.Remove(name))
+		// Belt-and-suspenders: SQLite normally removes these during clean
+		// shutdown, but some driver versions leave them behind.
+		for _, suffix := range []string{"-wal", "-shm"} {
+			if rmErr := os.Remove(name + suffix); rmErr != nil && !errors.Is(rmErr, os.ErrNotExist) {
+				err = errors.Join(err, rmErr)
+			}
+		}
 	}
 	return err
 }


### PR DESCRIPTION
databaseCleanup.Close unlinked the spool file before closing the SQLite handle. SQLite's shutdown sequence (WAL checkpoint, -wal/-shm removal) relies on the main DB file still being on disk, so on some platform/filesystem combinations the -wal and -shm side files were abandoned in os.TempDir().

This was visible to long-running processes scanning RPM-on-SQLite databases (Rocky 9, RHEL 9, Fedora 35+, AlmaLinux 9), which accumulated rpm.package.sqlite.<n>-wal / -shm files indefinitely. CentOS 6/7 (BDB backend) was unaffected because those code paths never open a real SQLite connection.

Close the SQLite handle first, then unlink the spool. As a belt-and-suspenders measure, also remove the -wal and -shm siblings explicitly, ignoring ErrNotExist, in case a driver version skips them during clean shutdown.