### PR TITLE
filterfs: don't use /dev in test

### DIFF
--- a/internal/filterfs/file.go
+++ b/internal/filterfs/file.go
@@ -5,7 +5,7 @@ import (
 	"io/fs"
 )
 
-// A ReadDirFile wrapper for fs.File
+// DirFile is a ReadDirFile wrapper for [fs.File].
 type DirFile struct {
 	fdir    fs.File
 	fsys    *FS

--- a/internal/filterfs/fs.go
+++ b/internal/filterfs/fs.go
@@ -1,11 +1,17 @@
+// Package filterfs provides a wrapper around an [fs.FS] that only presents
+// regular files and directories to the user.
+//
+// This wrapper has some overhead, as it attempts to open files to ensure that
+// "invisible" permissions (SELinux, etc.) are also valid.
 package filterfs
 
 import (
 	"io/fs"
 	"path"
+	"slices"
 )
 
-// FS wraps an fs.FS and hides inaccessible files and directories
+// FS wraps an [fs.FS] and hides inaccessible files and directories
 // by returning appropriate "not found" errors or filtering them from listings.
 type FS struct {
 	fsys fs.FS
@@ -52,23 +58,22 @@ func (f *FS) ReadDir(name string) ([]fs.DirEntry, error) {
 	if err != nil {
 		return nil, fs.SkipDir
 	}
-
-	var filtered []fs.DirEntry
-	// Filter out entries that are inaccessible
-	for _, entry := range entries {
-		// Try to stat the entry to check if it's accessible
-		path := path.Join(name, entry.Name())
-		fi, err := fs.Stat(f.fsys, path)
-		if err == nil {
-			// Accessible, include it
-			if fi.Mode().IsRegular() || fi.Mode().IsDir() {
-				if file, err := f.fsys.Open(path); err == nil {
-					file.Close()
-					filtered = append(filtered, entry)
-				}
-			}
+	entries = slices.DeleteFunc(entries, func(d fs.DirEntry) bool {
+		p := path.Join(name, d.Name())
+		fi, err := fs.Stat(f.fsys, p)
+		if err != nil {
+			return true
 		}
-	}
+		if m := fi.Mode(); !m.IsDir() && !m.IsRegular() {
+			return true
+		}
+		t, err := f.fsys.Open(p)
+		if err != nil {
+			return true
+		}
+		t.Close()
+		return false
+	})
 
-	return filtered, nil
+	return entries, nil
 }

--- a/internal/filterfs/fs_test.go
+++ b/internal/filterfs/fs_test.go
@@ -1,7 +1,9 @@
 package filterfs
 
 import (
+	"net"
 	"os"
+	"path/filepath"
 	"testing"
 	"testing/fstest"
 )
@@ -19,14 +21,27 @@ func TestCurrentDir(t *testing.T) {
 	}
 }
 
-func TestDev(t *testing.T) {
-	fileset := []string{
-		"cpu",
+func TestSocket(t *testing.T) {
+	d := t.TempDir()
+	sys := New(os.DirFS(d))
+
+	l, err := net.Listen("unix", filepath.Join(d, "socket"))
+	if err != nil {
+		t.Fatalf("socket: %v", err)
+	}
+	defer l.Close()
+	// Passing nothing means the TestFS call should see an empty FS.
+	if err := fstest.TestFS(sys); err != nil {
+		t.Fatal(err)
 	}
 
-	sys := New(os.DirFS("/dev"))
-
-	if err := fstest.TestFS(sys, fileset...); err != nil {
+	f, err := os.Create(filepath.Join(d, "file"))
+	if err != nil {
+		t.Fatalf("file: %v", err)
+	}
+	defer f.Close()
+	// TestFS should see the new regular file that was added.
+	if err := fstest.TestFS(sys, "file"); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
The `TestDev` test used the machine's `/dev` directory to test special files getting filtered out. However when running concurrently with tests starting and stopping PostgreSQL, the test would flap on `shm` files disappearing from underneath it.

This replaces the test with creating a fifo in a test-created directory, which will not have files change unexpectedly.