### PR TITLE
test/vex: move exposed `testing` use to dedicated package

### DIFF
--- a/rhel/vex/fetcher_test.go
+++ b/rhel/vex/fetcher_test.go
@@ -9,12 +9,13 @@ import (
 
 	"github.com/quay/claircore/libvuln/driver"
 	"github.com/quay/claircore/test"
+	testvex "github.com/quay/claircore/test/vex"
 	"github.com/quay/claircore/toolkit/types/csaf"
 )
 
 func TestFactory(t *testing.T) {
 	ctx := test.Logging(t)
-	root, c := ServeSecDB(t, "testdata/server.txtar")
+	root, c := testvex.ServeSecDB(ctx, t, "testdata/server.txtar")
 	fac := &Factory{}
 	err := fac.Configure(ctx, func(v any) error {
 		cf := v.(*FactoryConfig)

--- a/test/rhel/rhcc_matcher_integration_test.go
+++ b/test/rhel/rhcc_matcher_integration_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/quay/claircore/test"
 	"github.com/quay/claircore/test/integration"
 	testpostgres "github.com/quay/claircore/test/postgres"
+	testvex "github.com/quay/claircore/test/vex"
 )
 
 func TestMain(m *testing.M) {
@@ -57,7 +58,7 @@ func TestRHCCMatcherIntegration(t *testing.T) {
 			match:       false,
 		},
 		{
-			Name:        "Clair labels",
+			Name:        "ClairLabels",
 			indexReport: "clair-rhel8-v3.5.5-4-labels",
 			cveID:       "CVE-2021-3762",
 			match:       true,
@@ -74,7 +75,7 @@ func TestRHCCMatcherIntegration(t *testing.T) {
 	}
 	defer locks.Close(ctx)
 
-	root, c := vex.ServeSecDB(t, "testdata/server.txtar")
+	root, c := testvex.ServeSecDB(ctx, t, "testdata/server.txtar")
 	fac := &vex.Factory{}
 	cfg := updates.Configs{
 		"rhel-vex": func(v any) error {

--- a/test/vex/vex.go
+++ b/test/vex/vex.go
@@ -3,6 +3,7 @@ package vex
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -11,8 +12,16 @@ import (
 	"path/filepath"
 	"testing"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/tools/txtar"
 )
+
+var tracer trace.Tracer
+
+func init() {
+	tracer = otel.Tracer("github.com/quay/claircore/test/vex")
+}
 
 func parseFilenameHeaders(data []byte) (string, http.Header, error) {
 	pf, h, _ := bytes.Cut(data, []byte{' '})
@@ -27,7 +36,10 @@ func parseFilenameHeaders(data []byte) (string, http.Header, error) {
 	return string(compressedFilepath), http.Header(hdr), nil
 }
 
-func ServeSecDB(t *testing.T, txtarFile string) (string, *http.Client) {
+func ServeSecDB(ctx context.Context, t *testing.T, txtarFile string) (string, *http.Client) {
+	ctx, span := tracer.Start(ctx, "ServeSecDB")
+	defer span.End()
+
 	mux := http.NewServeMux()
 	archive, err := txtar.ParseFile(txtarFile)
 	if err != nil {
@@ -39,6 +51,12 @@ func ServeSecDB(t *testing.T, txtarFile string) (string, *http.Client) {
 	}
 	filename := filepath.Base(relFilepath)
 	mux.HandleFunc("/"+filename, func(w http.ResponseWriter, r *http.Request) {
+		_, span := tracer.Start(ctx, r.URL.Path,
+			trace.WithLinks(trace.LinkFromContext(ctx)),
+			trace.WithSpanKind(trace.SpanKindServer),
+		)
+		defer span.End()
+
 		for k, v := range headers {
 			w.Header().Set(k, v[0])
 		}


### PR DESCRIPTION
As a general rule, code that's exported and uses the `testing` package in its API should go under the `test` hierarchy. Ultimately, we shouldn't have non-test builds pull in the `testing` package.

See-Also: CLAIRDEV-238