### PR TITLE
acceptance: allow changing the fixture repository

### DIFF
--- a/docs/howto/acceptance_testing.md
+++ b/docs/howto/acceptance_testing.md
@@ -155,24 +155,24 @@ Use the `test/acceptance/cmd/fixture` tool to create fixtures:
 ```bash
 # Create a fixture
 go run ./test/acceptance/cmd/fixture create \
-    -image registry.io/namespace/image@sha256:abc123... \
-    -tag my-fixture-name \
+    -image registry.example.com/namespace/image@sha256:abc123... \
+    -tag fixture-name \
     -vex path/to/vex.json \
     -manifest path/to/expected.csv \
-    -repo your.registry.io/namespace/your-repo
+    -repo registry.example.com/namespace/fixtures
 
 # You can attach multiple VEX documents
 go run ./test/acceptance/cmd/fixture create \
-    -image registry.io/namespace/image@sha256:abc123... \
+    -image registry.example.com/namespace/image@sha256:abc123... \
     -tag multi-vex-fixture \
     -vex vex1.json \
     -vex vex2.json \
     -vex vex3.json \
     -manifest expected.csv \
-    -repo your.registry.io/your-repo
+    -repo registry.example.com/namespace/fixtures
 
 # Verify the fixture was created
-go run ./test/acceptance/cmd/fixture list -image your.registry.io/your-repo:my-fixture-name
+go run ./test/acceptance/cmd/fixture list -image registry.example.com/namespace/fixtures:fixture-name
 ```
 
 #### Create Options
@@ -191,10 +191,19 @@ go run ./test/acceptance/cmd/fixture list -image your.registry.io/your-repo:my-f
 ### Running Integration Tests
 
 The integration tests automatically download and run embedded PostgreSQL
-binaries - no database setup required:
+binaries; no database setup required:
 
 ```bash
 go test -tags=integration -v ./test/acceptance/...
+```
+
+### Using Alternative Repository
+
+The `fixtures-repo` flag can be passed to the test to run against an alternative
+repository of fixtures.
+
+```bash
+go test -tags=integration -v ./test/acceptance -fixtures-repo registry.example.com/namespace/fixtures:fixture-name
 ```
 
 ### Using Local OCI Layout

--- a/test/acceptance/integration_test.go
+++ b/test/acceptance/integration_test.go
@@ -17,11 +17,6 @@ import (
 	"github.com/quay/claircore/toolkit/fixtures"
 )
 
-// FixturesRepo is the OCI repository containing acceptance test fixtures.
-// Each image in this repo has VEX documents and expected results attached
-// via OCI referrers.
-const FixturesRepo = "quay.io/projectquay/clair-fixtures"
-
 // ReadVEX reads a VEX file from testdata directory.
 func readVEX(t *testing.T, name string) []byte {
 	t.Helper()
@@ -203,7 +198,6 @@ func TestAcceptanceRun(t *testing.T) {
 		}
 		Run(ctx, t, auditor, []string{testFixture.Reference}, WithFixture(testFixture))
 	})
-
 }
 
 // TestFixturesRepo runs acceptance tests against all images in the fixtures repository.

--- a/test/acceptance/main_test.go
+++ b/test/acceptance/main_test.go
@@ -1,0 +1,25 @@
+package acceptance
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/quay/claircore/test/integration"
+)
+
+// FixturesRepo is the OCI repository containing acceptance test fixtures.
+// Each image in this repo has VEX documents and expected results attached
+// via OCI referrers.
+var FixturesRepo = "quay.io/projectquay/clair-fixtures"
+
+func TestMain(m *testing.M) {
+	var c int
+	defer func() { os.Exit(c) }()
+	defer integration.DBSetup()()
+
+	flag.StringVar(&FixturesRepo, "fixtures-repo", FixturesRepo, "the OCI repository to check for fixtures")
+	flag.Parse()
+
+	c = m.Run()
+}


### PR DESCRIPTION
This adds a command line flag to set the fixtures repository.

```
  -fixtures-repo string
            the OCI repository to check for fixtures (default "quay.io/projectquay/clair-fixtures")
```
