### PR TITLE
claircore: add "not vulnerable" lookup to `VulnerabiltityReport`

### DIFF
--- a/vulnerabilityreport.go
+++ b/vulnerabilityreport.go
@@ -17,8 +17,20 @@ type VulnerabilityReport struct {
 	Environments map[string][]*Environment `json:"environments"`
 	// all discovered vulnerabilities affecting this manifest
 	Vulnerabilities map[string]*Vulnerability `json:"vulnerabilities"`
-	// a lookup table associating package ids with 1 or more vulnerability ids. keyed by package id
+	// PackageVulnerabilities records the vulnerabilities associated with a
+	// given package. Package and Vulnerability objects are referred to by their
+	// ID.
+	//
+	// The Vulnerability objects with these IDs will have their "Invert" member
+	// set to "false".
 	PackageVulnerabilities map[string][]string `json:"package_vulnerabilities"`
 	// a map of enrichments keyed by a type.
 	Enrichments map[string][]json.RawMessage `json:"enrichments"`
+
+	// PackageNotVulnerable records "not vulnerable" assertions provided by some
+	// data sources.
+	//
+	// The Vulnerability objects with these IDs will have their "Invert" member
+	// set to "true".
+	PackageNotVulnerable map[string][]string
 }


### PR DESCRIPTION
This is to be the API that's actually exposed for this information.

I think this is all that's needed on this end.