### PR TITLE
acceptance: modify framework to make dynamic fixture passing easier

### DIFF
--- a/docs/howto/acceptance_testing.md
+++ b/docs/howto/acceptance_testing.md
@@ -18,7 +18,9 @@ identifies vulnerabilities in container images using VEX documents.
       - [Create Options](#create-options)
   - [Running Tests](#running-tests)
     - [Running Integration Tests](#running-integration-tests)
+    - [Using Alternative Repository](#using-alternative-repository)
     - [Using Local OCI Layout](#using-local-oci-layout)
+    - [Building Fixtures from Live VEX URLs](#building-fixtures-from-live-vex-urls)
   - [Testing with Claircore](#testing-with-claircore)
   - [Implementing a Custom Auditor](#implementing-a-custom-auditor)
   - [Media Types](#media-types)
@@ -216,6 +218,22 @@ acceptance.Run(ctx, t, auditor, []string{
     "ocidir:///path/to/local/fixture",
 })
 ```
+
+### Building Fixtures from Live VEX URLs
+
+If you already have VEX documents hosted at known URLs (e.g. from a security
+advisory feed), you can supply them directly without storing them as OCI referrers.
+Use `FetchVEXDocs` to download the documents, populate a `Fixture` directly, and
+pass it to `Run` via `WithFixture`. The image `Reference` is still pulled from a
+registry for indexing.
+
+See [`example_test.go`](../../test/acceptance/example_test.go) for an example
+(`ExampleWithFixture`).
+
+This approach is useful for:
+
+- Rapid iteration during development without pushing VEX documents to a registry
+- Testing regressions in a live advisory feed
 
 ## Testing with Claircore
 

--- a/test/acceptance/acceptance.go
+++ b/test/acceptance/acceptance.go
@@ -109,6 +109,7 @@ func runOne(ctx context.Context, t *testing.T, a Auditor, ref string, opts ...Lo
 			}
 		}
 	}
+
 	results, err := a.Audit(ctx, t, fix.Reference, csafReaders)
 	if err != nil {
 		t.Fatalf("audit: %v", err)
@@ -116,7 +117,7 @@ func runOne(ctx context.Context, t *testing.T, a Auditor, ref string, opts ...Lo
 	t.Logf("auditor returned %d results", len(results))
 
 	cmp := Compare(fix.Expected, results)
-	cmp.Fixture = ref
+	cmp.Fixture = fix.Reference
 
 	for _, m := range cmp.Mismatches {
 		t.Errorf("MISMATCH %s/%s: got %s, want %s",
@@ -125,7 +126,6 @@ func runOne(ctx context.Context, t *testing.T, a Auditor, ref string, opts ...Lo
 	for _, m := range cmp.Misses {
 		t.Errorf("MISSING %s/%s: expected %s", m.ID, m.Product, m.Status)
 	}
-
 	if len(cmp.Extras) > 0 {
 		t.Logf("note: scanner reported %d results not in fixture", len(cmp.Extras))
 		for _, e := range cmp.Extras {

--- a/test/acceptance/auditor_claircore.go
+++ b/test/acceptance/auditor_claircore.go
@@ -183,9 +183,6 @@ func (a *ClaircoreAuditor) Audit(ctx context.Context, t testing.TB, reference st
 		return nil, fmt.Errorf("parse CSAF: %w", err)
 	}
 	slog.DebugContext(ctx, "parsed CSAF documents", "vuln_count", len(vulns))
-	for i, v := range vulns {
-		slog.DebugContext(ctx, "parsed vulnerability", "idx", i, "name", v.Name, "pkg_name", v.Package.Name, "pkg_version", v.Package.Version)
-	}
 	if len(vulns) > 0 {
 		_, err = a.store.UpdateVulnerabilities(ctx, "acceptance-test", "csaf", vulns)
 		if err != nil {

--- a/test/acceptance/example_test.go
+++ b/test/acceptance/example_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"io"
 	"iter"
+	"net/http"
 	"testing"
 
 	"github.com/quay/claircore/test/acceptance"
+	"github.com/quay/claircore/toolkit/fixtures"
 )
 
 // ExampleAuditor demonstrates how to implement a custom Auditor.
@@ -37,4 +39,30 @@ func Example() {
 	acceptance.Run(ctx, t, auditor, []string{
 		"quay.io/projectquay/clair-fixtures:python-test",
 	})
+}
+
+// ExampleWithFixture demonstrates building a fixture from live VEX URLs
+// using [acceptance.FetchVEXDocs] and [acceptance.WithFixture], without
+// storing VEX documents as OCI referrers.
+func ExampleWithFixture() {
+	ctx := context.Background()
+	t := &testing.T{}
+	auditor := &ExampleAuditor{}
+
+	docs, err := acceptance.FetchVEXDocs(ctx, http.DefaultClient, []string{
+		"https://security.example.com/advisories/CVE-2024-1234.json",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fix := &acceptance.Fixture{
+		Reference:    "registry.example.com/namespace/image@sha256:abc123...",
+		VEXDocuments: docs,
+		Expected: []fixtures.ManifestRecord{
+			{ID: "CVE-2024-1234", Product: "mypackage-1.2.3", Status: fixtures.StatusAffected},
+		},
+	}
+
+	acceptance.Run(ctx, t, auditor, nil, acceptance.WithFixture(fix))
 }

--- a/test/acceptance/loader.go
+++ b/test/acceptance/loader.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"slices"
 
 	"github.com/klauspost/compress/zstd"
@@ -41,6 +42,10 @@ type loaderConfig struct {
 // provided. The same fixture is returned for all references, ignoring which
 // reference was requested. For testing multiple fixtures, use real registry
 // fixtures with OCI referrers or call [Run] multiple times.
+//
+// To build a fixture from live VEX URLs rather than OCI referrers, use
+// [FetchVEXDocs] to populate [Fixture.VEXDocuments] and set [Fixture.Expected]
+// inline, then pass the result to [Run].
 func WithFixture(f *Fixture) LoaderOption {
 	return func(c *loaderConfig) {
 		c.fixture = f
@@ -184,6 +189,32 @@ func processReferrer(ctx context.Context, rc *regclient.RegClient, r ref.Ref, de
 	}
 
 	return nil
+}
+
+// FetchVEXDocs fetches CSAF/VEX documents from the given URLs using client.
+// The returned slice can be assigned directly to [Fixture.VEXDocuments].
+func FetchVEXDocs(ctx context.Context, client *http.Client, urls []string) ([][]byte, error) {
+	docs := make([][]byte, 0, len(urls))
+	for _, u := range urls {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		data, readErr := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if readErr != nil {
+			return nil, readErr
+		}
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("fetch %s: unexpected response: %s", u, resp.Status)
+		}
+		docs = append(docs, data)
+	}
+	return docs, nil
 }
 
 // FetchBlob retrieves a blob from the registry, decompressing if needed.


### PR DESCRIPTION
For some test profiles it is nice to have the ability to dynamically fetch VEX data as opposed to them being static. These kind of tests help have live signal.