### PR TITLE
vex: only check vendor_fix remediations

### DIFF
--- a/rhel/vex/index.go
+++ b/rhel/vex/index.go
@@ -108,13 +108,20 @@ func newRemediationIndex() *remediationIndex {
 }
 
 // PopulateRemediations is the populate function for a remediationIndex.
+//
+// Only vendor_fix remediations are indexed, as these are the entries that carry
+// RHSA URLs.
 func populateRemediations(m map[string]*csaf.RemediationData, doc *csaf.CSAF) {
 	for i := range doc.Vulnerabilities {
-		v := &doc.Vulnerabilities[i]
-		for i := range v.Remediations {
-			r := &v.Remediations[i]
+		for j := range doc.Vulnerabilities[i].Remediations {
+			r := &doc.Vulnerabilities[i].Remediations[j]
+			if r.Category != "vendor_fix" {
+				continue
+			}
 			for _, id := range r.ProductIDs {
-				m[id] = r
+				if _, exists := m[id]; !exists {
+					m[id] = r
+				}
 			}
 		}
 	}

--- a/rhel/vex/parser.go
+++ b/rhel/vex/parser.go
@@ -171,7 +171,9 @@ func (p *Parser) parseDoc(ctx context.Context, doc []byte) (string, []*claircore
 				}
 			}
 		}
-		links = append(links, creator.docLink)
+		if creator.docLink != "" {
+			links = append(links, creator.docLink)
+		}
 
 		var desc string
 		for _, n := range v.Notes {
@@ -736,9 +738,9 @@ func (c *creator) knownAffectedVulnerabilities(ctx context.Context, v *csaf.Vuln
 			vuln.Repo = c.rc.Get(st.WFN, repoKey)
 		}
 
-		// Append VEX product ID as URL fragment to the last link for downstream comparison.
-		if vuln.Links != "" {
-			vuln.Links = vuln.Links + "#" + url.PathEscape(st.ID)
+		// Embed VEX product ID as a URL fragment on the VEX document self-link for downstream comparison.
+		if c.docLink != "" {
+			vuln.Links = strings.Replace(vuln.Links, c.docLink, c.docLink+"#"+url.PathEscape(st.ID), 1)
 		}
 	}
 
@@ -879,13 +881,13 @@ func (c *creator) fixedVulnerabilities(ctx context.Context, v *csaf.Vulnerabilit
 			default:
 				panic("unreachable")
 			}
-			// Find remediations and add RHSA URL to links.
+			// Embed VEX product ID as a URL fragment on the VEX document self-link for downstream comparison.
+			if c.docLink != "" {
+				vuln.Links = strings.Replace(vuln.Links, c.docLink, c.docLink+"#"+url.PathEscape(st.ID), 1)
+			}
+			// Append RHSA URL after the VEX self-link.
 			if rem := st.Remediation; rem != nil {
 				vuln.Links = vuln.Links + " " + rem.URL
-			}
-			// Append VEX product ID as URL fragment to the last link for downstream comparison.
-			if vuln.Links != "" {
-				vuln.Links = vuln.Links + "#" + url.PathEscape(st.ID)
 			}
 
 			commit(key, vuln)
@@ -993,13 +995,13 @@ func (c *creator) knownNotAffectedVulnerabilities(ctx context.Context, v *csaf.V
 			default:
 				panic("unreachable")
 			}
-			// Find remediations and add RHSA URL to links.
+			// Embed VEX product ID as a URL fragment on the VEX document self-link for downstream comparison.
+			if c.docLink != "" {
+				vuln.Links = strings.Replace(vuln.Links, c.docLink, c.docLink+"#"+url.PathEscape(st.ID), 1)
+			}
+			// Append RHSA URL after the VEX self-link.
 			if rem := st.Remediation; rem != nil {
 				vuln.Links = vuln.Links + " " + rem.URL
-			}
-			// Append VEX product ID as URL fragment to the last link for downstream comparison.
-			if vuln.Links != "" {
-				vuln.Links = vuln.Links + "#" + url.PathEscape(st.ID)
 			}
 
 			commit(key, vuln)

--- a/test/acceptance/auditor_claircore.go
+++ b/test/acceptance/auditor_claircore.go
@@ -638,23 +638,24 @@ func convertVulnReport(vr *claircore.VulnerabilityReport) []Result {
 }
 
 // ExtractProductIDFromLinks extracts the VEX product ID from the URL fragment
-// appended to the last link in the Links string.
+// in the Links string. The product ID is encoded as a fragment on the VEX
+// self-link, which may be followed by a remediation URL without a fragment.
+// All links are scanned and all fragments are collected; only one product ID
+// fragment is expected, so the first one found is returned.
 func extractProductIDFromLinks(links string) string {
 	if links == "" {
 		return ""
 	}
-	parts := strings.Split(links, " ")
-	lastLink := parts[len(parts)-1]
-	u, err := url.Parse(lastLink)
-	if err != nil {
-		return ""
+	for _, link := range strings.Fields(links) {
+		u, err := url.Parse(link)
+		if err != nil || u.Fragment == "" {
+			continue
+		}
+		productID, err := url.PathUnescape(u.Fragment)
+		if err != nil {
+			continue
+		}
+		return productID
 	}
-	if u.Fragment == "" {
-		return ""
-	}
-	productID, err := url.PathUnescape(u.Fragment)
-	if err != nil {
-		return ""
-	}
-	return productID
+	return ""
 }


### PR DESCRIPTION
RHSA links were being lost for vulnerabilities where the productID had multiple remediations and the last one (without a `url` was winning). This change modifies populateRemediations to only consider `vendor_fix` remediations.