### PR TITLE
rhcc: fix matching for timestamp-based versions

### DIFF
--- a/rhel/rhcc/matcher.go
+++ b/rhel/rhcc/matcher.go
@@ -64,13 +64,16 @@ func (*matcher) Vulnerable(ctx context.Context, record *claircore.IndexRecord, v
 	if record.Package.Version == "" {
 		return false, errors.New("rhcc: unable to parse package version: empty version")
 	}
+	if vuln.FixedInVersion == "" {
+		return true, nil
+	}
 	pkgVer, err := rpmver.Parse(ensureEVR(record.Package.Version))
 	if err != nil {
 		return false, fmt.Errorf("rhcc: unable to parse version %q: %w", record.Package.Version, err)
 	}
 	fixedVer, err := rpmver.Parse(ensureEVR(vuln.FixedInVersion))
 	if err != nil {
-		return false, fmt.Errorf("rhcc: unable to parse version %q: %w", vuln.FixedInVersion, err)
+		return false, fmt.Errorf("rhcc: unable to parse vulnerability version %q: %w", vuln.FixedInVersion, err)
 	}
 	return rpmver.Compare(&pkgVer, &fixedVer) == -1, nil
 }

--- a/rhel/rhcc/matcher.go
+++ b/rhel/rhcc/matcher.go
@@ -2,8 +2,10 @@ package rhcc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/internal/rpmver"
@@ -59,11 +61,14 @@ func (*matcher) Vulnerable(ctx context.Context, record *claircore.IndexRecord, v
 		return true, nil
 	}
 
-	pkgVer, err := rpmver.Parse(record.Package.Version)
+	if record.Package.Version == "" {
+		return false, errors.New("rhcc: unable to parse package version: empty version")
+	}
+	pkgVer, err := rpmver.Parse(ensureEVR(record.Package.Version))
 	if err != nil {
 		return false, fmt.Errorf("rhcc: unable to parse version %q: %w", record.Package.Version, err)
 	}
-	fixedVer, err := rpmver.Parse(vuln.FixedInVersion)
+	fixedVer, err := rpmver.Parse(ensureEVR(vuln.FixedInVersion))
 	if err != nil {
 		return false, fmt.Errorf("rhcc: unable to parse version %q: %w", vuln.FixedInVersion, err)
 	}
