### PR TITLE
chore: update 2.3 formatted string CPEs in the codebase to match spec

### DIFF
--- a/aws/releases.go
+++ b/aws/releases.go
@@ -50,7 +50,7 @@ var AL2Dist = &claircore.Distribution{
 	Version:    "2",
 	VersionID:  "2",
 	PrettyName: "Amazon Linux 2",
-	CPE:        cpe.MustUnbind("cpe:2.3:o:amazon:amazon_linux:2"),
+	CPE:        cpe.MustUnbind("cpe:2.3:o:amazon:amazon_linux:2:*:*:*:*:*:*:*"),
 }
 
 var AL2023Dist = &claircore.Distribution{
@@ -59,7 +59,7 @@ var AL2023Dist = &claircore.Distribution{
 	Version:    "2023",
 	VersionID:  "2023",
 	PrettyName: "Amazon Linux 2023",
-	CPE:        cpe.MustUnbind("cpe:2.3:o:amazon:amazon_linux:2023"),
+	CPE:        cpe.MustUnbind("cpe:2.3:o:amazon:amazon_linux:2023:*:*:*:*:*:*:*"),
 }
 
 func releaseToDist(release Release) *claircore.Distribution {

--- a/rhel/vex/parser_test.go
+++ b/rhel/vex/parser_test.go
@@ -288,7 +288,7 @@ func TestParseCompare(t *testing.T) {
 					Repo: &claircore.Repository{
 						Name: "cpe:2.3:a:redhat:openshift:4.16:*:el9:*:*:*:*:*",
 						Key:  "rhel-cpe-repository",
-						CPE:  cpe.MustUnbind("cpe:2.3:a:redhat:openshift:4.16::el9"),
+						CPE:  cpe.MustUnbind("cpe:2.3:a:redhat:openshift:4.16:*:el9:*:*:*:*:*"),
 					},
 					ArchOperation: claircore.OpPatternMatch,
 					Self:          claircore.Alias{Space: spaceRedHat, Name: "CVE-2024-24786"},

--- a/suse/purl_test.go
+++ b/suse/purl_test.go
@@ -33,8 +33,8 @@ func TestRoundTripIndexRecord(t *testing.T) {
 					Source:  &claircore.Package{},
 				},
 				Distribution: &claircore.Distribution{
-					CPE:        cpe.MustUnbind("cpe:2.3:o:opensuse:leap:15.5"),
-					Name:       "openSUSE Leap",
+				CPE:        cpe.MustUnbind("cpe:2.3:o:opensuse:leap:15.5:*:*:*:*:*:*:*"),
+				Name:       "openSUSE Leap",
 					VersionID:  "15.5",
 					Version:    "15.5",
 					DID:        "opensuse-leap",
@@ -100,8 +100,8 @@ func TestGeneratePURL(t *testing.T) {
 					Arch:    "x86_64",
 				},
 				Distribution: &claircore.Distribution{
-					CPE:       cpe.MustUnbind("cpe:2.3:o:opensuse:leap:15.5"),
-					Name:      "openSUSE Leap",
+				CPE:       cpe.MustUnbind("cpe:2.3:o:opensuse:leap:15.5:*:*:*:*:*:*:*"),
+				Name:      "openSUSE Leap",
 					VersionID: "15.5",
 					DID:       "opensuse",
 				},


### PR DESCRIPTION
This change bring the CPEs in the codebase up to spec which specifies: all eleven (11) attribute values MUST appear in the formatted string binding. (https://nvlpubs.nist.gov/nistpubs/Legacy/IR/nistir7695.pdf).