### PR TITLE
osv: backport ECOSYSTEM skip to stable-1.5.44

### DIFF
--- a/updater/osv/osv.go
+++ b/updater/osv/osv.go
@@ -564,6 +564,17 @@ func (e *ecs) Insert(ctx context.Context, skipped *stats, name string, a *adviso
 			switch r.Type {
 			case `SEMVER`:
 			case `ECOSYSTEM`:
+				switch af.Package.Ecosystem {
+				case ecosystemGo, ecosystemNPM:
+					zlog.Warn(ctx).
+						Str("ecosystem", string(af.Package.Ecosystem)).
+						Str("advisory", a.ID).
+						Msg("unexpected ECOSYSTEM range, skipping")
+					if skipped != nil {
+						skipped.Ignored = append(skipped.Ignored, a.ID)
+					}
+					continue
+				}
 				b.Reset()
 			case `GIT`:
 				// ignore, not going to fetch source.
@@ -657,8 +668,6 @@ func (e *ecs) Insert(ctx context.Context, skipped *stats, name string, a *adviso
 						case ev.LastAffected != "":
 							vs.ecosystemRange.Add("lastAffected", ev.LastAffected)
 						}
-					case ecosystemGo, ecosystemNPM:
-						return fmt.Errorf(`unexpected "ECOSYSTEM" entry for %q ecosystem: %s`, af.Package.Ecosystem, a.ID)
 					default:
 						switch {
 						case ev.Introduced == "0": // -Inf

--- a/updater/osv/osv_test.go
+++ b/updater/osv/osv_test.go
@@ -608,6 +608,62 @@ var insertTestCases = []struct {
 			},
 		},
 	},
+	{
+		name: "npm_ecosystem_range_skipped",
+		ad: &advisory{
+			ID: "GHSA-test-npm-1",
+			Affected: []affected{
+				{
+					Package: _package{
+						Ecosystem: "npm",
+						Name:      "nocodb",
+					},
+					Ranges: []_range{
+						{
+							Type: "ECOSYSTEM",
+							Events: []rangeEvent{
+								{
+									Introduced: "0",
+								},
+								{
+									Fixed: "2026.04.1",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		expectedVulns: nil,
+	},
+	{
+		name: "go_ecosystem_range_skipped",
+		ad: &advisory{
+			ID: "GHSA-test-go-1",
+			Affected: []affected{
+				{
+					Package: _package{
+						Ecosystem: "Go",
+						Name:      "example.com/module",
+					},
+					Ranges: []_range{
+						{
+							Type: "ECOSYSTEM",
+							Events: []rangeEvent{
+								{
+									Introduced: "0",
+								},
+								{
+									Fixed: "1.2.3",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		expectedVulns: nil,
+	},
 }
 
 // cmpIgnore will ignore everything expect the Name, Updater, Range and FixedInVersion.


### PR DESCRIPTION
Backport of #1908 to `stable-1.5.44` for the ACS 4.9.x v2 vulnerability bundle stream.

Adapted for the v1.5.44 API: uses `zlog` instead of `slog`, `skipped.Ignored` as a slice append instead of a method call.

Context: [ROX-34975](https://redhat.atlassian.net/browse/ROX-34975)