@@ -77,3 +82,15 @@ func (*matcher) Vulnerable(ctx context.Context, record *claircore.IndexRecord, v
 func (*matcher) VersionFilter() {}
 
 func (*matcher) VersionAuthoritative() bool { return false }
+
+// ensureEVR appends a "-0" release suffix to version strings that lack a
+// dash (i.e., release), making them valid EVR strings for rpmver.Parse.
+// Timestamp-based versions from labels.json (e.g., "1744596866") and timestamp
+// tags from VEX pURLs have no dash; tag-based versions (e.g., "v3.5.7-8")
+// already do and are returned unchanged.
+func ensureEVR(s string) string {
+	if !strings.Contains(s, "-") {
+		return s + "-0"
+	}
+	return s
+}

--- a/rhel/rhcc/matcher_test.go
+++ b/rhel/rhcc/matcher_test.go
@@ -5,67 +5,129 @@ import (
 
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/test"
+	"github.com/quay/claircore/toolkit/types/cpe"
 )
 
 func TestMatcherVulnerable(t *testing.T) {
 	t.Parallel()
 	ctx := test.Logging(t)
-	m := &matcher{}
 
-	t.Run("Inverted", func(t *testing.T) {
-		record := &claircore.IndexRecord{
-			Package:    &claircore.Package{Name: "mta/mta-rhel8-operator", Version: "7.0.3-13"},
-			Repository: &GoldRepo,
-		}
-		vuln := &claircore.Vulnerability{
-			Name:   "CVE-2024-24786",
-			Invert: true,
-			Repo:   &GoldRepo,
-		}
-		got, err := m.Vulnerable(ctx, record, vuln)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !got {
-			t.Error("expected vulnerable=true for inverted vulnerability")
-		}
-	})
+	type testcase struct {
+		name           string
+		packageVersion string
+		fixedInVersion string
+		repo           *claircore.Repository
+		vulnRepo       *claircore.Repository
+		invert         bool
+		want           bool
+	}
+	table := []testcase{
+		{
+			name:           "TimestampOlder",
+			packageVersion: "1740000000",
+			fixedInVersion: "1742843776",
+			repo:           cpeRepo("cpe:/a:redhat:openshift_gitops:1.16::el8"),
+			vulnRepo:       cpeRepo("cpe:/a:redhat:openshift_gitops:1.16::el8"),
+			want:           true,
+		},
+		{
+			name:           "TimestampNewer",
+			packageVersion: "1744596866",
+			fixedInVersion: "1742843776",
+			repo:           cpeRepo("cpe:/a:redhat:openshift_gitops:1.16::el8"),
+			vulnRepo:       cpeRepo("cpe:/a:redhat:openshift_gitops:1.16::el8"),
+			want:           false,
+		},
+		{
+			name:           "TimestampEqual",
+			packageVersion: "1742843776",
+			fixedInVersion: "1742843776",
+			repo:           cpeRepo("cpe:/a:redhat:openshift_gitops:1.16::el8"),
+			vulnRepo:       cpeRepo("cpe:/a:redhat:openshift_gitops:1.16::el8"),
+			want:           false,
+		},
+		{
+			name:           "TagOlder",
+			packageVersion: "v3.5.5-4",
+			fixedInVersion: "v3.5.7-8",
+			repo:           cpeRepo("cpe:/a:redhat:quay:3::el8"),
+			vulnRepo:       cpeRepo("cpe:/a:redhat:quay:3::el8"),
+			want:           true,
+		},
+		{
+			name:           "GoldenRepoTagOlder",
+			packageVersion: "v3.5.5-4",
+			fixedInVersion: "v3.5.6-1",
+			repo:           &GoldRepo,
+			vulnRepo:       &GoldRepo,
+			want:           true,
+		},
+		{
+			name:           "TagNewer",
+			packageVersion: "v3.5.9-2",
+			fixedInVersion: "v3.5.7-8",
+			repo:           cpeRepo("cpe:/a:redhat:quay:3::el8"),
+			vulnRepo:       cpeRepo("cpe:/a:redhat:quay:3::el8"),
+			want:           false,
+		},
+		{
+			name:           "GoldenRepoTagNewer",
+			packageVersion: "v3.5.7-1",
+			fixedInVersion: "v3.5.6-1",
+			repo:           &GoldRepo,
+			vulnRepo:       &GoldRepo,
+			want:           false,
+		},
+		{
+			name:           "TagCPEMismatch",
+			packageVersion: "v3.5.5-4",
+			fixedInVersion: "v3.5.7-8",
+			repo:           cpeRepo("cpe:/a:redhat:quay:3::el8"),
+			vulnRepo:       cpeRepo("cpe:/a:redhat:openshift:4::el8"),
+			want:           false,
+		},
+		{
+			name:           "GoldenRepoInverted",
+			packageVersion: "7.0.3-13",
+			repo:           &GoldRepo,
+			vulnRepo:       &GoldRepo,
+			invert:         true,
+			want:           true,
+		},
+	}
 
-	t.Run("Normal", func(t *testing.T) {
-		record := &claircore.IndexRecord{
-			Package:    &claircore.Package{Name: "quay/quay-rhel8", Version: "v3.5.5-4"},
-			Repository: &GoldRepo,
-		}
-		vuln := &claircore.Vulnerability{
-			Name:           "CVE-2023-12345",
-			FixedInVersion: "v3.5.6-1",
-			Repo:           &GoldRepo,
-		}
-		got, err := m.Vulnerable(ctx, record, vuln)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !got {
-			t.Error("expected vulnerable=true when version < fixed")
-		}
-	})
+	var m matcher
+	for _, tc := range table {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			record := &claircore.IndexRecord{
+				Package: &claircore.Package{
+					Version: tc.packageVersion,
+				},
+				Repository: tc.repo,
+			}
+			vuln := &claircore.Vulnerability{
+				Invert:         tc.invert,
+				FixedInVersion: tc.fixedInVersion,
+				Repo:           tc.vulnRepo,
+			}
+			got, err := m.Vulnerable(ctx, record, vuln)
+			if err != nil {
+				t.Error(err)
+			}
+			if got != tc.want {
+				t.Errorf("%q failed: Vulnerable(%q, %q) = %v, want %v",
+					tc.name, tc.packageVersion, tc.fixedInVersion, got, tc.want)
+			}
+		})
+	}
+}
 
