### PR TITLE
chore: add json tags to new vulnerabilityreport fields

### DIFF
--- a/vulnerability.go
+++ b/vulnerability.go
@@ -42,18 +42,18 @@ type Vulnerability struct {
 	// Self is an Alias that is the "identity" for this Vulnerability.
 	//
 	// This should be a system-wide, external identifier.
-	Self Alias
+	Self Alias `json:"self,omitempty"`
 	// Aliases is a set of aliases for the same abstract software flaw.
 	//
 	// For example, GHSA advisories frequently also reference CVE identifiers.
 	//
 	// For instances from a claircore "datastore" implementation, this will also
 	// include the "Self" alias.
-	Aliases []Alias
+	Aliases []Alias `json:"aliases,omitempty"`
 
 	// Invert means this Vulnerability should be interpreted as an assertion
 	// that matched packages are NOT vulnerable to the indicated flaw.
-	Invert bool
+	Invert bool `json:"invert,omitempty"`
 }
 
 // CheckVulnernableFunc takes a vulnerability and an indexRecord and checks if the record is


### PR DESCRIPTION
Without these tags, the unmarshaled json keys are Pascal case.