### PR TITLE
rhcc: backport double-quoted labels.json values fix

### DIFF
--- a/rhel/rhcc/detector.go
+++ b/rhel/rhcc/detector.go
@@ -113,6 +113,14 @@ func findJSONLabels(ctx context.Context, sys fs.FS) (*labels, error) {
 	if err != nil {
 		return nil, err
 	}
+	// A build tooling bug caused some images to be published with label
+	// values wrapped in an extra layer of JSON string quoting (e.g.
+	// `"\"rhacs-main-container\""` instead of `"rhacs-main-container"`).
+	for _, p := range []*string{&labels.Name, &labels.Architecture, &labels.CPE} {
+		if u, err := strconv.Unquote(*p); err == nil {
+			*p = u
+		}
+	}
 	return &labels, nil
 }
 

--- a/rhel/rhcc/detector_test.go
+++ b/rhel/rhcc/detector_test.go
@@ -58,6 +58,26 @@ func TestPackageDetector(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name:       "PackageQuotedLabelsTest",
+			LabelsFile: "testdata/quoted_labels.json",
+			Want: []*claircore.Package{
+				gitopsSourceContainer,
+				{
+					Name:    "openshift-gitops-1/gitops-rhel8-operator",
+					Version: "1744596866",
+					NormalizedVersion: claircore.Version{
+						Kind: "rhctag",
+						V:    [10]int32{1744596866},
+					},
+					Kind:           claircore.BINARY,
+					Source:         gitopsSourceContainer,
+					PackageDB:      "root/buildinfo/labels.json",
+					RepositoryHint: "rhcc",
+					Arch:           "x86_64",
+				},
+			},
+		},
 	}
 	var cd detector
 
@@ -114,6 +134,17 @@ func TestRepositoryDetector(t *testing.T) {
 		{
 			Name:       "RepositoryLabelsTest",
 			LabelsFile: "testdata/simple_labels.json",
+			Want: []*claircore.Repository{
+				{
+					Name: "cpe:2.3:a:redhat:openshift_gitops:1.16:*:el8:*:*:*:*:*",
+					Key:  "rhcc-container-repository",
+					CPE:  cpe.MustUnbind("cpe:2.3:a:redhat:openshift_gitops:1.16:*:el8:*:*:*:*:*"),
+				},
+			},
+		},
+		{
+			Name:       "RepositoryQuotedLabelsTest",
+			LabelsFile: "testdata/quoted_labels.json",
 			Want: []*claircore.Repository{
 				{
 					Name: "cpe:2.3:a:redhat:openshift_gitops:1.16:*:el8:*:*:*:*:*",

--- a/rhel/rhcc/testdata/quoted_labels.json
+++ b/rhel/rhcc/testdata/quoted_labels.json
@@ -1,0 +1,6 @@
+{
+    "name": "\"openshift-gitops-1/gitops-rhel8-operator\"",
+    "org.opencontainers.image.created": "2025-04-14T02:14:26Z",
+    "cpe": "cpe:/a:redhat:openshift_gitops:1.16::el8",
+    "architecture": "\"x86_64\""
+}


### PR DESCRIPTION
Backports https://github.com/quay/claircore/pull/1921 to `stable-1.5.44`. Stacked on top of https://github.com/quay/claircore/pull/1931