### PR TITLE
claircore: tweak Alias formatting

### DIFF
--- a/alias.go
+++ b/alias.go
@@ -27,7 +27,9 @@ func (a Alias) String() string {
 	var b strings.Builder
 	b.WriteString(space)
 	if strings.Contains(space, "://") { // If URI-ish:
-		b.WriteByte('#')
+		if !strings.HasSuffix(space, "/") { // If not a "directory":
+			b.WriteByte('#')
+		}
 	} else {
 		b.WriteByte('-')
 	}

--- a/alias_test.go
+++ b/alias_test.go
@@ -13,10 +13,16 @@ func alias(space, name string) Alias {
 	}
 }
 
-func ExampleAlias_uri() {
+func ExampleAlias_uri_slash() {
 	fmt.Println(alias("https://example.com/", "CVE-2014-0160"))
 	// Output:
-	// https://example.com/#CVE-2014-0160
+	// https://example.com/CVE-2014-0160
+}
+
+func ExampleAlias_uri_anchor() {
+	fmt.Println(alias("https://example.com/cve", "CVE-2014-0160"))
+	// Output:
+	// https://example.com/cve#CVE-2014-0160
 }
 
 func ExampleAlias_cve() {


### PR DESCRIPTION
This allows for URI namespaces that end in "/" to just have the name appended.