### PR TITLE
osv: skip ECOSYSTEM ranges for Go and npm

### DIFF
--- a/updater/osv/osv.go
+++ b/updater/osv/osv.go
@@ -641,6 +641,16 @@ func (e *ecs) Insert(ctx context.Context, log *slog.Logger, skipped *stats, name
 			switch r.Type {
 			case `SEMVER`:
 			case `ECOSYSTEM`:
+				switch af.Package.Ecosystem {
+				case ecosystemGo, ecosystemNPM:
+					log.WarnContext(ctx, "unexpected ECOSYSTEM range, skipping",
+						"ecosystem", af.Package.Ecosystem,
+						"advisory", a.ID)
+					if skipped != nil {
+						skipped.Ignored(a.ID)
+					}
+					continue
+				}
 				b.Reset()
 			case `GIT`:
 				// ignore, not going to fetch source.
@@ -730,8 +740,6 @@ func (e *ecs) Insert(ctx context.Context, log *slog.Logger, skipped *stats, name
 						case ev.LastAffected != "":
 							vs.ecosystemRange.Add("lastAffected", ev.LastAffected)
 						}
-					case ecosystemGo, ecosystemNPM:
-						return fmt.Errorf(`unexpected "ECOSYSTEM" entry for %q ecosystem: %s`, af.Package.Ecosystem, a.ID)
 					default:
 						switch {
 						case ev.Introduced == "0": // -Inf

--- a/updater/osv/osv_test.go
+++ b/updater/osv/osv_test.go
@@ -632,6 +632,62 @@ var insertTestCases = []struct {
 			},
 		},
 	},
+	{
+		name: "npm_ecosystem_range_skipped",
+		ad: &advisory{
+			ID: "GHSA-test-npm-1",
+			Affected: []affected{
+				{
+					Package: _package{
+						Ecosystem: "npm",
+						Name:      "nocodb",
+					},
+					Ranges: []_range{
+						{
+							Type: "ECOSYSTEM",
+							Events: []rangeEvent{
+								{
+									Introduced: "0",
+								},
+								{
+									Fixed: "2026.04.1",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		expectedVulns: nil,
+	},
+	{
+		name: "go_ecosystem_range_skipped",
+		ad: &advisory{
+			ID: "GHSA-test-go-1",
+			Affected: []affected{
+				{
+					Package: _package{
+						Ecosystem: "Go",
+						Name:      "example.com/module",
+					},
+					Ranges: []_range{
+						{
+							Type: "ECOSYSTEM",
+							Events: []rangeEvent{
+								{
+									Introduced: "0",
+								},
+								{
+									Fixed: "1.2.3",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		expectedVulns: nil,
+	},
 }
 
 // cmpIgnore will ignore everything expect the Name, Updater, Range and FixedInVersion.


### PR DESCRIPTION
The GitHub Advisory Database published advisories for the npm package `nocodb` using `ECOSYSTEM` range type instead of `SEMVER` (e.g., [GHSA-4w6r-5c2j-qf5f](https://github.com/advisories/GHSA-4w6r-5c2j-qf5f)). This happens because nocodb switched to calendar-based versioning (`2026.04.1`), which is not valid SemVer 2.0 — the advisory database chose `ECOSYSTEM` accordingly.

The parser currently returns a hard error for `ECOSYSTEM` ranges on Go and npm ecosystems, added as a defensive check in a607a05d and 87be0246. This error propagates through Parse, aborting the entire ecosystem update.

This change skips the range with a warning instead, using the same pattern as `GIT` ranges. The advisory is recorded via `stats.Ignored`.