### PR TITLE
cicd: allow deploy-docs to trigger from comments

### DIFF
--- a/.github/workflows/fast-forward.yml
+++ b/.github/workflows/fast-forward.yml
@@ -31,7 +31,7 @@ jobs:
           merge: true
           comment: on-error
   deploy-docs:
-    if: ${{ success() && github.base_ref == 'main' }}
+    if: ${{ success() && github.event.issue.pull_request }}
     permissions:
       contents: write
     needs: fast-forward


### PR DESCRIPTION
Considering just letting the crypto miners have at it if it means that the documentation will actually get built.