-	t.Run("Fixed", func(t *testing.T) {
-		record := &claircore.IndexRecord{
-			Package:    &claircore.Package{Name: "quay/quay-rhel8", Version: "v3.5.7-1"},
-			Repository: &GoldRepo,
-		}
-		vuln := &claircore.Vulnerability{
-			Name:           "CVE-2023-12345",
-			FixedInVersion: "v3.5.6-1",
-			Repo:           &GoldRepo,
-		}
-		got, err := m.Vulnerable(ctx, record, vuln)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if got {
-			t.Error("expected vulnerable=false when version >= fixed")
-		}
-	})
+func cpeRepo(s string) *claircore.Repository {
+	w := cpe.MustUnbind(s)
+	return &claircore.Repository{
+		Key:  RepositoryKey,
+		Name: w.String(),
+		CPE:  w,
+	}
 }

--- a/rhel/rhcc/matcher_test.go
+++ b/rhel/rhcc/matcher_test.go
@@ -47,6 +47,14 @@ func TestMatcherVulnerable(t *testing.T) {
 			want:           false,
 		},
 		{
+			name:           "TimestampUnfixed",
+			packageVersion: "1742843776",
+			fixedInVersion: "",
+			repo:           cpeRepo("cpe:/a:redhat:openshift_gitops:1.16::el8"),
+			vulnRepo:       cpeRepo("cpe:/a:redhat:openshift_gitops:1.16::el8"),
+			want:           true,
+		},
+		{
 			name:           "TagOlder",
 			packageVersion: "v3.5.5-4",
 			fixedInVersion: "v3.5.7-8",
@@ -77,6 +85,22 @@ func TestMatcherVulnerable(t *testing.T) {
 			repo:           &GoldRepo,
 			vulnRepo:       &GoldRepo,
 			want:           false,
+		},
+		{
+			name:           "TagUnfixed",
+			packageVersion: "v3.5.9-2",
+			fixedInVersion: "",
+			repo:           cpeRepo("cpe:/a:redhat:quay:3::el8"),
+			vulnRepo:       cpeRepo("cpe:/a:redhat:quay:3::el8"),
+			want:           true,
+		},
+		{
+			name:           "GoldenRepoTagUnfixed",
+			packageVersion: "v3.5.9-2",
+			fixedInVersion: "",
+			repo:           &GoldRepo,
+			vulnRepo:       &GoldRepo,
+			want:           true,
 		},
 		{
 			name:           "TagCPEMismatch",


### PR DESCRIPTION
rpmver.Parse requires a string in the EVR format (version-release, with
at least one dash). For newer (e.g., Konflux-built) Red Hat images, the
rhcc detector parses a Unix timestamp-based version (e.g., "1744596866")
from the labels.json file and the VEX parser extracts matching timestamp
tags from OCI PURLs, neither of which contain a dash. This caused
rpmver.Parse to reject them with "missing separators", preventing any
vulnerability matching for containers using the new labels.json
metadata.

These changes normalize version strings in the matcher by appending "-0"
when no dash (release) is present, consistent with what rhctag.toEVR()
already does.