### PR TITLE
rhcc: account for incorrectly double-quoted labels.json values

### DIFF
--- a/rhel/rhcc/detector.go
+++ b/rhel/rhcc/detector.go
@@ -121,6 +121,14 @@ func findLabelsJSON(sys fs.FS) (*labels, string, error) {
 			if err := json.Unmarshal(l, &lb); err != nil {
 				return nil, "", err
 			}
+			// A build tooling bug caused some images to be published with label
+			// values wrapped in an extra layer of JSON string quoting (e.g.
+			// `"\"rhacs-main-container\""` instead of `"rhacs-main-container"`).
+			for _, p := range []*string{&lb.Name, &lb.Architecture, &lb.CPE} {
+				if u, err := strconv.Unquote(*p); err == nil {
+					*p = u
+				}
+			}
 			return &lb, p, nil
 		case errors.Is(err, fs.ErrNotExist):
 			continue

--- a/rhel/rhcc/detector_test.go
+++ b/rhel/rhcc/detector_test.go
@@ -161,6 +161,73 @@ func TestPackageDetector(t *testing.T) {
 			},
 		},
 		{
+			Name:       "PackageQuotedLabelsTest",
+			LabelsFile: "testdata/quoted_labels.json",
+			LabelsPath: "root/buildinfo/labels.json",
+			Want: []*claircore.Package{
+				{
+					Name:    "openshift-gitops-1/gitops-rhel8-operator",
+					Version: "1744596866",
+					NormalizedVersion: claircore.Version{
+						Kind: "rhctag",
+						V:    [10]int32{1744596866},
+					},
+					Kind:           types.SourcePackage,
+					PackageDB:      "root/buildinfo/labels.json",
+					RepositoryHint: "rhcc",
+					Arch:           "x86_64",
+				},
+				{
+					Name:    "openshift-gitops-1/gitops-rhel8-operator",
+					Version: "1744596866",
+					NormalizedVersion: claircore.Version{
+						Kind: "rhctag",
+						V:    [10]int32{1744596866},
+					},
+					Kind: types.BinaryPackage,
+					Source: &claircore.Package{
+						Name:    "openshift-gitops-1/gitops-rhel8-operator",
+						Version: "1744596866",
+						NormalizedVersion: claircore.Version{
+							Kind: "rhctag",
+							V:    [10]int32{1744596866},
+						},
+						Kind:           types.SourcePackage,
+						PackageDB:      "root/buildinfo/labels.json",
+						RepositoryHint: "rhcc",
+						Arch:           "x86_64",
+					},
+					PackageDB:      "root/buildinfo/labels.json",
+					RepositoryHint: "rhcc",
+					Arch:           "x86_64",
+				},
+				{
+					Name:    "openshift-gitops-1/gitops-rhel8-operator",
+					Version: "1744596866",
+					NormalizedVersion: claircore.Version{
+						Kind: "rhctag",
+						V:    [10]int32{1744596866},
+					},
+					Kind: types.AncestryPackage,
+					Source: &claircore.Package{
+						Name:    "openshift-gitops-1/gitops-rhel8-operator",
+						Version: "1744596866",
+						NormalizedVersion: claircore.Version{
+							Kind: "rhctag",
+							V:    [10]int32{1744596866},
+						},
+						Kind:           types.SourcePackage,
+						PackageDB:      "root/buildinfo/labels.json",
+						RepositoryHint: "rhcc",
+						Arch:           "x86_64",
+					},
+					PackageDB:      "root/buildinfo/labels.json",
+					RepositoryHint: "rhcc",
+					Arch:           "x86_64",
+				},
+			},
+		},
+		{
 			Name:       "PackageBadPathLabelsTest",
 			LabelsFile: "testdata/simple_labels.json",
 			LabelsPath: "bad/path/labels.json",
@@ -236,6 +303,18 @@ func TestRepositoryDetector(t *testing.T) {
 			Name:       "RepositoryRHCOSLabelsTest",
 			LabelsFile: "testdata/simple_labels.json",
 			LabelsPath: "usr/share/buildinfo/labels.json",
+			Want: []*claircore.Repository{
+				{
+					Name: "cpe:2.3:a:redhat:openshift_gitops:1.16:*:el8:*:*:*:*:*",
+					Key:  "rhcc-container-repository",
+					CPE:  cpe.MustUnbind("cpe:2.3:a:redhat:openshift_gitops:1.16:*:el8:*:*:*:*:*"),
+				},
+			},
+		},
+		{
+			Name:       "RepositoryQuotedLabelsTest",
+			LabelsFile: "testdata/quoted_labels.json",
+			LabelsPath: "root/buildinfo/labels.json",
 			Want: []*claircore.Repository{
 				{
 					Name: "cpe:2.3:a:redhat:openshift_gitops:1.16:*:el8:*:*:*:*:*",

--- a/rhel/rhcc/testdata/quoted_labels.json
+++ b/rhel/rhcc/testdata/quoted_labels.json
@@ -1,0 +1,6 @@
+{
+    "name": "\"openshift-gitops-1/gitops-rhel8-operator\"",
+    "org.opencontainers.image.created": "2025-04-14T02:14:26Z",
+    "cpe": "cpe:/a:redhat:openshift_gitops:1.16::el8",
+    "architecture": "\"x86_64\""
+}


### PR DESCRIPTION
The Red Hat build system was writing labels.json files that had double quoted values which would cause false negatives during matching.