### PR TITLE
fix: make sure all whiteout files are processed

### DIFF
--- a/indexer/controller/controller.go
+++ b/indexer/controller/controller.go
@@ -42,7 +42,7 @@ func New(options *indexer.Options) *Controller {
 		Environments:  map[string][]*claircore.Environment{},
 		Distributions: map[string]*claircore.Distribution{},
 		Repositories:  map[string]*claircore.Repository{},
-		Files:         map[string]claircore.File{},
+		Files:         map[string]map[string]claircore.FileKind{},
 	}
 
 	s := &Controller{

--- a/indexreport.go
+++ b/indexreport.go
@@ -34,7 +34,7 @@ type IndexReport struct {
 	// an error string in the case the index did not succeed
 	Err string `json:"err"`
 	// Files doesn't end up in the json report but needs to be available at post-coalesce
-	Files map[string]File `json:"-"`
+	Files map[string]map[string]FileKind `json:"-"`
 }
 
 // IndexRecords returns a list of IndexRecords derived from the IndexReport

--- a/whiteout/coalescer.go
+++ b/whiteout/coalescer.go
@@ -14,9 +14,13 @@ func (c *coalescer) Coalesce(ctx context.Context, layerArtifacts []*indexer.Laye
 	for _, l := range layerArtifacts {
 		for _, f := range l.Files {
 			if ir.Files == nil {
-				ir.Files = make(map[string]claircore.File)
+				ir.Files = map[string]map[string]claircore.FileKind{}
 			}
-			ir.Files[l.Hash.String()] = f
+			layerHash := l.Hash.String()
+			if ir.Files[layerHash] == nil {
+				ir.Files[layerHash] = map[string]claircore.FileKind{}
+			}
+			ir.Files[layerHash][f.Path] = f.Kind
 		}
 	}
 	return ir, nil

--- a/whiteout/resolver.go
+++ b/whiteout/resolver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/quay/claircore"
@@ -18,6 +19,16 @@ func (r *Resolver) Resolve(ctx context.Context, ir *claircore.IndexReport, layer
 	// Here we need to check if any of the packages
 	// found are moot due to whiteouts.
 	ls := newLayerSorter(layers)
+
+	whiteouts := make(map[string][]string)
+	for layer, files := range ir.Files {
+		for path, kind := range files {
+			if kind == claircore.FileKindWhiteout {
+				whiteouts[layer] = append(whiteouts[layer], path)
+			}
+		}
+	}
+
 	finalPackages := map[string]*claircore.Package{}
 	finalEnvironments := map[string][]*claircore.Environment{}
 	for pkgID, pkg := range ir.Packages {
@@ -29,24 +40,26 @@ func (r *Resolver) Resolve(ctx context.Context, ir *claircore.IndexReport, layer
 				packageLayer = ir.Environments[pkgID][i].IntroducedIn.String()
 			}
 		}
-		for fileLayer, f := range ir.Files {
-			// Check if it's a whiteout file, if it applies to the package's
-			// filepath and if the layer the whiteout file came from came after.
-			// The spec states: "Whiteout files MUST only apply to resources in
-			// lower/parent layers" hence why we don't check if they're in the same
-			// layer.
-			if f.Kind == claircore.FileKindWhiteout && ls.isChildOf(fileLayer, packageLayer) && fileIsDeleted(pkg.Filepath, f.Path) {
+		// Check if it's a whiteout file, if it applies to the package's
+		// filepath and if the layer the whiteout file came from came after.
+		// The spec states: "Whiteout files MUST only apply to resources in
+		// lower/parent layers" hence why we don't check if they're in the same
+		// layer.
+		for layer, paths := range whiteouts {
+			if ls.isChildOf(layer, packageLayer) && slices.ContainsFunc(paths, func(p string) bool {
+				return fileIsDeleted(pkg.Filepath, p)
+			}) {
 				packageDeleted = true
-				slog.DebugContext(ctx, "package determined to be deleted",
-					"package name", pkg.Name,
-					"package file", pkg.Filepath,
-					"whiteout file", f.Path)
+				break
 			}
 		}
-		if !packageDeleted {
+		if packageDeleted {
+			slog.DebugContext(ctx, "package determined to be deleted",
+				"package name", pkg.Name,
+				"package file", pkg.Filepath)
+		} else {
 			finalPackages[pkgID] = pkg
 			finalEnvironments[pkgID] = ir.Environments[pkgID]
-
 		}
 	}
 	ir.Packages = finalPackages

--- a/whiteout/resolver_test.go
+++ b/whiteout/resolver_test.go
@@ -49,10 +49,9 @@ func TestResolver(t *testing.T) {
 					"1": {{IntroducedIn: firstLayerHash}},
 					"2": {{IntroducedIn: firstLayerHash}},
 				},
-				Files: map[string]claircore.File{
-					secondLayerHash.String(): {
-						Path: "a/path/to/some/file/site-packages/.wh.a_package",
-						Kind: claircore.FileKindWhiteout,
+				Files: map[string]map[string]claircore.FileKind{
+					secondLayerHash.String(): map[string]claircore.FileKind{
+						"a/path/to/some/file/site-packages/.wh.a_package": claircore.FileKindWhiteout,
 					},
 				},
 			},
@@ -80,18 +79,11 @@ func TestResolver(t *testing.T) {
 					"1": {{IntroducedIn: firstLayerHash}},
 					"2": {{IntroducedIn: firstLayerHash}},
 				},
-				Files: map[string]claircore.File{
-					secondLayerHash.String(): {
-						Path: "a/path/to/some/different_file/site-packages/.wh.a_package",
-						Kind: claircore.FileKindWhiteout,
-					},
-					secondLayerHash.String(): {
-						Path: "a/path/to/some/different_file/.wh.site-packages",
-						Kind: claircore.FileKindWhiteout,
-					},
-					secondLayerHash.String(): {
-						Path: "a/path/to/some/.wh.different_file",
-						Kind: claircore.FileKindWhiteout,
+				Files: map[string]map[string]claircore.FileKind{
+					secondLayerHash.String(): map[string]claircore.FileKind{
+						"a/path/to/some/different_file/site-packages/.wh.a_package": claircore.FileKindWhiteout,
+						"a/path/to/some/different_file/.wh.site-packages":           claircore.FileKindWhiteout,
+						"a/path/to/some/.wh.different_file":                         claircore.FileKindWhiteout,
 					},
 				},
 			},
@@ -119,10 +111,9 @@ func TestResolver(t *testing.T) {
 					"1": {{IntroducedIn: firstLayerHash}},
 					"2": {{IntroducedIn: firstLayerHash}},
 				},
-				Files: map[string]claircore.File{
-					secondLayerHash.String(): {
-						Path: "a/path/to/some/file/.wh.site-packages",
-						Kind: claircore.FileKindWhiteout,
+				Files: map[string]map[string]claircore.FileKind{
+					secondLayerHash.String(): map[string]claircore.FileKind{
+						"a/path/to/some/file/.wh.site-packages": claircore.FileKindWhiteout,
 					},
 				},
 			},
@@ -150,10 +141,9 @@ func TestResolver(t *testing.T) {
 					"1": {{IntroducedIn: firstLayerHash}},
 					"2": {{IntroducedIn: firstLayerHash}},
 				},
-				Files: map[string]claircore.File{
-					firstLayerHash.String(): { // whiteout is in the same layer as packages
-						Path: "a/path/to/some/file/site-packages/.wh.b_package",
-						Kind: claircore.FileKindWhiteout,
+				Files: map[string]map[string]claircore.FileKind{
+					firstLayerHash.String(): map[string]claircore.FileKind{ // whiteout is in the same layer as packages
+						"a/path/to/some/file/site-packages/.wh.b_package": claircore.FileKindWhiteout,
 					},
 				},
 			},
@@ -181,10 +171,9 @@ func TestResolver(t *testing.T) {
 					"1": {{IntroducedIn: firstLayerHash}},
 					"2": {{IntroducedIn: firstLayerHash}},
 				},
-				Files: map[string]claircore.File{
-					secondLayerHash.String(): {
-						Path: "a/path/to/some/file/site/.wh..wh..opq",
-						Kind: claircore.FileKindWhiteout,
+				Files: map[string]map[string]claircore.FileKind{
+					secondLayerHash.String(): map[string]claircore.FileKind{
+						"a/path/to/some/file/site/.wh..wh..opq": claircore.FileKindWhiteout,
 					},
 				},
 			},
@@ -212,10 +201,9 @@ func TestResolver(t *testing.T) {
 					"1": {{IntroducedIn: firstLayerHash}},
 					"2": {{IntroducedIn: firstLayerHash}},
 				},
-				Files: map[string]claircore.File{
-					secondLayerHash.String(): {
-						Path: "a/path/to/some/file/site-packages/.wh..wh..opq",
-						Kind: claircore.FileKindWhiteout,
+				Files: map[string]map[string]claircore.FileKind{
+					secondLayerHash.String(): map[string]claircore.FileKind{
+						"a/path/to/some/file/site-packages/.wh..wh..opq": claircore.FileKindWhiteout,
 					},
 				},
 			},
@@ -238,10 +226,9 @@ func TestResolver(t *testing.T) {
 				Environments: map[string][]*claircore.Environment{
 					"1": {{IntroducedIn: firstLayerHash}, {IntroducedIn: thirdLayerHash}},
 				},
-				Files: map[string]claircore.File{
-					secondLayerHash.String(): { // whiteout is sandwiched
-						Path: "a/path/to/some/file/site-packages/.wh.a_package",
-						Kind: claircore.FileKindWhiteout,
+				Files: map[string]map[string]claircore.FileKind{
+					secondLayerHash.String(): map[string]claircore.FileKind{ // whiteout is sandwiched
+						"a/path/to/some/file/site-packages/.wh.a_package": claircore.FileKindWhiteout,
 					},
 				},
 			},
@@ -249,6 +236,48 @@ func TestResolver(t *testing.T) {
 				{Hash: firstLayerHash},
 				{Hash: secondLayerHash},
 				{Hash: thirdLayerHash},
+			},
+			LenPackage: 1,
+			LenEnvs:    1,
+		},
+		{
+			Name: "MultipleWhiteoutFiles",
+			Report: &claircore.IndexReport{
+				Packages: map[string]*claircore.Package{
+					"1": {
+						Name:     "package a",
+						Filepath: "a/path/to/some/file/site-packages/a_package/METADATA",
+					},
+					"2": {
+						Name:     "package b",
+						Filepath: "a/path/to/some/file/site-packages/b_package/METADATA",
+					},
+					"3": {
+						Name:     "package c",
+						Filepath: "a/path/to/some/file/site2-packages/c_package/METADATA",
+					},
+					"4": {
+						Name:     "package d",
+						Filepath: "a/path/to/some/file/site-packages/d_package/METADATA",
+					},
+				},
+				Environments: map[string][]*claircore.Environment{
+					"1": {{IntroducedIn: firstLayerHash}},
+					"2": {{IntroducedIn: firstLayerHash}},
+					"3": {{IntroducedIn: firstLayerHash}},
+					"4": {{IntroducedIn: firstLayerHash}},
+				},
+				Files: map[string]map[string]claircore.FileKind{
+					secondLayerHash.String(): map[string]claircore.FileKind{
+						"a/path/to/some/file/site-packages/.wh.a_package": claircore.FileKindWhiteout,
+						"a/path/to/some/file/site-packages/.wh.b_package": claircore.FileKindWhiteout,
+						"a/path/to/some/file/site2-packages/.wh..wh..opq": claircore.FileKindWhiteout,
+					},
+				},
+			},
+			Layers: []*claircore.Layer{
+				{Hash: firstLayerHash},
+				{Hash: secondLayerHash},
 			},
 			LenPackage: 1,
 			LenEnvs:    1,


### PR DESCRIPTION
This PR fixes the mapping for `IndexReport` files within a layer.  The previous mapping was for one file per layer, with one consequence being the inability to handle more than one whiteout file per layer.