### PR TITLE
aliases: widen the vulnerability FK columns in the alias tables from INTEGER to BIGINT

### DIFF
--- a/datastore/postgres/get.go
+++ b/datastore/postgres/get.go
@@ -210,7 +210,7 @@ func populateAliases(ctx context.Context, tx pgx.Tx, results map[string][]*clair
 		FROM vulnerability_alias va
 		JOIN alias a ON va.alias = a.id
 		JOIN alias_namespace ns ON a.namespace = ns.id
-		WHERE va.vulnerability = ANY($1)
+		WHERE va.vulnerability = ANY($1::bigint[])
 	`
 	aliasRows, err := tx.Query(ctx, aliasQuery, ids)
 	if err != nil {
@@ -242,7 +242,7 @@ func populateAliases(ctx context.Context, tx pgx.Tx, results map[string][]*clair
 		FROM vulnerability_self vs
 		JOIN alias a ON vs.self = a.id
 		JOIN alias_namespace ns ON a.namespace = ns.id
-		WHERE vs.vulnerability = ANY($1)
+		WHERE vs.vulnerability = ANY($1::bigint[])
 	`
 	selfRows, err := tx.Query(ctx, selfQuery, ids)
 	if err != nil {

--- a/datastore/postgres/migrations/matcher/19-alias-bigint.sql
+++ b/datastore/postgres/migrations/matcher/19-alias-bigint.sql
@@ -1,0 +1,7 @@
+-- Widen the vulnerability FK columns in the alias tables from INTEGER to BIGINT
+-- to match the vuln.id column.
+ALTER TABLE vulnerability_alias
+ALTER COLUMN vulnerability TYPE BIGINT;
+
+ALTER TABLE vulnerability_self
+ALTER COLUMN vulnerability TYPE BIGINT;


### PR DESCRIPTION
There is a possible error on long running instances where the `vuln.ID` has exceeded 32-bits but the `alias.vulnerability` can not handle anything > 32-bits.