### PR TITLE
cpe: cope with invalid (too long) formatted-string

### DIFF
--- a/toolkit/types/cpe/unbind.go
+++ b/toolkit/types/cpe/unbind.go
@@ -156,11 +156,15 @@ var valueURI = strings.NewReplacer(
 func UnbindFS(s string) (WFN, error) {
 	r := WFN{}
 	if !strings.HasPrefix(s, cpe23Prefix) {
-		return r, fmt.Errorf("cpe: malformed CPE formatted string")
+		return r, fmt.Errorf("cpe: malformed CPE formatted string: bad prefix")
 	}
 	fs := splitFS(s)
+	if l := len(fs); l != 13 {
+		return r, fmt.Errorf("cpe: malformed CPE formatted string: bad components: %d != 13", l)
+	}
+	fs = fs[2:13] // Skip the first two segments, "cpe" and "2.3".
 	var b strings.Builder
-	for i, c := range fs[2:] { // Skip the first two segments, "cpe" and "2.3".
+	for i, c := range fs {
 		r.Attr[i].unbindFS(&b, c)
 	}
 	return r, r.Valid()

--- a/toolkit/types/cpe/wfn_test.go
+++ b/toolkit/types/cpe/wfn_test.go
@@ -275,6 +275,11 @@ func TestUnbinding(t *testing.T) {
 				valueAny(),
 			}},
 		},
+		// Too many components.
+		{
+			Bound: `cpe:2.3:0:000000:00:0:0:0:0:0:0:0:0:0`,
+			Error: true,
+		},
 	}
 
 	// This table is made from the URI unbinding examples in the standards document.


### PR DESCRIPTION
This change validates slice length before using it for array indexes.

Reporter: @vikin91
Change-Id: I87ba434e665e1fa8f1514c14f3f91ef76a6a6964