### PR TITLE
matcher: initialize PackageNotVulnerable map

### DIFF
--- a/internal/matcher/match.go
+++ b/internal/matcher/match.go
@@ -98,6 +98,7 @@ func EnrichedMatch(ctx context.Context, ir *claircore.IndexReport, ms []driver.M
 		Repositories:           ir.Repositories,
 		Vulnerabilities:        map[string]*claircore.Vulnerability{},
 		PackageVulnerabilities: map[string][]string{},
+		PackageNotVulnerable:   map[string][]string{},
 		// The Enrichments member isn't constructed here because it's
 		// constructed separately and then added.
 	}

--- a/internal/matcher/match_test.go
+++ b/internal/matcher/match_test.go
@@ -1,0 +1,51 @@
+package matcher
+
+import (
+	"context"
+	"testing"
+
+	"github.com/quay/claircore"
+	"github.com/quay/claircore/datastore"
+	"github.com/quay/claircore/libvuln/driver"
+)
+
+type stubMatcher struct{}
+
+func (stubMatcher) Name() string                          { return "stub" }
+func (stubMatcher) Filter(*claircore.IndexRecord) bool    { return true }
+func (stubMatcher) Query() []driver.MatchConstraint       { return nil }
+func (stubMatcher) Vulnerable(context.Context, *claircore.IndexRecord, *claircore.Vulnerability) (bool, error) {
+	return true, nil
+}
+
+type stubStore struct{ vulns map[string][]*claircore.Vulnerability }
+
+func (s stubStore) Get(context.Context, []*claircore.IndexRecord, datastore.GetOpts) (map[string][]*claircore.Vulnerability, error) {
+	return s.vulns, nil
+}
+func (stubStore) GetEnrichment(context.Context, string, []string) ([]driver.EnrichmentRecord, error) {
+	return nil, nil
+}
+
+func TestEnrichedMatchInvert(t *testing.T) {
+	ctx := t.Context()
+	pkgID := "test-pkg"
+	ir := &claircore.IndexReport{
+		Hash:     claircore.MustParseDigest("sha256:0000000000000000000000000000000000000000000000000000000000000000"),
+		Packages: map[string]*claircore.Package{pkgID: {ID: pkgID, Name: "test"}},
+		Environments: map[string][]*claircore.Environment{
+			pkgID: {{PackageDB: "test"}},
+		},
+	}
+	store := stubStore{vulns: map[string][]*claircore.Vulnerability{
+		pkgID: {{ID: "CVE-2024-0001", Invert: true}},
+	}}
+
+	vr, err := EnrichedMatch(ctx, ir, []driver.Matcher{stubMatcher{}}, nil, store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := vr.PackageNotVulnerable[pkgID]; !ok {
+		t.Errorf("expected %q in PackageNotVulnerable", pkgID)
+	}
+}


### PR DESCRIPTION
## Summary

Initialize the `PackageNotVulnerable` map in `EnrichedMatch()` to prevent a nil map panic when vulnerabilities with `Invert: true` are processed.

## Test

- Added unit test `TestEnrichedMatchInvert` that reproduces the panic with an `Invert: true` vulnerability
