### PR TITLE
fix: update parser error handling for rpm format

### DIFF
--- a/rhel/vex/parser.go
+++ b/rhel/vex/parser.go
@@ -708,26 +708,31 @@ func (r *rope[E]) All() iter.Seq[*E] {
 // KnownAffectedVulnerabilities processes the "known_affected" array of products
 // in the VEX object.
 func (c *creator) knownAffectedVulnerabilities(ctx context.Context, v *csaf.Vulnerability, init vulnHook) ([]*claircore.Vulnerability, error) {
+	log := slog.With("link", c.docLink)
 	var backing rope[claircore.Vulnerability]
+	var doDrop bool
 	for st, err := range c.Status(ctx, v, csaf.ProductStatusKnownAffected) {
 		if err != nil {
 			return nil, err
 		}
 
-		// This loop never skips returned [status] values, so we can always just
-		// append a new [claircore.Vulnerability].
+		// This loop may skip returned [status] values on validation errors,
+		// so we need to manage when to commit a new [claircore.Vulnerability].
 		vuln := backing.New()
+		doDrop = true
 
 		if err := init(ctx, vuln); err != nil {
 			return nil, err
 		}
 		pkgName, err := st.PackageName()
 		if err != nil {
-			return nil, err
+			log.WarnContext(ctx, "bad purl", "reason", err, "purl", st.PURL, "missing", "PackageName")
+			continue
 		}
 		modName, err := st.Module()
 		if err != nil {
-			return nil, err
+			log.WarnContext(ctx, "bad purl", "reason", err, "purl", st.PURL, "missing", "ModuleName")
+			continue
 		}
 		vuln.Package = &claircore.Package{
 			Name:   pkgName,
@@ -737,7 +742,8 @@ func (c *creator) knownAffectedVulnerabilities(ctx context.Context, v *csaf.Vuln
 		if sc := st.Score; sc != nil {
 			vuln.Severity, err = cvssVectorFromScore(sc)
 			if err != nil {
-				return nil, fmt.Errorf("could not parse CVSS score: %w, file: %s", err, c.docLink)
+				log.WarnContext(ctx, "bad score", "reason", err, "found", true)
+				continue
 			}
 		}
 		if t := st.Threat; t != nil {
@@ -760,6 +766,11 @@ func (c *creator) knownAffectedVulnerabilities(ctx context.Context, v *csaf.Vuln
 		if c.productIDInLinks && c.docLink != "" {
 			vuln.Links = strings.Replace(vuln.Links, c.docLink, c.docLink+"#"+url.PathEscape(st.ID), 1)
 		}
+		doDrop = false
+	}
+	// Catch if the last status bailed.
+	if doDrop {
+		backing.Drop()
 	}
 
 	out := slices.Collect(backing.All())

--- a/rhel/vex/parser_test.go
+++ b/rhel/vex/parser_test.go
@@ -414,6 +414,12 @@ func TestParse(t *testing.T) {
 			expectedVulns:   269,
 			expectedDeleted: 0,
 		},
+		{
+			name:            "errortesting",
+			filenames:       []string{"testdata/error_CVE-2026-7323.json"},
+			expectedVulns:   193,
+			expectedDeleted: 0,
+		},
 	}
 
 	u := &Updater{url: url, client: http.DefaultClient}
@@ -686,4 +692,3 @@ func TestExtractPackageName(t *testing.T) {
 		})
 	}
 }
-

--- a/rhel/vex/testdata/error_CVE-2026-7323.json
+++ b/rhel/vex/testdata/error_CVE-2026-7323.json
@@ -1,0 +1,4276 @@
+{
+  "document": {
+    "aggregate_severity": {
+      "namespace": "https://access.redhat.com/security/updates/classification/",
+      "text": "Important"
+    },
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "publisher": {
+      "category": "vendor",
+      "contact_details": "https://access.redhat.com/security/team/contact/",
+      "issuing_authority": "Red Hat Product Security is responsible for vulnerability handling across all Red Hat products and services.",
+      "name": "Red Hat Product Security",
+      "namespace": "https://www.redhat.com"
+    },
+    "title": "Memory safety bugs fixed in Firefox ESR 140.10.1 and Firefox 150.0.1",
+    "tracking": {
+      "current_release_date": "2026-06-30T13:05:18+00:00",
+      "generator": {
+        "date": "2026-06-30T13:05:18+00:00",
+        "engine": {
+          "name": "CSAF Generator",
+          "version": "3.1.0"
+        }
+      },
+      "id": "CVE-2026-7323",
+      "initial_release_date": "2026-04-28T13:49:10+00:00",
+      "revision_history": [
+        {
+          "date": "2026-06-30T13:05:18+00:00",
+          "number": "1",
+          "summary": "Last generated version"
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "Red Hat",
+        "branches": [
+          {
+            "category": "product_name",
+            "name": "Red Hat Enterprise Linux 10.0.z",
+            "product": {
+              "name": "Red Hat Enterprise Linux 10.0.z",
+              "product_id": "rhel-10.0.z.eus",
+              "product_identification_helper": {
+                "cpe": "cpe:/o:redhat:enterprise_linux_eus:10.0"
+              }
+            }
+          },
+          {
+            "category": "product_name",
+            "name": "Red Hat Enterprise Linux 10.1.z",
+            "product": {
+              "name": "Red Hat Enterprise Linux 10.1.z",
+              "product_id": "rhel-10.1.z",
+              "product_identification_helper": {
+                "cpe": "cpe:/o:redhat:enterprise_linux:10.1"
+              }
+            }
+          },
+          {
+            "category": "product_name",
+            "name": "Red Hat Enterprise Linux 10.2.z",
+            "product": {
+              "name": "Red Hat Enterprise Linux 10.2.z",
+              "product_id": "rhel-10.2.z.eus",
+              "product_identification_helper": {
+                "cpe": "cpe:/o:redhat:enterprise_linux_eus:10.2"
+              }
+            }
+          },
+          {
+            "category": "product_name",
+            "name": "Red Hat Enterprise Linux 6-els",
+            "product": {
+              "name": "Red Hat Enterprise Linux 6-els",
+              "product_id": "rhel-6-els.els",
+              "product_identification_helper": {
+                "cpe": "cpe:/o:redhat:rhel_els:6"
+              }
+            }
+          },
+          {
+            "category": "product_name",
+            "name": "Red Hat Enterprise Linux 7-els",
+            "product": {
+              "name": "Red Hat Enterprise Linux 7-els",
+              "product_id": "rhel-7-els.els",
+              "product_identification_helper": {
+                "cpe": "cpe:/o:redhat:rhel_els:7"
+              }
+            }
+          },
+          {
+            "category": "product_name",
+            "name": "Red Hat Enterprise Linux 8.10.z",
+            "product": {
+              "name": "Red Hat Enterprise Linux 8.10.z",
+              "product_id": "rhel-8.10.z",
+              "product_identification_helper": {
+                "cpe": "cpe:/a:redhat:enterprise_linux:8"
+              }
+            }
+          },
+          {
+            "category": "product_name",
+            "name": "Red Hat Enterprise Linux 8.10.z",
+            "product": {
+              "name": "Red Hat Enterprise Linux 8.10.z",
+              "product_id": "rhel-8.10.z::appstream",
+              "product_identification_helper": {
+                "cpe": "cpe:/a:redhat:enterprise_linux:8::appstream"
+              }
+            }
+          },
+          {
+            "category": "product_name",
+            "name": "Red Hat Enterprise Linux 8.2.0.z",
+            "product": {
+              "name": "Red Hat Enterprise Linux 8.2.0.z",
+              "product_id": "rhel-8.2.0.z.aus",
+              "product_identification_helper": {
+                "cpe": "cpe:/a:redhat:rhel_aus:8.2"
+              }
+            }
+          },
+          {
+            "category": "product_name",
+            "name": "Red Hat Enterprise Linux 8.4.0.z",
+            "product": {
+              "name": "Red Hat Enterprise Linux 8.4.0.z",
+              "product_id": "rhel-8.4.0.z.aus::appstream",
+              "product_identification_helper": {
+                "cpe": "cpe:/a:redhat:rhel_aus:8.4::appstream"
+              }
+            }
+          },
+          {
+            "category": "product_name",
+            "name": "Red Hat Enterprise Linux 8.4.0.z",
+            "product": {
+              "name": "Red Hat Enterprise Linux 8.4.0.z",
+              "product_id": "rhel-8.4.0.z.eus",
+              "product_identification_helper": {
+                "cpe": "cpe:/a:redhat:rhel_eus:8.4"
+              }
+            }
+          },
+          {
+            "category": "product_name",
+            "name": "Red Hat Enterprise Linux 8.4.0.z",
+            "product": {
+              "name": "Red Hat Enterprise Linux 8.4.0.z",
+              "product_id": "rhel-8.4.0.z.eus::appstream",
+              "product_identification_helper": {
+                "cpe": "cpe:/a:redhat:rhel_eus_long_life:8.4::appstream"
+              }
+            }
+          },
+          {
+            "category": "product_name",
+            "name": "Red Hat Enterprise Linux 8.6.0.z",
+            "product": {
+              "name": "Red Hat Enterprise Linux 8.6.0.z",
+              "product_id": "rhel-8.6.0.z.aus",
+              "product_identification_helper": {
+                "cpe": "cpe:/a:redhat:rhel_aus:8.6"
+              }
+            }
+          },
+          {
+            "category": "product_name",
+            "name": "Red Hat Enterprise Linux 8.6.0.z",
+            "product": {
+              "name": "Red Hat Enterprise Linux 8.6.0.z",
+              "product_id": "rhel-8.6.0.z.aus::appstream",
+              "product_identification_helper": {
+                "cpe": "cpe:/a:redhat:rhel_aus:8.6::appstream"
+              }
+            }
+          },
+          {
+            "category": "product_name",
+            "name": "Red Hat Enterprise Linux 8.6.0.z",
+            "product": {
+              "name": "Red Hat Enterprise Linux 8.6.0.z",
+              "product_id": "rhel-8.6.0.z.eus::appstream",
+              "product_identification_helper": {
+                "cpe": "cpe:/a:redhat:rhel_eus_long_life:8.6::appstream"
+              }
+            }
+          },
+          {
+            "category": "product_name",
+            "name": "Red Hat Enterprise Linux 8.8.0.z",
+            "product": {
+              "name": "Red Hat Enterprise Linux 8.8.0.z",
+              "product_id": "rhel-8.8.0.z.e4s::appstream",
+              "product_identification_helper": {
+                "cpe": "cpe:/a:redhat:rhel_e4s:8.8::appstream"
+              }
+            }
+          },
+          {
+            "category": "product_name",
+            "name": "Red Hat Enterprise Linux 8.8.0.z",
+            "product": {
+              "name": "Red Hat Enterprise Linux 8.8.0.z",
+              "product_id": "rhel-8.8.0.z.eus",
+              "product_identification_helper": {
+                "cpe": "cpe:/a:redhat:rhel_eus:8.8"
+              }
+            }
+          },
+          {
+            "category": "product_name",
+            "name": "Red Hat Enterprise Linux 8.8.0.z",
+            "product": {
+              "name": "Red Hat Enterprise Linux 8.8.0.z",
+              "product_id": "rhel-8.8.0.z.tus::appstream",
+              "product_identification_helper": {
+                "cpe": "cpe:/a:redhat:rhel_tus:8.8::appstream"
+              }
+            }
+          },
+          {
+            "category": "product_name",
+            "name": "Red Hat Enterprise Linux 9.0.0.z",
+            "product": {
+              "name": "Red Hat Enterprise Linux 9.0.0.z",
+              "product_id": "rhel-9.0.0.z.e4s::appstream",
+              "product_identification_helper": {
+                "cpe": "cpe:/a:redhat:rhel_e4s:9.0::appstream"
+              }
+            }
+          },
+          {
+            "category": "product_name",
+            "name": "Red Hat Enterprise Linux 9.0.0.z",
+            "product": {
+              "name": "Red Hat Enterprise Linux 9.0.0.z",
+              "product_id": "rhel-9.0.0.z.eus",
+              "product_identification_helper": {
+                "cpe": "cpe:/a:redhat:rhel_eus:9.0"
+              }
+            }
+          },
+          {
+            "category": "product_name",
+            "name": "Red Hat Enterprise Linux 9.2.0.z",
+            "product": {
+              "name": "Red Hat Enterprise Linux 9.2.0.z",
+              "product_id": "rhel-9.2.0.z.e4s::appstream",
+              "product_identification_helper": {
+                "cpe": "cpe:/a:redhat:rhel_e4s:9.2::appstream"
+              }
+            }
+          },
+          {
+            "category": "product_name",
+            "name": "Red Hat Enterprise Linux 9.2.0.z",
+            "product": {
+              "name": "Red Hat Enterprise Linux 9.2.0.z",
+              "product_id": "rhel-9.2.0.z.eus",
+              "product_identification_helper": {
+                "cpe": "cpe:/a:redhat:rhel_eus:9.2"
+              }
+            }
+          },
+          {
+            "category": "product_name",
+            "name": "Red Hat Enterprise Linux 9.4",
+            "product": {
+              "name": "Red Hat Enterprise Linux 9.4",
+              "product_id": "rhel-9.4.0.e4s::appstream",
+              "product_identification_helper": {
+                "cpe": "cpe:/a:redhat:rhel_e4s:9.4::appstream"
+              }
+            }
+          },
+          {
+            "category": "product_name",
+            "name": "Red Hat Enterprise Linux 9.4.z",
+            "product": {
+              "name": "Red Hat Enterprise Linux 9.4.z",
+              "product_id": "rhel-9.4.z.eus",
+              "product_identification_helper": {
+                "cpe": "cpe:/a:redhat:rhel_eus:9.4"
+              }
+            }
+          },
+          {
+            "category": "product_name",
+            "name": "Red Hat Enterprise Linux 9.6.z",
+            "product": {
+              "name": "Red Hat Enterprise Linux 9.6.z",
+              "product_id": "rhel-9.6.z.eus",
+              "product_identification_helper": {
+                "cpe": "cpe:/a:redhat:rhel_eus:9.6"
+              }
+            }
+          },
+          {
+            "category": "product_name",
+            "name": "Red Hat Enterprise Linux 9.6.z",
+            "product": {
+              "name": "Red Hat Enterprise Linux 9.6.z",
+              "product_id": "rhel-9.6.z.eus::appstream",
+              "product_identification_helper": {
+                "cpe": "cpe:/a:redhat:rhel_eus:9.6::appstream"
+              }
+            }
+          },
+          {
+            "category": "product_name",
+            "name": "Red Hat Enterprise Linux 9.7.z",
+            "product": {
+              "name": "Red Hat Enterprise Linux 9.7.z",
+              "product_id": "rhel-9.7.z",
+              "product_identification_helper": {
+                "cpe": "cpe:/a:redhat:enterprise_linux:9"
+              }
+            }
+          },
+          {
+            "category": "product_name",
+            "name": "Red Hat Enterprise Linux 9.8.z",
+            "product": {
+              "name": "Red Hat Enterprise Linux 9.8.z",
+              "product_id": "rhel-9.8.z.eus",
+              "product_identification_helper": {
+                "cpe": "cpe:/a:redhat:rhel_eus:9.8"
+              }
+            }
+          },
+          {
+            "category": "product_name",
+            "name": "Red Hat Enterprise Linux 9.8.z",
+            "product": {
+              "name": "Red Hat Enterprise Linux 9.8.z",
+              "product_id": "rhel-9.8.z.eus::appstream",
+              "product_identification_helper": {
+                "cpe": "cpe:/a:redhat:rhel_eus:9.8::appstream"
+              }
+            }
+          },
+          {
+            "category": "product_name",
+            "name": "Red Hat Enterprise Linux 9.4",
+            "product": {
+              "name": "Red Hat Enterprise Linux 9.4",
+              "product_id": "rhel-br-9.4.0.e4s::appstream",
+              "product_identification_helper": {
+                "cpe": "cpe:/a:redhat:rhel_e4s:9.4::appstream"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "firefox",
+            "product": {
+              "name": "firefox",
+              "product_id": "firefox",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/firefox"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "firefox",
+            "product": {
+              "name": "firefox",
+              "product_id": "firefox-0:140.10.1-1.el10_0",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/firefox@140.10.1-1.el10_0?epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "firefox",
+            "product": {
+              "name": "firefox",
+              "product_id": "firefox-0:140.10.1-1.el10_0.src",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/firefox@140.10.1-1.el10_0?arch=src&epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "firefox",
+            "product": {
+              "name": "firefox",
+              "product_id": "firefox-0:140.10.1-1.el10_2",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/firefox@140.10.1-1.el10_2?epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "firefox",
+            "product": {
+              "name": "firefox",
+              "product_id": "firefox-0:140.10.1-1.el10_2.src",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/firefox@140.10.1-1.el10_2?arch=src&epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "firefox",
+            "product": {
+              "name": "firefox",
+              "product_id": "firefox-0:140.10.1-1.el7_9",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/firefox@140.10.1-1.el7_9?epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "firefox",
+            "product": {
+              "name": "firefox",
+              "product_id": "firefox-0:140.10.1-1.el7_9.src",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/firefox@140.10.1-1.el7_9?arch=src&epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "firefox",
+            "product": {
+              "name": "firefox",
+              "product_id": "firefox-0:140.10.1-1.el8_10",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/firefox@140.10.1-1.el8_10?epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "firefox",
+            "product": {
+              "name": "firefox",
+              "product_id": "firefox-0:140.10.1-1.el8_10.src",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/firefox@140.10.1-1.el8_10?arch=src&epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "firefox",
+            "product": {
+              "name": "firefox",
+              "product_id": "firefox-0:140.10.1-1.el8_4",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/firefox@140.10.1-1.el8_4?epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "firefox",
+            "product": {
+              "name": "firefox",
+              "product_id": "firefox-0:140.10.1-1.el8_4.src",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/firefox@140.10.1-1.el8_4?arch=src&epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "firefox",
+            "product": {
+              "name": "firefox",
+              "product_id": "firefox-0:140.10.1-1.el8_6",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/firefox@140.10.1-1.el8_6?epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "firefox",
+            "product": {
+              "name": "firefox",
+              "product_id": "firefox-0:140.10.1-1.el8_6.src",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/firefox@140.10.1-1.el8_6?arch=src&epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "firefox",
+            "product": {
+              "name": "firefox",
+              "product_id": "firefox-0:140.10.1-1.el8_8",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/firefox@140.10.1-1.el8_8?epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "firefox",
+            "product": {
+              "name": "firefox",
+              "product_id": "firefox-0:140.10.1-1.el8_8.src",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/firefox@140.10.1-1.el8_8?arch=src&epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "firefox",
+            "product": {
+              "name": "firefox",
+              "product_id": "firefox-0:140.10.1-1.el9_0",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/firefox@140.10.1-1.el9_0?epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "firefox",
+            "product": {
+              "name": "firefox",
+              "product_id": "firefox-0:140.10.1-1.el9_0.src",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/firefox@140.10.1-1.el9_0?arch=src&epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "firefox",
+            "product": {
+              "name": "firefox",
+              "product_id": "firefox-0:140.10.1-1.el9_2",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/firefox@140.10.1-1.el9_2?epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "firefox",
+            "product": {
+              "name": "firefox",
+              "product_id": "firefox-0:140.10.1-1.el9_2.src",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/firefox@140.10.1-1.el9_2?arch=src&epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "firefox",
+            "product": {
+              "name": "firefox",
+              "product_id": "firefox-0:140.10.1-1.el9_4",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/firefox@140.10.1-1.el9_4?epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "firefox",
+            "product": {
+              "name": "firefox",
+              "product_id": "firefox-0:140.10.1-1.el9_4.src",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/firefox@140.10.1-1.el9_4?arch=src&epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "firefox",
+            "product": {
+              "name": "firefox",
+              "product_id": "firefox-0:140.10.1-1.el9_6",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/firefox@140.10.1-1.el9_6?epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "firefox",
+            "product": {
+              "name": "firefox",
+              "product_id": "firefox-0:140.10.1-1.el9_6.src",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/firefox@140.10.1-1.el9_6?arch=src&epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "firefox",
+            "product": {
+              "name": "firefox",
+              "product_id": "firefox-0:140.10.1-1.el9_8",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/firefox@140.10.1-1.el9_8?epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "firefox",
+            "product": {
+              "name": "firefox",
+              "product_id": "firefox-0:140.10.1-1.el9_8.src",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/firefox@140.10.1-1.el9_8?arch=src&epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "firefox-debuginfo",
+            "product": {
+              "name": "firefox-debuginfo",
+              "product_id": "firefox-debuginfo",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/firefox-debuginfo"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "firefox-debugsource",
+            "product": {
+              "name": "firefox-debugsource",
+              "product_id": "firefox-debugsource",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/firefox-debugsource"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "firefox-x11",
+            "product": {
+              "name": "firefox-x11",
+              "product_id": "firefox-x11",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/firefox-x11"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "firefox-x11",
+            "product": {
+              "name": "firefox-x11",
+              "product_id": "firefox-x11-0:140.10.1-1.el9_2",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/firefox-x11@140.10.1-1.el9_2?epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "firefox-x11",
+            "product": {
+              "name": "firefox-x11",
+              "product_id": "firefox-x11-0:140.10.1-1.el9_4",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/firefox-x11@140.10.1-1.el9_4?epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "firefox-x11",
+            "product": {
+              "name": "firefox-x11",
+              "product_id": "firefox-x11-0:140.10.1-1.el9_6",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/firefox-x11@140.10.1-1.el9_6?epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "firefox-x11",
+            "product": {
+              "name": "firefox-x11",
+              "product_id": "firefox-x11-0:140.10.1-1.el9_8",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/firefox-x11@140.10.1-1.el9_8?epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "firefox",
+            "product": {
+              "name": "firefox",
+              "product_id": "firefox.src",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/firefox?arch=src"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "rhel10/firefox-flatpak",
+            "product": {
+              "name": "rhel10/firefox-flatpak",
+              "product_id": "rhel10/firefox-flatpak.src",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/firefox-flatpak?arch=src&rpmmod=rhel10"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "rhel10/thunderbird-flatpak",
+            "product": {
+              "name": "rhel10/thunderbird-flatpak",
+              "product_id": "rhel10/thunderbird-flatpak.src",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/thunderbird-flatpak?arch=src&rpmmod=rhel10"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "thunderbird",
+            "product": {
+              "name": "thunderbird",
+              "product_id": "thunderbird",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/thunderbird"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "thunderbird",
+            "product": {
+              "name": "thunderbird",
+              "product_id": "thunderbird-0:140.10.1-1.el10_0",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/thunderbird@140.10.1-1.el10_0?epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "thunderbird",
+            "product": {
+              "name": "thunderbird",
+              "product_id": "thunderbird-0:140.10.1-1.el10_0.src",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/thunderbird@140.10.1-1.el10_0?arch=src&epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "thunderbird",
+            "product": {
+              "name": "thunderbird",
+              "product_id": "thunderbird-0:140.10.1-1.el10_2",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/thunderbird@140.10.1-1.el10_2?epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "thunderbird",
+            "product": {
+              "name": "thunderbird",
+              "product_id": "thunderbird-0:140.10.1-1.el10_2.src",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/thunderbird@140.10.1-1.el10_2?arch=src&epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "thunderbird",
+            "product": {
+              "name": "thunderbird",
+              "product_id": "thunderbird-0:140.10.1-1.el8_10",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/thunderbird@140.10.1-1.el8_10?epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "thunderbird",
+            "product": {
+              "name": "thunderbird",
+              "product_id": "thunderbird-0:140.10.1-1.el8_10.src",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/thunderbird@140.10.1-1.el8_10?arch=src&epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "thunderbird",
+            "product": {
+              "name": "thunderbird",
+              "product_id": "thunderbird-0:140.10.1-1.el8_4",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/thunderbird@140.10.1-1.el8_4?epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "thunderbird",
+            "product": {
+              "name": "thunderbird",
+              "product_id": "thunderbird-0:140.10.1-1.el8_4.src",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/thunderbird@140.10.1-1.el8_4?arch=src&epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "thunderbird",
+            "product": {
+              "name": "thunderbird",
+              "product_id": "thunderbird-0:140.10.1-1.el8_6",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/thunderbird@140.10.1-1.el8_6?epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "thunderbird",
+            "product": {
+              "name": "thunderbird",
+              "product_id": "thunderbird-0:140.10.1-1.el8_6.src",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/thunderbird@140.10.1-1.el8_6?arch=src&epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "thunderbird",
+            "product": {
+              "name": "thunderbird",
+              "product_id": "thunderbird-0:140.10.1-1.el8_8",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/thunderbird@140.10.1-1.el8_8?epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "thunderbird",
+            "product": {
+              "name": "thunderbird",
+              "product_id": "thunderbird-0:140.10.1-1.el8_8.src",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/thunderbird@140.10.1-1.el8_8?arch=src&epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "thunderbird",
+            "product": {
+              "name": "thunderbird",
+              "product_id": "thunderbird-0:140.10.1-1.el9_2",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/thunderbird@140.10.1-1.el9_2?epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "thunderbird",
+            "product": {
+              "name": "thunderbird",
+              "product_id": "thunderbird-0:140.10.1-1.el9_2.src",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/thunderbird@140.10.1-1.el9_2?arch=src&epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "thunderbird",
+            "product": {
+              "name": "thunderbird",
+              "product_id": "thunderbird-0:140.10.1-1.el9_4",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/thunderbird@140.10.1-1.el9_4?epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "thunderbird",
+            "product": {
+              "name": "thunderbird",
+              "product_id": "thunderbird-0:140.10.1-1.el9_4.src",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/thunderbird@140.10.1-1.el9_4?arch=src&epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "thunderbird",
+            "product": {
+              "name": "thunderbird",
+              "product_id": "thunderbird-0:140.10.1-1.el9_6",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/thunderbird@140.10.1-1.el9_6?epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "thunderbird",
+            "product": {
+              "name": "thunderbird",
+              "product_id": "thunderbird-0:140.10.1-1.el9_6.src",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/thunderbird@140.10.1-1.el9_6?arch=src&epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "thunderbird",
+            "product": {
+              "name": "thunderbird",
+              "product_id": "thunderbird-0:140.10.1-1.el9_8",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/thunderbird@140.10.1-1.el9_8?epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "thunderbird",
+            "product": {
+              "name": "thunderbird",
+              "product_id": "thunderbird-0:140.10.1-1.el9_8.src",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/thunderbird@140.10.1-1.el9_8?arch=src&epoch=0"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "thunderbird-debuginfo",
+            "product": {
+              "name": "thunderbird-debuginfo",
+              "product_id": "thunderbird-debuginfo",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/thunderbird-debuginfo"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "thunderbird-debugsource",
+            "product": {
+              "name": "thunderbird-debugsource",
+              "product_id": "thunderbird-debugsource",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/thunderbird-debugsource"
+              }
+            }
+          },
+          {
+            "category": "product_version",
+            "name": "thunderbird",
+            "product": {
+              "name": "thunderbird",
+              "product_id": "thunderbird.src",
+              "product_identification_helper": {
+                "purl": "pkg:rpm/redhat/thunderbird?arch=src"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "relationships": [
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox as a component of Red Hat Enterprise Linux 9.7.z",
+          "product_id": "rhel-9.7.z:firefox"
+        },
+        "product_reference": "firefox",
+        "relates_to_product_reference": "rhel-9.7.z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox as a component of Red Hat Enterprise Linux 8.4.0.z",
+          "product_id": "rhel-8.4.0.z.eus:firefox"
+        },
+        "product_reference": "firefox",
+        "relates_to_product_reference": "rhel-8.4.0.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox as a component of Red Hat Enterprise Linux 7-els",
+          "product_id": "rhel-7-els.els:firefox"
+        },
+        "product_reference": "firefox",
+        "relates_to_product_reference": "rhel-7-els.els"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox as a component of Red Hat Enterprise Linux 9.2.0.z",
+          "product_id": "rhel-9.2.0.z.eus:firefox"
+        },
+        "product_reference": "firefox",
+        "relates_to_product_reference": "rhel-9.2.0.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox as a component of Red Hat Enterprise Linux 9.8.z",
+          "product_id": "rhel-9.8.z.eus:firefox"
+        },
+        "product_reference": "firefox",
+        "relates_to_product_reference": "rhel-9.8.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox as a component of Red Hat Enterprise Linux 8.8.0.z",
+          "product_id": "rhel-8.8.0.z.eus:firefox"
+        },
+        "product_reference": "firefox",
+        "relates_to_product_reference": "rhel-8.8.0.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox as a component of Red Hat Enterprise Linux 9.6.z",
+          "product_id": "rhel-9.6.z.eus:firefox"
+        },
+        "product_reference": "firefox",
+        "relates_to_product_reference": "rhel-9.6.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox as a component of Red Hat Enterprise Linux 10.1.z",
+          "product_id": "rhel-10.1.z:firefox"
+        },
+        "product_reference": "firefox",
+        "relates_to_product_reference": "rhel-10.1.z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox as a component of Red Hat Enterprise Linux 9.4.z",
+          "product_id": "rhel-9.4.z.eus:firefox"
+        },
+        "product_reference": "firefox",
+        "relates_to_product_reference": "rhel-9.4.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox as a component of Red Hat Enterprise Linux 10.0.z",
+          "product_id": "rhel-10.0.z.eus:firefox"
+        },
+        "product_reference": "firefox",
+        "relates_to_product_reference": "rhel-10.0.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox as a component of Red Hat Enterprise Linux 8.6.0.z",
+          "product_id": "rhel-8.6.0.z.aus:firefox"
+        },
+        "product_reference": "firefox",
+        "relates_to_product_reference": "rhel-8.6.0.z.aus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox as a component of Red Hat Enterprise Linux 8.2.0.z",
+          "product_id": "rhel-8.2.0.z.aus:firefox"
+        },
+        "product_reference": "firefox",
+        "relates_to_product_reference": "rhel-8.2.0.z.aus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox as a component of Red Hat Enterprise Linux 9.0.0.z",
+          "product_id": "rhel-9.0.0.z.eus:firefox"
+        },
+        "product_reference": "firefox",
+        "relates_to_product_reference": "rhel-9.0.0.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox as a component of Red Hat Enterprise Linux 8.10.z",
+          "product_id": "rhel-8.10.z:firefox"
+        },
+        "product_reference": "firefox",
+        "relates_to_product_reference": "rhel-8.10.z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox as a component of Red Hat Enterprise Linux 10.2.z",
+          "product_id": "rhel-10.2.z.eus:firefox"
+        },
+        "product_reference": "firefox",
+        "relates_to_product_reference": "rhel-10.2.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox as a component of Red Hat Enterprise Linux 6-els",
+          "product_id": "rhel-6-els.els:firefox"
+        },
+        "product_reference": "firefox",
+        "relates_to_product_reference": "rhel-6-els.els"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-0:140.10.1-1.el10_0 as a component of Red Hat Enterprise Linux 10.0.z",
+          "product_id": "rhel-10.0.z.eus:firefox-0:140.10.1-1.el10_0"
+        },
+        "product_reference": "firefox-0:140.10.1-1.el10_0",
+        "relates_to_product_reference": "rhel-10.0.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-0:140.10.1-1.el10_0.src as a component of Red Hat Enterprise Linux 10.0.z",
+          "product_id": "rhel-10.0.z.eus:firefox-0:140.10.1-1.el10_0.src"
+        },
+        "product_reference": "firefox-0:140.10.1-1.el10_0.src",
+        "relates_to_product_reference": "rhel-10.0.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-0:140.10.1-1.el10_2 as a component of Red Hat Enterprise Linux 10.2.z",
+          "product_id": "rhel-10.2.z.eus:firefox-0:140.10.1-1.el10_2"
+        },
+        "product_reference": "firefox-0:140.10.1-1.el10_2",
+        "relates_to_product_reference": "rhel-10.2.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-0:140.10.1-1.el10_2.src as a component of Red Hat Enterprise Linux 10.2.z",
+          "product_id": "rhel-10.2.z.eus:firefox-0:140.10.1-1.el10_2.src"
+        },
+        "product_reference": "firefox-0:140.10.1-1.el10_2.src",
+        "relates_to_product_reference": "rhel-10.2.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-0:140.10.1-1.el7_9 as a component of Red Hat Enterprise Linux 7-els",
+          "product_id": "rhel-7-els.els:firefox-0:140.10.1-1.el7_9"
+        },
+        "product_reference": "firefox-0:140.10.1-1.el7_9",
+        "relates_to_product_reference": "rhel-7-els.els"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-0:140.10.1-1.el7_9.src as a component of Red Hat Enterprise Linux 7-els",
+          "product_id": "rhel-7-els.els:firefox-0:140.10.1-1.el7_9.src"
+        },
+        "product_reference": "firefox-0:140.10.1-1.el7_9.src",
+        "relates_to_product_reference": "rhel-7-els.els"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-0:140.10.1-1.el8_10 as a component of Red Hat Enterprise Linux 8.10.z",
+          "product_id": "rhel-8.10.z::appstream:firefox-0:140.10.1-1.el8_10"
+        },
+        "product_reference": "firefox-0:140.10.1-1.el8_10",
+        "relates_to_product_reference": "rhel-8.10.z::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-0:140.10.1-1.el8_10.src as a component of Red Hat Enterprise Linux 8.10.z",
+          "product_id": "rhel-8.10.z::appstream:firefox-0:140.10.1-1.el8_10.src"
+        },
+        "product_reference": "firefox-0:140.10.1-1.el8_10.src",
+        "relates_to_product_reference": "rhel-8.10.z::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-0:140.10.1-1.el8_4 as a component of Red Hat Enterprise Linux 8.4.0.z",
+          "product_id": "rhel-8.4.0.z.aus::appstream:firefox-0:140.10.1-1.el8_4"
+        },
+        "product_reference": "firefox-0:140.10.1-1.el8_4",
+        "relates_to_product_reference": "rhel-8.4.0.z.aus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-0:140.10.1-1.el8_4 as a component of Red Hat Enterprise Linux 8.4.0.z",
+          "product_id": "rhel-8.4.0.z.eus::appstream:firefox-0:140.10.1-1.el8_4"
+        },
+        "product_reference": "firefox-0:140.10.1-1.el8_4",
+        "relates_to_product_reference": "rhel-8.4.0.z.eus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-0:140.10.1-1.el8_4.src as a component of Red Hat Enterprise Linux 8.4.0.z",
+          "product_id": "rhel-8.4.0.z.eus::appstream:firefox-0:140.10.1-1.el8_4.src"
+        },
+        "product_reference": "firefox-0:140.10.1-1.el8_4.src",
+        "relates_to_product_reference": "rhel-8.4.0.z.eus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-0:140.10.1-1.el8_4.src as a component of Red Hat Enterprise Linux 8.4.0.z",
+          "product_id": "rhel-8.4.0.z.aus::appstream:firefox-0:140.10.1-1.el8_4.src"
+        },
+        "product_reference": "firefox-0:140.10.1-1.el8_4.src",
+        "relates_to_product_reference": "rhel-8.4.0.z.aus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-0:140.10.1-1.el8_6 as a component of Red Hat Enterprise Linux 8.6.0.z",
+          "product_id": "rhel-8.6.0.z.eus::appstream:firefox-0:140.10.1-1.el8_6"
+        },
+        "product_reference": "firefox-0:140.10.1-1.el8_6",
+        "relates_to_product_reference": "rhel-8.6.0.z.eus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-0:140.10.1-1.el8_6 as a component of Red Hat Enterprise Linux 8.6.0.z",
+          "product_id": "rhel-8.6.0.z.aus::appstream:firefox-0:140.10.1-1.el8_6"
+        },
+        "product_reference": "firefox-0:140.10.1-1.el8_6",
+        "relates_to_product_reference": "rhel-8.6.0.z.aus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-0:140.10.1-1.el8_6.src as a component of Red Hat Enterprise Linux 8.6.0.z",
+          "product_id": "rhel-8.6.0.z.eus::appstream:firefox-0:140.10.1-1.el8_6.src"
+        },
+        "product_reference": "firefox-0:140.10.1-1.el8_6.src",
+        "relates_to_product_reference": "rhel-8.6.0.z.eus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-0:140.10.1-1.el8_6.src as a component of Red Hat Enterprise Linux 8.6.0.z",
+          "product_id": "rhel-8.6.0.z.aus::appstream:firefox-0:140.10.1-1.el8_6.src"
+        },
+        "product_reference": "firefox-0:140.10.1-1.el8_6.src",
+        "relates_to_product_reference": "rhel-8.6.0.z.aus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-0:140.10.1-1.el8_8 as a component of Red Hat Enterprise Linux 8.8.0.z",
+          "product_id": "rhel-8.8.0.z.e4s::appstream:firefox-0:140.10.1-1.el8_8"
+        },
+        "product_reference": "firefox-0:140.10.1-1.el8_8",
+        "relates_to_product_reference": "rhel-8.8.0.z.e4s::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-0:140.10.1-1.el8_8 as a component of Red Hat Enterprise Linux 8.8.0.z",
+          "product_id": "rhel-8.8.0.z.tus::appstream:firefox-0:140.10.1-1.el8_8"
+        },
+        "product_reference": "firefox-0:140.10.1-1.el8_8",
+        "relates_to_product_reference": "rhel-8.8.0.z.tus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-0:140.10.1-1.el8_8.src as a component of Red Hat Enterprise Linux 8.8.0.z",
+          "product_id": "rhel-8.8.0.z.e4s::appstream:firefox-0:140.10.1-1.el8_8.src"
+        },
+        "product_reference": "firefox-0:140.10.1-1.el8_8.src",
+        "relates_to_product_reference": "rhel-8.8.0.z.e4s::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-0:140.10.1-1.el8_8.src as a component of Red Hat Enterprise Linux 8.8.0.z",
+          "product_id": "rhel-8.8.0.z.tus::appstream:firefox-0:140.10.1-1.el8_8.src"
+        },
+        "product_reference": "firefox-0:140.10.1-1.el8_8.src",
+        "relates_to_product_reference": "rhel-8.8.0.z.tus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-0:140.10.1-1.el9_0 as a component of Red Hat Enterprise Linux 9.0.0.z",
+          "product_id": "rhel-9.0.0.z.e4s::appstream:firefox-0:140.10.1-1.el9_0"
+        },
+        "product_reference": "firefox-0:140.10.1-1.el9_0",
+        "relates_to_product_reference": "rhel-9.0.0.z.e4s::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-0:140.10.1-1.el9_0.src as a component of Red Hat Enterprise Linux 9.0.0.z",
+          "product_id": "rhel-9.0.0.z.e4s::appstream:firefox-0:140.10.1-1.el9_0.src"
+        },
+        "product_reference": "firefox-0:140.10.1-1.el9_0.src",
+        "relates_to_product_reference": "rhel-9.0.0.z.e4s::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-0:140.10.1-1.el9_2 as a component of Red Hat Enterprise Linux 9.2.0.z",
+          "product_id": "rhel-9.2.0.z.e4s::appstream:firefox-0:140.10.1-1.el9_2"
+        },
+        "product_reference": "firefox-0:140.10.1-1.el9_2",
+        "relates_to_product_reference": "rhel-9.2.0.z.e4s::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-0:140.10.1-1.el9_2.src as a component of Red Hat Enterprise Linux 9.2.0.z",
+          "product_id": "rhel-9.2.0.z.e4s::appstream:firefox-0:140.10.1-1.el9_2.src"
+        },
+        "product_reference": "firefox-0:140.10.1-1.el9_2.src",
+        "relates_to_product_reference": "rhel-9.2.0.z.e4s::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-0:140.10.1-1.el9_4 as a component of Red Hat Enterprise Linux 9.4",
+          "product_id": "rhel-br-9.4.0.e4s::appstream:firefox-0:140.10.1-1.el9_4"
+        },
+        "product_reference": "firefox-0:140.10.1-1.el9_4",
+        "relates_to_product_reference": "rhel-br-9.4.0.e4s::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-0:140.10.1-1.el9_4 as a component of Red Hat Enterprise Linux 9.4",
+          "product_id": "rhel-9.4.0.e4s::appstream:firefox-0:140.10.1-1.el9_4"
+        },
+        "product_reference": "firefox-0:140.10.1-1.el9_4",
+        "relates_to_product_reference": "rhel-9.4.0.e4s::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-0:140.10.1-1.el9_4.src as a component of Red Hat Enterprise Linux 9.4",
+          "product_id": "rhel-br-9.4.0.e4s::appstream:firefox-0:140.10.1-1.el9_4.src"
+        },
+        "product_reference": "firefox-0:140.10.1-1.el9_4.src",
+        "relates_to_product_reference": "rhel-br-9.4.0.e4s::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-0:140.10.1-1.el9_4.src as a component of Red Hat Enterprise Linux 9.4",
+          "product_id": "rhel-9.4.0.e4s::appstream:firefox-0:140.10.1-1.el9_4.src"
+        },
+        "product_reference": "firefox-0:140.10.1-1.el9_4.src",
+        "relates_to_product_reference": "rhel-9.4.0.e4s::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-0:140.10.1-1.el9_6 as a component of Red Hat Enterprise Linux 9.6.z",
+          "product_id": "rhel-9.6.z.eus::appstream:firefox-0:140.10.1-1.el9_6"
+        },
+        "product_reference": "firefox-0:140.10.1-1.el9_6",
+        "relates_to_product_reference": "rhel-9.6.z.eus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-0:140.10.1-1.el9_6.src as a component of Red Hat Enterprise Linux 9.6.z",
+          "product_id": "rhel-9.6.z.eus::appstream:firefox-0:140.10.1-1.el9_6.src"
+        },
+        "product_reference": "firefox-0:140.10.1-1.el9_6.src",
+        "relates_to_product_reference": "rhel-9.6.z.eus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-0:140.10.1-1.el9_8 as a component of Red Hat Enterprise Linux 9.8.z",
+          "product_id": "rhel-9.8.z.eus::appstream:firefox-0:140.10.1-1.el9_8"
+        },
+        "product_reference": "firefox-0:140.10.1-1.el9_8",
+        "relates_to_product_reference": "rhel-9.8.z.eus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-0:140.10.1-1.el9_8.src as a component of Red Hat Enterprise Linux 9.8.z",
+          "product_id": "rhel-9.8.z.eus::appstream:firefox-0:140.10.1-1.el9_8.src"
+        },
+        "product_reference": "firefox-0:140.10.1-1.el9_8.src",
+        "relates_to_product_reference": "rhel-9.8.z.eus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debuginfo as a component of Red Hat Enterprise Linux 8.8.0.z",
+          "product_id": "rhel-8.8.0.z.tus::appstream:firefox-debuginfo"
+        },
+        "product_reference": "firefox-debuginfo",
+        "relates_to_product_reference": "rhel-8.8.0.z.tus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debuginfo as a component of Red Hat Enterprise Linux 8.6.0.z",
+          "product_id": "rhel-8.6.0.z.eus::appstream:firefox-debuginfo"
+        },
+        "product_reference": "firefox-debuginfo",
+        "relates_to_product_reference": "rhel-8.6.0.z.eus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debuginfo as a component of Red Hat Enterprise Linux 8.8.0.z",
+          "product_id": "rhel-8.8.0.z.e4s::appstream:firefox-debuginfo"
+        },
+        "product_reference": "firefox-debuginfo",
+        "relates_to_product_reference": "rhel-8.8.0.z.e4s::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debuginfo as a component of Red Hat Enterprise Linux 9.8.z",
+          "product_id": "rhel-9.8.z.eus:firefox-debuginfo"
+        },
+        "product_reference": "firefox-debuginfo",
+        "relates_to_product_reference": "rhel-9.8.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debuginfo as a component of Red Hat Enterprise Linux 8.6.0.z",
+          "product_id": "rhel-8.6.0.z.aus:firefox-debuginfo"
+        },
+        "product_reference": "firefox-debuginfo",
+        "relates_to_product_reference": "rhel-8.6.0.z.aus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debuginfo as a component of Red Hat Enterprise Linux 8.8.0.z",
+          "product_id": "rhel-8.8.0.z.eus:firefox-debuginfo"
+        },
+        "product_reference": "firefox-debuginfo",
+        "relates_to_product_reference": "rhel-8.8.0.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debuginfo as a component of Red Hat Enterprise Linux 8.4.0.z",
+          "product_id": "rhel-8.4.0.z.eus:firefox-debuginfo"
+        },
+        "product_reference": "firefox-debuginfo",
+        "relates_to_product_reference": "rhel-8.4.0.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debuginfo as a component of Red Hat Enterprise Linux 7-els",
+          "product_id": "rhel-7-els.els:firefox-debuginfo"
+        },
+        "product_reference": "firefox-debuginfo",
+        "relates_to_product_reference": "rhel-7-els.els"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debuginfo as a component of Red Hat Enterprise Linux 9.2.0.z",
+          "product_id": "rhel-9.2.0.z.eus:firefox-debuginfo"
+        },
+        "product_reference": "firefox-debuginfo",
+        "relates_to_product_reference": "rhel-9.2.0.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debuginfo as a component of Red Hat Enterprise Linux 8.10.z",
+          "product_id": "rhel-8.10.z::appstream:firefox-debuginfo"
+        },
+        "product_reference": "firefox-debuginfo",
+        "relates_to_product_reference": "rhel-8.10.z::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debuginfo as a component of Red Hat Enterprise Linux 9.6.z",
+          "product_id": "rhel-9.6.z.eus:firefox-debuginfo"
+        },
+        "product_reference": "firefox-debuginfo",
+        "relates_to_product_reference": "rhel-9.6.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debuginfo as a component of Red Hat Enterprise Linux 8.6.0.z",
+          "product_id": "rhel-8.6.0.z.aus::appstream:firefox-debuginfo"
+        },
+        "product_reference": "firefox-debuginfo",
+        "relates_to_product_reference": "rhel-8.6.0.z.aus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debuginfo as a component of Red Hat Enterprise Linux 9.4.z",
+          "product_id": "rhel-9.4.z.eus:firefox-debuginfo"
+        },
+        "product_reference": "firefox-debuginfo",
+        "relates_to_product_reference": "rhel-9.4.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debuginfo as a component of Red Hat Enterprise Linux 9.4",
+          "product_id": "rhel-9.4.0.e4s::appstream:firefox-debuginfo"
+        },
+        "product_reference": "firefox-debuginfo",
+        "relates_to_product_reference": "rhel-9.4.0.e4s::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debuginfo as a component of Red Hat Enterprise Linux 9.8.z",
+          "product_id": "rhel-9.8.z.eus::appstream:firefox-debuginfo"
+        },
+        "product_reference": "firefox-debuginfo",
+        "relates_to_product_reference": "rhel-9.8.z.eus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debuginfo as a component of Red Hat Enterprise Linux 9.4",
+          "product_id": "rhel-br-9.4.0.e4s::appstream:firefox-debuginfo"
+        },
+        "product_reference": "firefox-debuginfo",
+        "relates_to_product_reference": "rhel-br-9.4.0.e4s::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debuginfo as a component of Red Hat Enterprise Linux 9.6.z",
+          "product_id": "rhel-9.6.z.eus::appstream:firefox-debuginfo"
+        },
+        "product_reference": "firefox-debuginfo",
+        "relates_to_product_reference": "rhel-9.6.z.eus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debuginfo as a component of Red Hat Enterprise Linux 10.0.z",
+          "product_id": "rhel-10.0.z.eus:firefox-debuginfo"
+        },
+        "product_reference": "firefox-debuginfo",
+        "relates_to_product_reference": "rhel-10.0.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debuginfo as a component of Red Hat Enterprise Linux 9.0.0.z",
+          "product_id": "rhel-9.0.0.z.e4s::appstream:firefox-debuginfo"
+        },
+        "product_reference": "firefox-debuginfo",
+        "relates_to_product_reference": "rhel-9.0.0.z.e4s::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debuginfo as a component of Red Hat Enterprise Linux 8.4.0.z",
+          "product_id": "rhel-8.4.0.z.aus::appstream:firefox-debuginfo"
+        },
+        "product_reference": "firefox-debuginfo",
+        "relates_to_product_reference": "rhel-8.4.0.z.aus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debuginfo as a component of Red Hat Enterprise Linux 8.4.0.z",
+          "product_id": "rhel-8.4.0.z.eus::appstream:firefox-debuginfo"
+        },
+        "product_reference": "firefox-debuginfo",
+        "relates_to_product_reference": "rhel-8.4.0.z.eus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debuginfo as a component of Red Hat Enterprise Linux 9.2.0.z",
+          "product_id": "rhel-9.2.0.z.e4s::appstream:firefox-debuginfo"
+        },
+        "product_reference": "firefox-debuginfo",
+        "relates_to_product_reference": "rhel-9.2.0.z.e4s::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debuginfo as a component of Red Hat Enterprise Linux 8.10.z",
+          "product_id": "rhel-8.10.z:firefox-debuginfo"
+        },
+        "product_reference": "firefox-debuginfo",
+        "relates_to_product_reference": "rhel-8.10.z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debuginfo as a component of Red Hat Enterprise Linux 10.2.z",
+          "product_id": "rhel-10.2.z.eus:firefox-debuginfo"
+        },
+        "product_reference": "firefox-debuginfo",
+        "relates_to_product_reference": "rhel-10.2.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debugsource as a component of Red Hat Enterprise Linux 9.8.z",
+          "product_id": "rhel-9.8.z.eus:firefox-debugsource"
+        },
+        "product_reference": "firefox-debugsource",
+        "relates_to_product_reference": "rhel-9.8.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debugsource as a component of Red Hat Enterprise Linux 8.8.0.z",
+          "product_id": "rhel-8.8.0.z.eus:firefox-debugsource"
+        },
+        "product_reference": "firefox-debugsource",
+        "relates_to_product_reference": "rhel-8.8.0.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debugsource as a component of Red Hat Enterprise Linux 9.6.z",
+          "product_id": "rhel-9.6.z.eus:firefox-debugsource"
+        },
+        "product_reference": "firefox-debugsource",
+        "relates_to_product_reference": "rhel-9.6.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debugsource as a component of Red Hat Enterprise Linux 8.6.0.z",
+          "product_id": "rhel-8.6.0.z.eus::appstream:firefox-debugsource"
+        },
+        "product_reference": "firefox-debugsource",
+        "relates_to_product_reference": "rhel-8.6.0.z.eus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debugsource as a component of Red Hat Enterprise Linux 9.4",
+          "product_id": "rhel-br-9.4.0.e4s::appstream:firefox-debugsource"
+        },
+        "product_reference": "firefox-debugsource",
+        "relates_to_product_reference": "rhel-br-9.4.0.e4s::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debugsource as a component of Red Hat Enterprise Linux 9.4",
+          "product_id": "rhel-9.4.0.e4s::appstream:firefox-debugsource"
+        },
+        "product_reference": "firefox-debugsource",
+        "relates_to_product_reference": "rhel-9.4.0.e4s::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debugsource as a component of Red Hat Enterprise Linux 8.6.0.z",
+          "product_id": "rhel-8.6.0.z.aus:firefox-debugsource"
+        },
+        "product_reference": "firefox-debugsource",
+        "relates_to_product_reference": "rhel-8.6.0.z.aus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debugsource as a component of Red Hat Enterprise Linux 9.2.0.z",
+          "product_id": "rhel-9.2.0.z.eus:firefox-debugsource"
+        },
+        "product_reference": "firefox-debugsource",
+        "relates_to_product_reference": "rhel-9.2.0.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debugsource as a component of Red Hat Enterprise Linux 8.10.z",
+          "product_id": "rhel-8.10.z::appstream:firefox-debugsource"
+        },
+        "product_reference": "firefox-debugsource",
+        "relates_to_product_reference": "rhel-8.10.z::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debugsource as a component of Red Hat Enterprise Linux 8.10.z",
+          "product_id": "rhel-8.10.z:firefox-debugsource"
+        },
+        "product_reference": "firefox-debugsource",
+        "relates_to_product_reference": "rhel-8.10.z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debugsource as a component of Red Hat Enterprise Linux 9.6.z",
+          "product_id": "rhel-9.6.z.eus::appstream:firefox-debugsource"
+        },
+        "product_reference": "firefox-debugsource",
+        "relates_to_product_reference": "rhel-9.6.z.eus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debugsource as a component of Red Hat Enterprise Linux 9.4.z",
+          "product_id": "rhel-9.4.z.eus:firefox-debugsource"
+        },
+        "product_reference": "firefox-debugsource",
+        "relates_to_product_reference": "rhel-9.4.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debugsource as a component of Red Hat Enterprise Linux 10.0.z",
+          "product_id": "rhel-10.0.z.eus:firefox-debugsource"
+        },
+        "product_reference": "firefox-debugsource",
+        "relates_to_product_reference": "rhel-10.0.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debugsource as a component of Red Hat Enterprise Linux 8.8.0.z",
+          "product_id": "rhel-8.8.0.z.e4s::appstream:firefox-debugsource"
+        },
+        "product_reference": "firefox-debugsource",
+        "relates_to_product_reference": "rhel-8.8.0.z.e4s::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debugsource as a component of Red Hat Enterprise Linux 9.8.z",
+          "product_id": "rhel-9.8.z.eus::appstream:firefox-debugsource"
+        },
+        "product_reference": "firefox-debugsource",
+        "relates_to_product_reference": "rhel-9.8.z.eus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debugsource as a component of Red Hat Enterprise Linux 8.8.0.z",
+          "product_id": "rhel-8.8.0.z.tus::appstream:firefox-debugsource"
+        },
+        "product_reference": "firefox-debugsource",
+        "relates_to_product_reference": "rhel-8.8.0.z.tus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debugsource as a component of Red Hat Enterprise Linux 8.4.0.z",
+          "product_id": "rhel-8.4.0.z.eus:firefox-debugsource"
+        },
+        "product_reference": "firefox-debugsource",
+        "relates_to_product_reference": "rhel-8.4.0.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debugsource as a component of Red Hat Enterprise Linux 8.4.0.z",
+          "product_id": "rhel-8.4.0.z.aus::appstream:firefox-debugsource"
+        },
+        "product_reference": "firefox-debugsource",
+        "relates_to_product_reference": "rhel-8.4.0.z.aus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debugsource as a component of Red Hat Enterprise Linux 9.0.0.z",
+          "product_id": "rhel-9.0.0.z.e4s::appstream:firefox-debugsource"
+        },
+        "product_reference": "firefox-debugsource",
+        "relates_to_product_reference": "rhel-9.0.0.z.e4s::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debugsource as a component of Red Hat Enterprise Linux 8.6.0.z",
+          "product_id": "rhel-8.6.0.z.aus::appstream:firefox-debugsource"
+        },
+        "product_reference": "firefox-debugsource",
+        "relates_to_product_reference": "rhel-8.6.0.z.aus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debugsource as a component of Red Hat Enterprise Linux 8.4.0.z",
+          "product_id": "rhel-8.4.0.z.eus::appstream:firefox-debugsource"
+        },
+        "product_reference": "firefox-debugsource",
+        "relates_to_product_reference": "rhel-8.4.0.z.eus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debugsource as a component of Red Hat Enterprise Linux 9.2.0.z",
+          "product_id": "rhel-9.2.0.z.e4s::appstream:firefox-debugsource"
+        },
+        "product_reference": "firefox-debugsource",
+        "relates_to_product_reference": "rhel-9.2.0.z.e4s::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-debugsource as a component of Red Hat Enterprise Linux 10.2.z",
+          "product_id": "rhel-10.2.z.eus:firefox-debugsource"
+        },
+        "product_reference": "firefox-debugsource",
+        "relates_to_product_reference": "rhel-10.2.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-x11 as a component of Red Hat Enterprise Linux 9.8.z",
+          "product_id": "rhel-9.8.z.eus:firefox-x11"
+        },
+        "product_reference": "firefox-x11",
+        "relates_to_product_reference": "rhel-9.8.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-x11 as a component of Red Hat Enterprise Linux 9.0.0.z",
+          "product_id": "rhel-9.0.0.z.eus:firefox-x11"
+        },
+        "product_reference": "firefox-x11",
+        "relates_to_product_reference": "rhel-9.0.0.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-x11 as a component of Red Hat Enterprise Linux 9.2.0.z",
+          "product_id": "rhel-9.2.0.z.eus:firefox-x11"
+        },
+        "product_reference": "firefox-x11",
+        "relates_to_product_reference": "rhel-9.2.0.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-x11 as a component of Red Hat Enterprise Linux 9.7.z",
+          "product_id": "rhel-9.7.z:firefox-x11"
+        },
+        "product_reference": "firefox-x11",
+        "relates_to_product_reference": "rhel-9.7.z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-x11 as a component of Red Hat Enterprise Linux 9.6.z",
+          "product_id": "rhel-9.6.z.eus:firefox-x11"
+        },
+        "product_reference": "firefox-x11",
+        "relates_to_product_reference": "rhel-9.6.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-x11 as a component of Red Hat Enterprise Linux 9.4.z",
+          "product_id": "rhel-9.4.z.eus:firefox-x11"
+        },
+        "product_reference": "firefox-x11",
+        "relates_to_product_reference": "rhel-9.4.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-x11 as a component of Red Hat Enterprise Linux 10.2.z",
+          "product_id": "rhel-10.2.z.eus:firefox-x11"
+        },
+        "product_reference": "firefox-x11",
+        "relates_to_product_reference": "rhel-10.2.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-x11 as a component of Red Hat Enterprise Linux 10.0.z",
+          "product_id": "rhel-10.0.z.eus:firefox-x11"
+        },
+        "product_reference": "firefox-x11",
+        "relates_to_product_reference": "rhel-10.0.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-x11-0:140.10.1-1.el9_2 as a component of Red Hat Enterprise Linux 9.2.0.z",
+          "product_id": "rhel-9.2.0.z.e4s::appstream:firefox-x11-0:140.10.1-1.el9_2"
+        },
+        "product_reference": "firefox-x11-0:140.10.1-1.el9_2",
+        "relates_to_product_reference": "rhel-9.2.0.z.e4s::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-x11-0:140.10.1-1.el9_4 as a component of Red Hat Enterprise Linux 9.4",
+          "product_id": "rhel-br-9.4.0.e4s::appstream:firefox-x11-0:140.10.1-1.el9_4"
+        },
+        "product_reference": "firefox-x11-0:140.10.1-1.el9_4",
+        "relates_to_product_reference": "rhel-br-9.4.0.e4s::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-x11-0:140.10.1-1.el9_4 as a component of Red Hat Enterprise Linux 9.4",
+          "product_id": "rhel-9.4.0.e4s::appstream:firefox-x11-0:140.10.1-1.el9_4"
+        },
+        "product_reference": "firefox-x11-0:140.10.1-1.el9_4",
+        "relates_to_product_reference": "rhel-9.4.0.e4s::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-x11-0:140.10.1-1.el9_6 as a component of Red Hat Enterprise Linux 9.6.z",
+          "product_id": "rhel-9.6.z.eus::appstream:firefox-x11-0:140.10.1-1.el9_6"
+        },
+        "product_reference": "firefox-x11-0:140.10.1-1.el9_6",
+        "relates_to_product_reference": "rhel-9.6.z.eus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox-x11-0:140.10.1-1.el9_8 as a component of Red Hat Enterprise Linux 9.8.z",
+          "product_id": "rhel-9.8.z.eus::appstream:firefox-x11-0:140.10.1-1.el9_8"
+        },
+        "product_reference": "firefox-x11-0:140.10.1-1.el9_8",
+        "relates_to_product_reference": "rhel-9.8.z.eus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox.src as a component of Red Hat Enterprise Linux 8.4.0.z",
+          "product_id": "rhel-8.4.0.z.eus:firefox.src"
+        },
+        "product_reference": "firefox.src",
+        "relates_to_product_reference": "rhel-8.4.0.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox.src as a component of Red Hat Enterprise Linux 7-els",
+          "product_id": "rhel-7-els.els:firefox.src"
+        },
+        "product_reference": "firefox.src",
+        "relates_to_product_reference": "rhel-7-els.els"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox.src as a component of Red Hat Enterprise Linux 9.2.0.z",
+          "product_id": "rhel-9.2.0.z.eus:firefox.src"
+        },
+        "product_reference": "firefox.src",
+        "relates_to_product_reference": "rhel-9.2.0.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox.src as a component of Red Hat Enterprise Linux 9.7.z",
+          "product_id": "rhel-9.7.z:firefox.src"
+        },
+        "product_reference": "firefox.src",
+        "relates_to_product_reference": "rhel-9.7.z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox.src as a component of Red Hat Enterprise Linux 9.8.z",
+          "product_id": "rhel-9.8.z.eus:firefox.src"
+        },
+        "product_reference": "firefox.src",
+        "relates_to_product_reference": "rhel-9.8.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox.src as a component of Red Hat Enterprise Linux 8.6.0.z",
+          "product_id": "rhel-8.6.0.z.aus:firefox.src"
+        },
+        "product_reference": "firefox.src",
+        "relates_to_product_reference": "rhel-8.6.0.z.aus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox.src as a component of Red Hat Enterprise Linux 8.8.0.z",
+          "product_id": "rhel-8.8.0.z.eus:firefox.src"
+        },
+        "product_reference": "firefox.src",
+        "relates_to_product_reference": "rhel-8.8.0.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox.src as a component of Red Hat Enterprise Linux 9.6.z",
+          "product_id": "rhel-9.6.z.eus:firefox.src"
+        },
+        "product_reference": "firefox.src",
+        "relates_to_product_reference": "rhel-9.6.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox.src as a component of Red Hat Enterprise Linux 9.4.z",
+          "product_id": "rhel-9.4.z.eus:firefox.src"
+        },
+        "product_reference": "firefox.src",
+        "relates_to_product_reference": "rhel-9.4.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox.src as a component of Red Hat Enterprise Linux 10.1.z",
+          "product_id": "rhel-10.1.z:firefox.src"
+        },
+        "product_reference": "firefox.src",
+        "relates_to_product_reference": "rhel-10.1.z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox.src as a component of Red Hat Enterprise Linux 10.0.z",
+          "product_id": "rhel-10.0.z.eus:firefox.src"
+        },
+        "product_reference": "firefox.src",
+        "relates_to_product_reference": "rhel-10.0.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox.src as a component of Red Hat Enterprise Linux 8.2.0.z",
+          "product_id": "rhel-8.2.0.z.aus:firefox.src"
+        },
+        "product_reference": "firefox.src",
+        "relates_to_product_reference": "rhel-8.2.0.z.aus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox.src as a component of Red Hat Enterprise Linux 9.0.0.z",
+          "product_id": "rhel-9.0.0.z.eus:firefox.src"
+        },
+        "product_reference": "firefox.src",
+        "relates_to_product_reference": "rhel-9.0.0.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox.src as a component of Red Hat Enterprise Linux 6-els",
+          "product_id": "rhel-6-els.els:firefox.src"
+        },
+        "product_reference": "firefox.src",
+        "relates_to_product_reference": "rhel-6-els.els"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox.src as a component of Red Hat Enterprise Linux 10.2.z",
+          "product_id": "rhel-10.2.z.eus:firefox.src"
+        },
+        "product_reference": "firefox.src",
+        "relates_to_product_reference": "rhel-10.2.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "firefox.src as a component of Red Hat Enterprise Linux 8.10.z",
+          "product_id": "rhel-8.10.z:firefox.src"
+        },
+        "product_reference": "firefox.src",
+        "relates_to_product_reference": "rhel-8.10.z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "rhel10/firefox-flatpak.src as a component of Red Hat Enterprise Linux 10.2.z",
+          "product_id": "rhel-10.2.z.eus:rhel10/firefox-flatpak.src"
+        },
+        "product_reference": "rhel10/firefox-flatpak.src",
+        "relates_to_product_reference": "rhel-10.2.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "rhel10/thunderbird-flatpak.src as a component of Red Hat Enterprise Linux 10.2.z",
+          "product_id": "rhel-10.2.z.eus:rhel10/thunderbird-flatpak.src"
+        },
+        "product_reference": "rhel10/thunderbird-flatpak.src",
+        "relates_to_product_reference": "rhel-10.2.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird as a component of Red Hat Enterprise Linux 9.8.z",
+          "product_id": "rhel-9.8.z.eus:thunderbird"
+        },
+        "product_reference": "thunderbird",
+        "relates_to_product_reference": "rhel-9.8.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird as a component of Red Hat Enterprise Linux 8.6.0.z",
+          "product_id": "rhel-8.6.0.z.aus:thunderbird"
+        },
+        "product_reference": "thunderbird",
+        "relates_to_product_reference": "rhel-8.6.0.z.aus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird as a component of Red Hat Enterprise Linux 7-els",
+          "product_id": "rhel-7-els.els:thunderbird"
+        },
+        "product_reference": "thunderbird",
+        "relates_to_product_reference": "rhel-7-els.els"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird as a component of Red Hat Enterprise Linux 8.8.0.z",
+          "product_id": "rhel-8.8.0.z.eus:thunderbird"
+        },
+        "product_reference": "thunderbird",
+        "relates_to_product_reference": "rhel-8.8.0.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird as a component of Red Hat Enterprise Linux 10.0.z",
+          "product_id": "rhel-10.0.z.eus:thunderbird"
+        },
+        "product_reference": "thunderbird",
+        "relates_to_product_reference": "rhel-10.0.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird as a component of Red Hat Enterprise Linux 8.2.0.z",
+          "product_id": "rhel-8.2.0.z.aus:thunderbird"
+        },
+        "product_reference": "thunderbird",
+        "relates_to_product_reference": "rhel-8.2.0.z.aus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird as a component of Red Hat Enterprise Linux 9.0.0.z",
+          "product_id": "rhel-9.0.0.z.eus:thunderbird"
+        },
+        "product_reference": "thunderbird",
+        "relates_to_product_reference": "rhel-9.0.0.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird as a component of Red Hat Enterprise Linux 9.6.z",
+          "product_id": "rhel-9.6.z.eus:thunderbird"
+        },
+        "product_reference": "thunderbird",
+        "relates_to_product_reference": "rhel-9.6.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird as a component of Red Hat Enterprise Linux 6-els",
+          "product_id": "rhel-6-els.els:thunderbird"
+        },
+        "product_reference": "thunderbird",
+        "relates_to_product_reference": "rhel-6-els.els"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird as a component of Red Hat Enterprise Linux 8.10.z",
+          "product_id": "rhel-8.10.z:thunderbird"
+        },
+        "product_reference": "thunderbird",
+        "relates_to_product_reference": "rhel-8.10.z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird as a component of Red Hat Enterprise Linux 9.4.z",
+          "product_id": "rhel-9.4.z.eus:thunderbird"
+        },
+        "product_reference": "thunderbird",
+        "relates_to_product_reference": "rhel-9.4.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird as a component of Red Hat Enterprise Linux 10.1.z",
+          "product_id": "rhel-10.1.z:thunderbird"
+        },
+        "product_reference": "thunderbird",
+        "relates_to_product_reference": "rhel-10.1.z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird as a component of Red Hat Enterprise Linux 8.4.0.z",
+          "product_id": "rhel-8.4.0.z.eus:thunderbird"
+        },
+        "product_reference": "thunderbird",
+        "relates_to_product_reference": "rhel-8.4.0.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird as a component of Red Hat Enterprise Linux 10.2.z",
+          "product_id": "rhel-10.2.z.eus:thunderbird"
+        },
+        "product_reference": "thunderbird",
+        "relates_to_product_reference": "rhel-10.2.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird as a component of Red Hat Enterprise Linux 9.7.z",
+          "product_id": "rhel-9.7.z:thunderbird"
+        },
+        "product_reference": "thunderbird",
+        "relates_to_product_reference": "rhel-9.7.z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird as a component of Red Hat Enterprise Linux 9.2.0.z",
+          "product_id": "rhel-9.2.0.z.eus:thunderbird"
+        },
+        "product_reference": "thunderbird",
+        "relates_to_product_reference": "rhel-9.2.0.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-0:140.10.1-1.el10_0 as a component of Red Hat Enterprise Linux 10.0.z",
+          "product_id": "rhel-10.0.z.eus:thunderbird-0:140.10.1-1.el10_0"
+        },
+        "product_reference": "thunderbird-0:140.10.1-1.el10_0",
+        "relates_to_product_reference": "rhel-10.0.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-0:140.10.1-1.el10_0.src as a component of Red Hat Enterprise Linux 10.0.z",
+          "product_id": "rhel-10.0.z.eus:thunderbird-0:140.10.1-1.el10_0.src"
+        },
+        "product_reference": "thunderbird-0:140.10.1-1.el10_0.src",
+        "relates_to_product_reference": "rhel-10.0.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-0:140.10.1-1.el10_2 as a component of Red Hat Enterprise Linux 10.2.z",
+          "product_id": "rhel-10.2.z.eus:thunderbird-0:140.10.1-1.el10_2"
+        },
+        "product_reference": "thunderbird-0:140.10.1-1.el10_2",
+        "relates_to_product_reference": "rhel-10.2.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-0:140.10.1-1.el10_2.src as a component of Red Hat Enterprise Linux 10.2.z",
+          "product_id": "rhel-10.2.z.eus:thunderbird-0:140.10.1-1.el10_2.src"
+        },
+        "product_reference": "thunderbird-0:140.10.1-1.el10_2.src",
+        "relates_to_product_reference": "rhel-10.2.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-0:140.10.1-1.el8_10 as a component of Red Hat Enterprise Linux 8.10.z",
+          "product_id": "rhel-8.10.z::appstream:thunderbird-0:140.10.1-1.el8_10"
+        },
+        "product_reference": "thunderbird-0:140.10.1-1.el8_10",
+        "relates_to_product_reference": "rhel-8.10.z::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-0:140.10.1-1.el8_10.src as a component of Red Hat Enterprise Linux 8.10.z",
+          "product_id": "rhel-8.10.z::appstream:thunderbird-0:140.10.1-1.el8_10.src"
+        },
+        "product_reference": "thunderbird-0:140.10.1-1.el8_10.src",
+        "relates_to_product_reference": "rhel-8.10.z::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-0:140.10.1-1.el8_4 as a component of Red Hat Enterprise Linux 8.4.0.z",
+          "product_id": "rhel-8.4.0.z.eus::appstream:thunderbird-0:140.10.1-1.el8_4"
+        },
+        "product_reference": "thunderbird-0:140.10.1-1.el8_4",
+        "relates_to_product_reference": "rhel-8.4.0.z.eus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-0:140.10.1-1.el8_4 as a component of Red Hat Enterprise Linux 8.4.0.z",
+          "product_id": "rhel-8.4.0.z.aus::appstream:thunderbird-0:140.10.1-1.el8_4"
+        },
+        "product_reference": "thunderbird-0:140.10.1-1.el8_4",
+        "relates_to_product_reference": "rhel-8.4.0.z.aus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-0:140.10.1-1.el8_4.src as a component of Red Hat Enterprise Linux 8.4.0.z",
+          "product_id": "rhel-8.4.0.z.aus::appstream:thunderbird-0:140.10.1-1.el8_4.src"
+        },
+        "product_reference": "thunderbird-0:140.10.1-1.el8_4.src",
+        "relates_to_product_reference": "rhel-8.4.0.z.aus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-0:140.10.1-1.el8_4.src as a component of Red Hat Enterprise Linux 8.4.0.z",
+          "product_id": "rhel-8.4.0.z.eus::appstream:thunderbird-0:140.10.1-1.el8_4.src"
+        },
+        "product_reference": "thunderbird-0:140.10.1-1.el8_4.src",
+        "relates_to_product_reference": "rhel-8.4.0.z.eus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-0:140.10.1-1.el8_6 as a component of Red Hat Enterprise Linux 8.6.0.z",
+          "product_id": "rhel-8.6.0.z.eus::appstream:thunderbird-0:140.10.1-1.el8_6"
+        },
+        "product_reference": "thunderbird-0:140.10.1-1.el8_6",
+        "relates_to_product_reference": "rhel-8.6.0.z.eus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-0:140.10.1-1.el8_6 as a component of Red Hat Enterprise Linux 8.6.0.z",
+          "product_id": "rhel-8.6.0.z.aus::appstream:thunderbird-0:140.10.1-1.el8_6"
+        },
+        "product_reference": "thunderbird-0:140.10.1-1.el8_6",
+        "relates_to_product_reference": "rhel-8.6.0.z.aus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-0:140.10.1-1.el8_6.src as a component of Red Hat Enterprise Linux 8.6.0.z",
+          "product_id": "rhel-8.6.0.z.eus::appstream:thunderbird-0:140.10.1-1.el8_6.src"
+        },
+        "product_reference": "thunderbird-0:140.10.1-1.el8_6.src",
+        "relates_to_product_reference": "rhel-8.6.0.z.eus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-0:140.10.1-1.el8_6.src as a component of Red Hat Enterprise Linux 8.6.0.z",
+          "product_id": "rhel-8.6.0.z.aus::appstream:thunderbird-0:140.10.1-1.el8_6.src"
+        },
+        "product_reference": "thunderbird-0:140.10.1-1.el8_6.src",
+        "relates_to_product_reference": "rhel-8.6.0.z.aus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-0:140.10.1-1.el8_8 as a component of Red Hat Enterprise Linux 8.8.0.z",
+          "product_id": "rhel-8.8.0.z.e4s::appstream:thunderbird-0:140.10.1-1.el8_8"
+        },
+        "product_reference": "thunderbird-0:140.10.1-1.el8_8",
+        "relates_to_product_reference": "rhel-8.8.0.z.e4s::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-0:140.10.1-1.el8_8 as a component of Red Hat Enterprise Linux 8.8.0.z",
+          "product_id": "rhel-8.8.0.z.tus::appstream:thunderbird-0:140.10.1-1.el8_8"
+        },
+        "product_reference": "thunderbird-0:140.10.1-1.el8_8",
+        "relates_to_product_reference": "rhel-8.8.0.z.tus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-0:140.10.1-1.el8_8.src as a component of Red Hat Enterprise Linux 8.8.0.z",
+          "product_id": "rhel-8.8.0.z.tus::appstream:thunderbird-0:140.10.1-1.el8_8.src"
+        },
+        "product_reference": "thunderbird-0:140.10.1-1.el8_8.src",
+        "relates_to_product_reference": "rhel-8.8.0.z.tus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-0:140.10.1-1.el8_8.src as a component of Red Hat Enterprise Linux 8.8.0.z",
+          "product_id": "rhel-8.8.0.z.e4s::appstream:thunderbird-0:140.10.1-1.el8_8.src"
+        },
+        "product_reference": "thunderbird-0:140.10.1-1.el8_8.src",
+        "relates_to_product_reference": "rhel-8.8.0.z.e4s::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-0:140.10.1-1.el9_2 as a component of Red Hat Enterprise Linux 9.2.0.z",
+          "product_id": "rhel-9.2.0.z.e4s::appstream:thunderbird-0:140.10.1-1.el9_2"
+        },
+        "product_reference": "thunderbird-0:140.10.1-1.el9_2",
+        "relates_to_product_reference": "rhel-9.2.0.z.e4s::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-0:140.10.1-1.el9_2.src as a component of Red Hat Enterprise Linux 9.2.0.z",
+          "product_id": "rhel-9.2.0.z.e4s::appstream:thunderbird-0:140.10.1-1.el9_2.src"
+        },
+        "product_reference": "thunderbird-0:140.10.1-1.el9_2.src",
+        "relates_to_product_reference": "rhel-9.2.0.z.e4s::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-0:140.10.1-1.el9_4 as a component of Red Hat Enterprise Linux 9.4",
+          "product_id": "rhel-9.4.0.e4s::appstream:thunderbird-0:140.10.1-1.el9_4"
+        },
+        "product_reference": "thunderbird-0:140.10.1-1.el9_4",
+        "relates_to_product_reference": "rhel-9.4.0.e4s::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-0:140.10.1-1.el9_4 as a component of Red Hat Enterprise Linux 9.4",
+          "product_id": "rhel-br-9.4.0.e4s::appstream:thunderbird-0:140.10.1-1.el9_4"
+        },
+        "product_reference": "thunderbird-0:140.10.1-1.el9_4",
+        "relates_to_product_reference": "rhel-br-9.4.0.e4s::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-0:140.10.1-1.el9_4.src as a component of Red Hat Enterprise Linux 9.4",
+          "product_id": "rhel-br-9.4.0.e4s::appstream:thunderbird-0:140.10.1-1.el9_4.src"
+        },
+        "product_reference": "thunderbird-0:140.10.1-1.el9_4.src",
+        "relates_to_product_reference": "rhel-br-9.4.0.e4s::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-0:140.10.1-1.el9_4.src as a component of Red Hat Enterprise Linux 9.4",
+          "product_id": "rhel-9.4.0.e4s::appstream:thunderbird-0:140.10.1-1.el9_4.src"
+        },
+        "product_reference": "thunderbird-0:140.10.1-1.el9_4.src",
+        "relates_to_product_reference": "rhel-9.4.0.e4s::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-0:140.10.1-1.el9_6 as a component of Red Hat Enterprise Linux 9.6.z",
+          "product_id": "rhel-9.6.z.eus::appstream:thunderbird-0:140.10.1-1.el9_6"
+        },
+        "product_reference": "thunderbird-0:140.10.1-1.el9_6",
+        "relates_to_product_reference": "rhel-9.6.z.eus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-0:140.10.1-1.el9_6.src as a component of Red Hat Enterprise Linux 9.6.z",
+          "product_id": "rhel-9.6.z.eus::appstream:thunderbird-0:140.10.1-1.el9_6.src"
+        },
+        "product_reference": "thunderbird-0:140.10.1-1.el9_6.src",
+        "relates_to_product_reference": "rhel-9.6.z.eus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-0:140.10.1-1.el9_8 as a component of Red Hat Enterprise Linux 9.8.z",
+          "product_id": "rhel-9.8.z.eus::appstream:thunderbird-0:140.10.1-1.el9_8"
+        },
+        "product_reference": "thunderbird-0:140.10.1-1.el9_8",
+        "relates_to_product_reference": "rhel-9.8.z.eus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-0:140.10.1-1.el9_8.src as a component of Red Hat Enterprise Linux 9.8.z",
+          "product_id": "rhel-9.8.z.eus::appstream:thunderbird-0:140.10.1-1.el9_8.src"
+        },
+        "product_reference": "thunderbird-0:140.10.1-1.el9_8.src",
+        "relates_to_product_reference": "rhel-9.8.z.eus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-debuginfo as a component of Red Hat Enterprise Linux 9.8.z",
+          "product_id": "rhel-9.8.z.eus::appstream:thunderbird-debuginfo"
+        },
+        "product_reference": "thunderbird-debuginfo",
+        "relates_to_product_reference": "rhel-9.8.z.eus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-debuginfo as a component of Red Hat Enterprise Linux 9.6.z",
+          "product_id": "rhel-9.6.z.eus::appstream:thunderbird-debuginfo"
+        },
+        "product_reference": "thunderbird-debuginfo",
+        "relates_to_product_reference": "rhel-9.6.z.eus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-debuginfo as a component of Red Hat Enterprise Linux 8.8.0.z",
+          "product_id": "rhel-8.8.0.z.tus::appstream:thunderbird-debuginfo"
+        },
+        "product_reference": "thunderbird-debuginfo",
+        "relates_to_product_reference": "rhel-8.8.0.z.tus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-debuginfo as a component of Red Hat Enterprise Linux 8.4.0.z",
+          "product_id": "rhel-8.4.0.z.aus::appstream:thunderbird-debuginfo"
+        },
+        "product_reference": "thunderbird-debuginfo",
+        "relates_to_product_reference": "rhel-8.4.0.z.aus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-debuginfo as a component of Red Hat Enterprise Linux 8.6.0.z",
+          "product_id": "rhel-8.6.0.z.aus::appstream:thunderbird-debuginfo"
+        },
+        "product_reference": "thunderbird-debuginfo",
+        "relates_to_product_reference": "rhel-8.6.0.z.aus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-debuginfo as a component of Red Hat Enterprise Linux 10.2.z",
+          "product_id": "rhel-10.2.z.eus:thunderbird-debuginfo"
+        },
+        "product_reference": "thunderbird-debuginfo",
+        "relates_to_product_reference": "rhel-10.2.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-debuginfo as a component of Red Hat Enterprise Linux 8.4.0.z",
+          "product_id": "rhel-8.4.0.z.eus:thunderbird-debuginfo"
+        },
+        "product_reference": "thunderbird-debuginfo",
+        "relates_to_product_reference": "rhel-8.4.0.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-debuginfo as a component of Red Hat Enterprise Linux 9.2.0.z",
+          "product_id": "rhel-9.2.0.z.eus:thunderbird-debuginfo"
+        },
+        "product_reference": "thunderbird-debuginfo",
+        "relates_to_product_reference": "rhel-9.2.0.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-debuginfo as a component of Red Hat Enterprise Linux 8.6.0.z",
+          "product_id": "rhel-8.6.0.z.eus::appstream:thunderbird-debuginfo"
+        },
+        "product_reference": "thunderbird-debuginfo",
+        "relates_to_product_reference": "rhel-8.6.0.z.eus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-debuginfo as a component of Red Hat Enterprise Linux 9.4",
+          "product_id": "rhel-br-9.4.0.e4s::appstream:thunderbird-debuginfo"
+        },
+        "product_reference": "thunderbird-debuginfo",
+        "relates_to_product_reference": "rhel-br-9.4.0.e4s::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-debuginfo as a component of Red Hat Enterprise Linux 9.4",
+          "product_id": "rhel-9.4.0.e4s::appstream:thunderbird-debuginfo"
+        },
+        "product_reference": "thunderbird-debuginfo",
+        "relates_to_product_reference": "rhel-9.4.0.e4s::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-debuginfo as a component of Red Hat Enterprise Linux 9.8.z",
+          "product_id": "rhel-9.8.z.eus:thunderbird-debuginfo"
+        },
+        "product_reference": "thunderbird-debuginfo",
+        "relates_to_product_reference": "rhel-9.8.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-debuginfo as a component of Red Hat Enterprise Linux 8.6.0.z",
+          "product_id": "rhel-8.6.0.z.aus:thunderbird-debuginfo"
+        },
+        "product_reference": "thunderbird-debuginfo",
+        "relates_to_product_reference": "rhel-8.6.0.z.aus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-debuginfo as a component of Red Hat Enterprise Linux 8.8.0.z",
+          "product_id": "rhel-8.8.0.z.eus:thunderbird-debuginfo"
+        },
+        "product_reference": "thunderbird-debuginfo",
+        "relates_to_product_reference": "rhel-8.8.0.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-debuginfo as a component of Red Hat Enterprise Linux 8.10.z",
+          "product_id": "rhel-8.10.z::appstream:thunderbird-debuginfo"
+        },
+        "product_reference": "thunderbird-debuginfo",
+        "relates_to_product_reference": "rhel-8.10.z::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-debuginfo as a component of Red Hat Enterprise Linux 9.6.z",
+          "product_id": "rhel-9.6.z.eus:thunderbird-debuginfo"
+        },
+        "product_reference": "thunderbird-debuginfo",
+        "relates_to_product_reference": "rhel-9.6.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-debuginfo as a component of Red Hat Enterprise Linux 8.10.z",
+          "product_id": "rhel-8.10.z:thunderbird-debuginfo"
+        },
+        "product_reference": "thunderbird-debuginfo",
+        "relates_to_product_reference": "rhel-8.10.z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-debuginfo as a component of Red Hat Enterprise Linux 9.4.z",
+          "product_id": "rhel-9.4.z.eus:thunderbird-debuginfo"
+        },
+        "product_reference": "thunderbird-debuginfo",
+        "relates_to_product_reference": "rhel-9.4.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-debuginfo as a component of Red Hat Enterprise Linux 10.0.z",
+          "product_id": "rhel-10.0.z.eus:thunderbird-debuginfo"
+        },
+        "product_reference": "thunderbird-debuginfo",
+        "relates_to_product_reference": "rhel-10.0.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-debuginfo as a component of Red Hat Enterprise Linux 8.8.0.z",
+          "product_id": "rhel-8.8.0.z.e4s::appstream:thunderbird-debuginfo"
+        },
+        "product_reference": "thunderbird-debuginfo",
+        "relates_to_product_reference": "rhel-8.8.0.z.e4s::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-debuginfo as a component of Red Hat Enterprise Linux 8.4.0.z",
+          "product_id": "rhel-8.4.0.z.eus::appstream:thunderbird-debuginfo"
+        },
+        "product_reference": "thunderbird-debuginfo",
+        "relates_to_product_reference": "rhel-8.4.0.z.eus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-debuginfo as a component of Red Hat Enterprise Linux 9.2.0.z",
+          "product_id": "rhel-9.2.0.z.e4s::appstream:thunderbird-debuginfo"
+        },
+        "product_reference": "thunderbird-debuginfo",
+        "relates_to_product_reference": "rhel-9.2.0.z.e4s::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-debugsource as a component of Red Hat Enterprise Linux 10.2.z",
+          "product_id": "rhel-10.2.z.eus:thunderbird-debugsource"
+        },
+        "product_reference": "thunderbird-debugsource",
+        "relates_to_product_reference": "rhel-10.2.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-debugsource as a component of Red Hat Enterprise Linux 9.8.z",
+          "product_id": "rhel-9.8.z.eus::appstream:thunderbird-debugsource"
+        },
+        "product_reference": "thunderbird-debugsource",
+        "relates_to_product_reference": "rhel-9.8.z.eus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-debugsource as a component of Red Hat Enterprise Linux 9.6.z",
+          "product_id": "rhel-9.6.z.eus::appstream:thunderbird-debugsource"
+        },
+        "product_reference": "thunderbird-debugsource",
+        "relates_to_product_reference": "rhel-9.6.z.eus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-debugsource as a component of Red Hat Enterprise Linux 9.8.z",
+          "product_id": "rhel-9.8.z.eus:thunderbird-debugsource"
+        },
+        "product_reference": "thunderbird-debugsource",
+        "relates_to_product_reference": "rhel-9.8.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-debugsource as a component of Red Hat Enterprise Linux 8.8.0.z",
+          "product_id": "rhel-8.8.0.z.eus:thunderbird-debugsource"
+        },
+        "product_reference": "thunderbird-debugsource",
+        "relates_to_product_reference": "rhel-8.8.0.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-debugsource as a component of Red Hat Enterprise Linux 8.4.0.z",
+          "product_id": "rhel-8.4.0.z.aus::appstream:thunderbird-debugsource"
+        },
+        "product_reference": "thunderbird-debugsource",
+        "relates_to_product_reference": "rhel-8.4.0.z.aus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-debugsource as a component of Red Hat Enterprise Linux 8.6.0.z",
+          "product_id": "rhel-8.6.0.z.aus::appstream:thunderbird-debugsource"
+        },
+        "product_reference": "thunderbird-debugsource",
+        "relates_to_product_reference": "rhel-8.6.0.z.aus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-debugsource as a component of Red Hat Enterprise Linux 9.2.0.z",
+          "product_id": "rhel-9.2.0.z.eus:thunderbird-debugsource"
+        },
+        "product_reference": "thunderbird-debugsource",
+        "relates_to_product_reference": "rhel-9.2.0.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-debugsource as a component of Red Hat Enterprise Linux 8.6.0.z",
+          "product_id": "rhel-8.6.0.z.eus::appstream:thunderbird-debugsource"
+        },
+        "product_reference": "thunderbird-debugsource",
+        "relates_to_product_reference": "rhel-8.6.0.z.eus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-debugsource as a component of Red Hat Enterprise Linux 9.4",
+          "product_id": "rhel-9.4.0.e4s::appstream:thunderbird-debugsource"
+        },
+        "product_reference": "thunderbird-debugsource",
+        "relates_to_product_reference": "rhel-9.4.0.e4s::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-debugsource as a component of Red Hat Enterprise Linux 8.6.0.z",
+          "product_id": "rhel-8.6.0.z.aus:thunderbird-debugsource"
+        },
+        "product_reference": "thunderbird-debugsource",
+        "relates_to_product_reference": "rhel-8.6.0.z.aus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-debugsource as a component of Red Hat Enterprise Linux 8.10.z",
+          "product_id": "rhel-8.10.z:thunderbird-debugsource"
+        },
+        "product_reference": "thunderbird-debugsource",
+        "relates_to_product_reference": "rhel-8.10.z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-debugsource as a component of Red Hat Enterprise Linux 9.4",
+          "product_id": "rhel-br-9.4.0.e4s::appstream:thunderbird-debugsource"
+        },
+        "product_reference": "thunderbird-debugsource",
+        "relates_to_product_reference": "rhel-br-9.4.0.e4s::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-debugsource as a component of Red Hat Enterprise Linux 8.10.z",
+          "product_id": "rhel-8.10.z::appstream:thunderbird-debugsource"
+        },
+        "product_reference": "thunderbird-debugsource",
+        "relates_to_product_reference": "rhel-8.10.z::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-debugsource as a component of Red Hat Enterprise Linux 10.0.z",
+          "product_id": "rhel-10.0.z.eus:thunderbird-debugsource"
+        },
+        "product_reference": "thunderbird-debugsource",
+        "relates_to_product_reference": "rhel-10.0.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-debugsource as a component of Red Hat Enterprise Linux 8.8.0.z",
+          "product_id": "rhel-8.8.0.z.e4s::appstream:thunderbird-debugsource"
+        },
+        "product_reference": "thunderbird-debugsource",
+        "relates_to_product_reference": "rhel-8.8.0.z.e4s::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-debugsource as a component of Red Hat Enterprise Linux 9.6.z",
+          "product_id": "rhel-9.6.z.eus:thunderbird-debugsource"
+        },
+        "product_reference": "thunderbird-debugsource",
+        "relates_to_product_reference": "rhel-9.6.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-debugsource as a component of Red Hat Enterprise Linux 8.4.0.z",
+          "product_id": "rhel-8.4.0.z.eus::appstream:thunderbird-debugsource"
+        },
+        "product_reference": "thunderbird-debugsource",
+        "relates_to_product_reference": "rhel-8.4.0.z.eus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-debugsource as a component of Red Hat Enterprise Linux 9.4.z",
+          "product_id": "rhel-9.4.z.eus:thunderbird-debugsource"
+        },
+        "product_reference": "thunderbird-debugsource",
+        "relates_to_product_reference": "rhel-9.4.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-debugsource as a component of Red Hat Enterprise Linux 8.8.0.z",
+          "product_id": "rhel-8.8.0.z.tus::appstream:thunderbird-debugsource"
+        },
+        "product_reference": "thunderbird-debugsource",
+        "relates_to_product_reference": "rhel-8.8.0.z.tus::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-debugsource as a component of Red Hat Enterprise Linux 8.4.0.z",
+          "product_id": "rhel-8.4.0.z.eus:thunderbird-debugsource"
+        },
+        "product_reference": "thunderbird-debugsource",
+        "relates_to_product_reference": "rhel-8.4.0.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird-debugsource as a component of Red Hat Enterprise Linux 9.2.0.z",
+          "product_id": "rhel-9.2.0.z.e4s::appstream:thunderbird-debugsource"
+        },
+        "product_reference": "thunderbird-debugsource",
+        "relates_to_product_reference": "rhel-9.2.0.z.e4s::appstream"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird.src as a component of Red Hat Enterprise Linux 7-els",
+          "product_id": "rhel-7-els.els:thunderbird.src"
+        },
+        "product_reference": "thunderbird.src",
+        "relates_to_product_reference": "rhel-7-els.els"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird.src as a component of Red Hat Enterprise Linux 9.0.0.z",
+          "product_id": "rhel-9.0.0.z.eus:thunderbird.src"
+        },
+        "product_reference": "thunderbird.src",
+        "relates_to_product_reference": "rhel-9.0.0.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird.src as a component of Red Hat Enterprise Linux 8.10.z",
+          "product_id": "rhel-8.10.z:thunderbird.src"
+        },
+        "product_reference": "thunderbird.src",
+        "relates_to_product_reference": "rhel-8.10.z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird.src as a component of Red Hat Enterprise Linux 10.0.z",
+          "product_id": "rhel-10.0.z.eus:thunderbird.src"
+        },
+        "product_reference": "thunderbird.src",
+        "relates_to_product_reference": "rhel-10.0.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird.src as a component of Red Hat Enterprise Linux 8.6.0.z",
+          "product_id": "rhel-8.6.0.z.aus:thunderbird.src"
+        },
+        "product_reference": "thunderbird.src",
+        "relates_to_product_reference": "rhel-8.6.0.z.aus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird.src as a component of Red Hat Enterprise Linux 8.2.0.z",
+          "product_id": "rhel-8.2.0.z.aus:thunderbird.src"
+        },
+        "product_reference": "thunderbird.src",
+        "relates_to_product_reference": "rhel-8.2.0.z.aus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird.src as a component of Red Hat Enterprise Linux 9.6.z",
+          "product_id": "rhel-9.6.z.eus:thunderbird.src"
+        },
+        "product_reference": "thunderbird.src",
+        "relates_to_product_reference": "rhel-9.6.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird.src as a component of Red Hat Enterprise Linux 10.1.z",
+          "product_id": "rhel-10.1.z:thunderbird.src"
+        },
+        "product_reference": "thunderbird.src",
+        "relates_to_product_reference": "rhel-10.1.z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird.src as a component of Red Hat Enterprise Linux 9.4.z",
+          "product_id": "rhel-9.4.z.eus:thunderbird.src"
+        },
+        "product_reference": "thunderbird.src",
+        "relates_to_product_reference": "rhel-9.4.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird.src as a component of Red Hat Enterprise Linux 8.4.0.z",
+          "product_id": "rhel-8.4.0.z.eus:thunderbird.src"
+        },
+        "product_reference": "thunderbird.src",
+        "relates_to_product_reference": "rhel-8.4.0.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird.src as a component of Red Hat Enterprise Linux 6-els",
+          "product_id": "rhel-6-els.els:thunderbird.src"
+        },
+        "product_reference": "thunderbird.src",
+        "relates_to_product_reference": "rhel-6-els.els"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird.src as a component of Red Hat Enterprise Linux 10.2.z",
+          "product_id": "rhel-10.2.z.eus:thunderbird.src"
+        },
+        "product_reference": "thunderbird.src",
+        "relates_to_product_reference": "rhel-10.2.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird.src as a component of Red Hat Enterprise Linux 9.7.z",
+          "product_id": "rhel-9.7.z:thunderbird.src"
+        },
+        "product_reference": "thunderbird.src",
+        "relates_to_product_reference": "rhel-9.7.z"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird.src as a component of Red Hat Enterprise Linux 9.8.z",
+          "product_id": "rhel-9.8.z.eus:thunderbird.src"
+        },
+        "product_reference": "thunderbird.src",
+        "relates_to_product_reference": "rhel-9.8.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird.src as a component of Red Hat Enterprise Linux 8.8.0.z",
+          "product_id": "rhel-8.8.0.z.eus:thunderbird.src"
+        },
+        "product_reference": "thunderbird.src",
+        "relates_to_product_reference": "rhel-8.8.0.z.eus"
+      },
+      {
+        "category": "default_component_of",
+        "full_product_name": {
+          "name": "thunderbird.src as a component of Red Hat Enterprise Linux 9.2.0.z",
+          "product_id": "rhel-9.2.0.z.eus:thunderbird.src"
+        },
+        "product_reference": "thunderbird.src",
+        "relates_to_product_reference": "rhel-9.2.0.z.eus"
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2026-7323",
+      "discovery_date": "2026-04-28T15:01:06+00:00",
+      "flags": [
+        {
+          "label": "vulnerable_code_not_present",
+          "product_ids": [
+            "rhel-10.0.z.eus:firefox-debuginfo",
+            "rhel-10.0.z.eus:firefox-debugsource",
+            "rhel-10.0.z.eus:thunderbird-debuginfo",
+            "rhel-10.0.z.eus:thunderbird-debugsource",
+            "rhel-10.2.z.eus:firefox-debuginfo",
+            "rhel-10.2.z.eus:firefox-debugsource",
+            "rhel-10.2.z.eus:thunderbird-debuginfo",
+            "rhel-10.2.z.eus:thunderbird-debugsource",
+            "rhel-7-els.els:firefox-debuginfo",
+            "rhel-8.10.z::appstream:firefox-debuginfo",
+            "rhel-8.10.z::appstream:firefox-debugsource",
+            "rhel-8.10.z::appstream:thunderbird-debuginfo",
+            "rhel-8.10.z::appstream:thunderbird-debugsource",
+            "rhel-8.10.z:firefox-debuginfo",
+            "rhel-8.10.z:firefox-debugsource",
+            "rhel-8.10.z:thunderbird-debuginfo",
+            "rhel-8.10.z:thunderbird-debugsource",
+            "rhel-8.4.0.z.aus::appstream:firefox-debuginfo",
+            "rhel-8.4.0.z.aus::appstream:firefox-debugsource",
+            "rhel-8.4.0.z.aus::appstream:thunderbird-debuginfo",
+            "rhel-8.4.0.z.aus::appstream:thunderbird-debugsource",
+            "rhel-8.4.0.z.eus::appstream:firefox-debuginfo",
+            "rhel-8.4.0.z.eus::appstream:firefox-debugsource",
+            "rhel-8.4.0.z.eus::appstream:thunderbird-debuginfo",
+            "rhel-8.4.0.z.eus::appstream:thunderbird-debugsource",
+            "rhel-8.4.0.z.eus:firefox-debuginfo",
+            "rhel-8.4.0.z.eus:firefox-debugsource",
+            "rhel-8.4.0.z.eus:thunderbird-debuginfo",
+            "rhel-8.4.0.z.eus:thunderbird-debugsource",
+            "rhel-8.6.0.z.aus::appstream:firefox-debuginfo",
+            "rhel-8.6.0.z.aus::appstream:firefox-debugsource",
+            "rhel-8.6.0.z.aus::appstream:thunderbird-debuginfo",
+            "rhel-8.6.0.z.aus::appstream:thunderbird-debugsource",
+            "rhel-8.6.0.z.aus:firefox-debuginfo",
+            "rhel-8.6.0.z.aus:firefox-debugsource",
+            "rhel-8.6.0.z.aus:thunderbird-debuginfo",
+            "rhel-8.6.0.z.aus:thunderbird-debugsource",
+            "rhel-8.6.0.z.eus::appstream:firefox-debuginfo",
+            "rhel-8.6.0.z.eus::appstream:firefox-debugsource",
+            "rhel-8.6.0.z.eus::appstream:thunderbird-debuginfo",
+            "rhel-8.6.0.z.eus::appstream:thunderbird-debugsource",
+            "rhel-8.8.0.z.e4s::appstream:firefox-debuginfo",
+            "rhel-8.8.0.z.e4s::appstream:firefox-debugsource",
+            "rhel-8.8.0.z.e4s::appstream:thunderbird-debuginfo",
+            "rhel-8.8.0.z.e4s::appstream:thunderbird-debugsource",
+            "rhel-8.8.0.z.eus:firefox-debuginfo",
+            "rhel-8.8.0.z.eus:firefox-debugsource",
+            "rhel-8.8.0.z.eus:thunderbird-debuginfo",
+            "rhel-8.8.0.z.eus:thunderbird-debugsource",
+            "rhel-8.8.0.z.tus::appstream:firefox-debuginfo",
+            "rhel-8.8.0.z.tus::appstream:firefox-debugsource",
+            "rhel-8.8.0.z.tus::appstream:thunderbird-debuginfo",
+            "rhel-8.8.0.z.tus::appstream:thunderbird-debugsource",
+            "rhel-9.0.0.z.e4s::appstream:firefox-debuginfo",
+            "rhel-9.0.0.z.e4s::appstream:firefox-debugsource",
+            "rhel-9.2.0.z.e4s::appstream:firefox-debuginfo",
+            "rhel-9.2.0.z.e4s::appstream:firefox-debugsource",
+            "rhel-9.2.0.z.e4s::appstream:thunderbird-debuginfo",
+            "rhel-9.2.0.z.e4s::appstream:thunderbird-debugsource",
+            "rhel-9.2.0.z.eus:firefox-debuginfo",
+            "rhel-9.2.0.z.eus:firefox-debugsource",
+            "rhel-9.2.0.z.eus:thunderbird-debuginfo",
+            "rhel-9.2.0.z.eus:thunderbird-debugsource",
+            "rhel-9.4.0.e4s::appstream:firefox-debuginfo",
+            "rhel-9.4.0.e4s::appstream:firefox-debugsource",
+            "rhel-9.4.0.e4s::appstream:thunderbird-debuginfo",
+            "rhel-9.4.0.e4s::appstream:thunderbird-debugsource",
+            "rhel-9.4.z.eus:firefox-debuginfo",
+            "rhel-9.4.z.eus:firefox-debugsource",
+            "rhel-9.4.z.eus:thunderbird-debuginfo",
+            "rhel-9.4.z.eus:thunderbird-debugsource",
+            "rhel-9.6.z.eus::appstream:firefox-debuginfo",
+            "rhel-9.6.z.eus::appstream:firefox-debugsource",
+            "rhel-9.6.z.eus::appstream:thunderbird-debuginfo",
+            "rhel-9.6.z.eus::appstream:thunderbird-debugsource",
+            "rhel-9.6.z.eus:firefox-debuginfo",
+            "rhel-9.6.z.eus:firefox-debugsource",
+            "rhel-9.6.z.eus:thunderbird-debuginfo",
+            "rhel-9.6.z.eus:thunderbird-debugsource",
+            "rhel-9.8.z.eus::appstream:firefox-debuginfo",
+            "rhel-9.8.z.eus::appstream:firefox-debugsource",
+            "rhel-9.8.z.eus::appstream:thunderbird-debuginfo",
+            "rhel-9.8.z.eus::appstream:thunderbird-debugsource",
+            "rhel-9.8.z.eus:firefox-debuginfo",
+            "rhel-9.8.z.eus:firefox-debugsource",
+            "rhel-9.8.z.eus:thunderbird-debuginfo",
+            "rhel-9.8.z.eus:thunderbird-debugsource",
+            "rhel-br-9.4.0.e4s::appstream:firefox-debuginfo",
+            "rhel-br-9.4.0.e4s::appstream:firefox-debugsource",
+            "rhel-br-9.4.0.e4s::appstream:thunderbird-debuginfo",
+            "rhel-br-9.4.0.e4s::appstream:thunderbird-debugsource"
+          ]
+        }
+      ],
+      "notes": [
+        {
+          "category": "other",
+          "text": "Red Hat Product Security rates the severity of this flaw as determined by the Mozilla Foundation Security Advisory.",
+          "title": "Statement"
+        },
+        {
+          "category": "description",
+          "text": "A flaw was found in Firefox and Thunderbird. The Mozilla Foundation's Security Advisory describes the following issue:\nMemory safety bugs present in Thunderbird ESR 140.10.0 and Thunderbird 150.0.0. Some of these bugs showed evidence of memory corruption and we presume that with enough effort some of these could have been exploited to run arbitrary code.",
+          "title": "Vulnerability description"
+        }
+      ],
+      "product_status": {
+        "fixed": [
+          "rhel-10.0.z.eus:firefox-0:140.10.1-1.el10_0",
+          "rhel-10.0.z.eus:firefox-0:140.10.1-1.el10_0.src",
+          "rhel-10.0.z.eus:thunderbird-0:140.10.1-1.el10_0",
+          "rhel-10.0.z.eus:thunderbird-0:140.10.1-1.el10_0.src",
+          "rhel-10.2.z.eus:firefox-0:140.10.1-1.el10_2",
+          "rhel-10.2.z.eus:firefox-0:140.10.1-1.el10_2.src",
+          "rhel-10.2.z.eus:thunderbird-0:140.10.1-1.el10_2",
+          "rhel-10.2.z.eus:thunderbird-0:140.10.1-1.el10_2.src",
+          "rhel-7-els.els:firefox-0:140.10.1-1.el7_9",
+          "rhel-7-els.els:firefox-0:140.10.1-1.el7_9.src",
+          "rhel-8.10.z::appstream:firefox-0:140.10.1-1.el8_10",
+          "rhel-8.10.z::appstream:firefox-0:140.10.1-1.el8_10.src",
+          "rhel-8.10.z::appstream:thunderbird-0:140.10.1-1.el8_10",
+          "rhel-8.10.z::appstream:thunderbird-0:140.10.1-1.el8_10.src",
+          "rhel-8.4.0.z.aus::appstream:firefox-0:140.10.1-1.el8_4",
+          "rhel-8.4.0.z.aus::appstream:firefox-0:140.10.1-1.el8_4.src",
+          "rhel-8.4.0.z.aus::appstream:thunderbird-0:140.10.1-1.el8_4",
+          "rhel-8.4.0.z.aus::appstream:thunderbird-0:140.10.1-1.el8_4.src",
+          "rhel-8.4.0.z.eus::appstream:firefox-0:140.10.1-1.el8_4",
+          "rhel-8.4.0.z.eus::appstream:firefox-0:140.10.1-1.el8_4.src",
+          "rhel-8.4.0.z.eus::appstream:thunderbird-0:140.10.1-1.el8_4",
+          "rhel-8.4.0.z.eus::appstream:thunderbird-0:140.10.1-1.el8_4.src",
+          "rhel-8.6.0.z.aus::appstream:firefox-0:140.10.1-1.el8_6",
+          "rhel-8.6.0.z.aus::appstream:firefox-0:140.10.1-1.el8_6.src",
+          "rhel-8.6.0.z.aus::appstream:thunderbird-0:140.10.1-1.el8_6",
+          "rhel-8.6.0.z.aus::appstream:thunderbird-0:140.10.1-1.el8_6.src",
+          "rhel-8.6.0.z.eus::appstream:firefox-0:140.10.1-1.el8_6",
+          "rhel-8.6.0.z.eus::appstream:firefox-0:140.10.1-1.el8_6.src",
+          "rhel-8.6.0.z.eus::appstream:thunderbird-0:140.10.1-1.el8_6",
+          "rhel-8.6.0.z.eus::appstream:thunderbird-0:140.10.1-1.el8_6.src",
+          "rhel-8.8.0.z.e4s::appstream:firefox-0:140.10.1-1.el8_8",
+          "rhel-8.8.0.z.e4s::appstream:firefox-0:140.10.1-1.el8_8.src",
+          "rhel-8.8.0.z.e4s::appstream:thunderbird-0:140.10.1-1.el8_8",
+          "rhel-8.8.0.z.e4s::appstream:thunderbird-0:140.10.1-1.el8_8.src",
+          "rhel-8.8.0.z.tus::appstream:firefox-0:140.10.1-1.el8_8",
+          "rhel-8.8.0.z.tus::appstream:firefox-0:140.10.1-1.el8_8.src",
+          "rhel-8.8.0.z.tus::appstream:thunderbird-0:140.10.1-1.el8_8",
+          "rhel-8.8.0.z.tus::appstream:thunderbird-0:140.10.1-1.el8_8.src",
+          "rhel-9.0.0.z.e4s::appstream:firefox-0:140.10.1-1.el9_0",
+          "rhel-9.0.0.z.e4s::appstream:firefox-0:140.10.1-1.el9_0.src",
+          "rhel-9.2.0.z.e4s::appstream:firefox-0:140.10.1-1.el9_2",
+          "rhel-9.2.0.z.e4s::appstream:firefox-0:140.10.1-1.el9_2.src",
+          "rhel-9.2.0.z.e4s::appstream:firefox-x11-0:140.10.1-1.el9_2",
+          "rhel-9.2.0.z.e4s::appstream:thunderbird-0:140.10.1-1.el9_2",
+          "rhel-9.2.0.z.e4s::appstream:thunderbird-0:140.10.1-1.el9_2.src",
+          "rhel-9.4.0.e4s::appstream:firefox-0:140.10.1-1.el9_4",
+          "rhel-9.4.0.e4s::appstream:firefox-0:140.10.1-1.el9_4.src",
+          "rhel-9.4.0.e4s::appstream:firefox-x11-0:140.10.1-1.el9_4",
+          "rhel-9.4.0.e4s::appstream:thunderbird-0:140.10.1-1.el9_4",
+          "rhel-9.4.0.e4s::appstream:thunderbird-0:140.10.1-1.el9_4.src",
+          "rhel-9.6.z.eus::appstream:firefox-0:140.10.1-1.el9_6",
+          "rhel-9.6.z.eus::appstream:firefox-0:140.10.1-1.el9_6.src",
+          "rhel-9.6.z.eus::appstream:firefox-x11-0:140.10.1-1.el9_6",
+          "rhel-9.6.z.eus::appstream:thunderbird-0:140.10.1-1.el9_6",
+          "rhel-9.6.z.eus::appstream:thunderbird-0:140.10.1-1.el9_6.src",
+          "rhel-9.8.z.eus::appstream:firefox-0:140.10.1-1.el9_8",
+          "rhel-9.8.z.eus::appstream:firefox-0:140.10.1-1.el9_8.src",
+          "rhel-9.8.z.eus::appstream:firefox-x11-0:140.10.1-1.el9_8",
+          "rhel-9.8.z.eus::appstream:thunderbird-0:140.10.1-1.el9_8",
+          "rhel-9.8.z.eus::appstream:thunderbird-0:140.10.1-1.el9_8.src",
+          "rhel-br-9.4.0.e4s::appstream:firefox-0:140.10.1-1.el9_4",
+          "rhel-br-9.4.0.e4s::appstream:firefox-0:140.10.1-1.el9_4.src",
+          "rhel-br-9.4.0.e4s::appstream:firefox-x11-0:140.10.1-1.el9_4",
+          "rhel-br-9.4.0.e4s::appstream:thunderbird-0:140.10.1-1.el9_4",
+          "rhel-br-9.4.0.e4s::appstream:thunderbird-0:140.10.1-1.el9_4.src"
+        ],
+        "known_affected": [
+          "rhel-10.0.z.eus:firefox",
+          "rhel-10.0.z.eus:firefox-x11",
+          "rhel-10.0.z.eus:firefox.src",
+          "rhel-10.0.z.eus:thunderbird",
+          "rhel-10.0.z.eus:thunderbird.src",
+          "rhel-10.1.z:firefox",
+          "rhel-10.1.z:firefox.src",
+          "rhel-10.1.z:thunderbird",
+          "rhel-10.1.z:thunderbird.src",
+          "rhel-10.2.z.eus:firefox",
+          "rhel-10.2.z.eus:firefox-x11",
+          "rhel-10.2.z.eus:firefox.src",
+          "rhel-10.2.z.eus:rhel10/firefox-flatpak.src",
+          "rhel-10.2.z.eus:rhel10/thunderbird-flatpak.src",
+          "rhel-10.2.z.eus:thunderbird",
+          "rhel-10.2.z.eus:thunderbird.src",
+          "rhel-6-els.els:firefox",
+          "rhel-6-els.els:firefox.src",
+          "rhel-6-els.els:thunderbird",
+          "rhel-6-els.els:thunderbird.src",
+          "rhel-7-els.els:firefox",
+          "rhel-7-els.els:firefox.src",
+          "rhel-7-els.els:thunderbird",
+          "rhel-7-els.els:thunderbird.src",
+          "rhel-8.10.z:firefox",
+          "rhel-8.10.z:firefox.src",
+          "rhel-8.10.z:thunderbird",
+          "rhel-8.10.z:thunderbird.src",
+          "rhel-8.2.0.z.aus:firefox",
+          "rhel-8.2.0.z.aus:firefox.src",
+          "rhel-8.2.0.z.aus:thunderbird",
+          "rhel-8.2.0.z.aus:thunderbird.src",
+          "rhel-8.4.0.z.eus:firefox",
+          "rhel-8.4.0.z.eus:firefox.src",
+          "rhel-8.4.0.z.eus:thunderbird",
+          "rhel-8.4.0.z.eus:thunderbird.src",
+          "rhel-8.6.0.z.aus:firefox",
+          "rhel-8.6.0.z.aus:firefox.src",
+          "rhel-8.6.0.z.aus:thunderbird",
+          "rhel-8.6.0.z.aus:thunderbird.src",
+          "rhel-8.8.0.z.eus:firefox",
+          "rhel-8.8.0.z.eus:firefox.src",
+          "rhel-8.8.0.z.eus:thunderbird",
+          "rhel-8.8.0.z.eus:thunderbird.src",
+          "rhel-9.0.0.z.eus:firefox",
+          "rhel-9.0.0.z.eus:firefox-x11",
+          "rhel-9.0.0.z.eus:firefox.src",
+          "rhel-9.0.0.z.eus:thunderbird",
+          "rhel-9.0.0.z.eus:thunderbird.src",
+          "rhel-9.2.0.z.eus:firefox",
+          "rhel-9.2.0.z.eus:firefox-x11",
+          "rhel-9.2.0.z.eus:firefox.src",
+          "rhel-9.2.0.z.eus:thunderbird",
+          "rhel-9.2.0.z.eus:thunderbird.src",
+          "rhel-9.4.z.eus:firefox",
+          "rhel-9.4.z.eus:firefox-x11",
+          "rhel-9.4.z.eus:firefox.src",
+          "rhel-9.4.z.eus:thunderbird",
+          "rhel-9.4.z.eus:thunderbird.src",
+          "rhel-9.6.z.eus:firefox",
+          "rhel-9.6.z.eus:firefox-x11",
+          "rhel-9.6.z.eus:firefox.src",
+          "rhel-9.6.z.eus:thunderbird",
+          "rhel-9.6.z.eus:thunderbird.src",
+          "rhel-9.7.z:firefox",
+          "rhel-9.7.z:firefox-x11",
+          "rhel-9.7.z:firefox.src",
+          "rhel-9.7.z:thunderbird",
+          "rhel-9.7.z:thunderbird.src",
+          "rhel-9.8.z.eus:firefox",
+          "rhel-9.8.z.eus:firefox-x11",
+          "rhel-9.8.z.eus:firefox.src",
+          "rhel-9.8.z.eus:thunderbird",
+          "rhel-9.8.z.eus:thunderbird.src"
+        ],
+        "known_not_affected": [
+          "rhel-10.0.z.eus:firefox-debuginfo",
+          "rhel-10.0.z.eus:firefox-debugsource",
+          "rhel-10.0.z.eus:thunderbird-debuginfo",
+          "rhel-10.0.z.eus:thunderbird-debugsource",
+          "rhel-10.2.z.eus:firefox-debuginfo",
+          "rhel-10.2.z.eus:firefox-debugsource",
+          "rhel-10.2.z.eus:thunderbird-debuginfo",
+          "rhel-10.2.z.eus:thunderbird-debugsource",
+          "rhel-7-els.els:firefox-debuginfo",
+          "rhel-8.10.z::appstream:firefox-debuginfo",
+          "rhel-8.10.z::appstream:firefox-debugsource",
+          "rhel-8.10.z::appstream:thunderbird-debuginfo",
+          "rhel-8.10.z::appstream:thunderbird-debugsource",
+          "rhel-8.10.z:firefox-debuginfo",
+          "rhel-8.10.z:firefox-debugsource",
+          "rhel-8.10.z:thunderbird-debuginfo",
+          "rhel-8.10.z:thunderbird-debugsource",
+          "rhel-8.4.0.z.aus::appstream:firefox-debuginfo",
+          "rhel-8.4.0.z.aus::appstream:firefox-debugsource",
+          "rhel-8.4.0.z.aus::appstream:thunderbird-debuginfo",
+          "rhel-8.4.0.z.aus::appstream:thunderbird-debugsource",
+          "rhel-8.4.0.z.eus::appstream:firefox-debuginfo",
+          "rhel-8.4.0.z.eus::appstream:firefox-debugsource",
+          "rhel-8.4.0.z.eus::appstream:thunderbird-debuginfo",
+          "rhel-8.4.0.z.eus::appstream:thunderbird-debugsource",
+          "rhel-8.4.0.z.eus:firefox-debuginfo",
+          "rhel-8.4.0.z.eus:firefox-debugsource",
+          "rhel-8.4.0.z.eus:thunderbird-debuginfo",
+          "rhel-8.4.0.z.eus:thunderbird-debugsource",
+          "rhel-8.6.0.z.aus::appstream:firefox-debuginfo",
+          "rhel-8.6.0.z.aus::appstream:firefox-debugsource",
+          "rhel-8.6.0.z.aus::appstream:thunderbird-debuginfo",
+          "rhel-8.6.0.z.aus::appstream:thunderbird-debugsource",
+          "rhel-8.6.0.z.aus:firefox-debuginfo",
+          "rhel-8.6.0.z.aus:firefox-debugsource",
+          "rhel-8.6.0.z.aus:thunderbird-debuginfo",
+          "rhel-8.6.0.z.aus:thunderbird-debugsource",
+          "rhel-8.6.0.z.eus::appstream:firefox-debuginfo",
+          "rhel-8.6.0.z.eus::appstream:firefox-debugsource",
+          "rhel-8.6.0.z.eus::appstream:thunderbird-debuginfo",
+          "rhel-8.6.0.z.eus::appstream:thunderbird-debugsource",
+          "rhel-8.8.0.z.e4s::appstream:firefox-debuginfo",
+          "rhel-8.8.0.z.e4s::appstream:firefox-debugsource",
+          "rhel-8.8.0.z.e4s::appstream:thunderbird-debuginfo",
+          "rhel-8.8.0.z.e4s::appstream:thunderbird-debugsource",
+          "rhel-8.8.0.z.eus:firefox-debuginfo",
+          "rhel-8.8.0.z.eus:firefox-debugsource",
+          "rhel-8.8.0.z.eus:thunderbird-debuginfo",
+          "rhel-8.8.0.z.eus:thunderbird-debugsource",
+          "rhel-8.8.0.z.tus::appstream:firefox-debuginfo",
+          "rhel-8.8.0.z.tus::appstream:firefox-debugsource",
+          "rhel-8.8.0.z.tus::appstream:thunderbird-debuginfo",
+          "rhel-8.8.0.z.tus::appstream:thunderbird-debugsource",
+          "rhel-9.0.0.z.e4s::appstream:firefox-debuginfo",
+          "rhel-9.0.0.z.e4s::appstream:firefox-debugsource",
+          "rhel-9.2.0.z.e4s::appstream:firefox-debuginfo",
+          "rhel-9.2.0.z.e4s::appstream:firefox-debugsource",
+          "rhel-9.2.0.z.e4s::appstream:thunderbird-debuginfo",
+          "rhel-9.2.0.z.e4s::appstream:thunderbird-debugsource",
+          "rhel-9.2.0.z.eus:firefox-debuginfo",
+          "rhel-9.2.0.z.eus:firefox-debugsource",
+          "rhel-9.2.0.z.eus:thunderbird-debuginfo",
+          "rhel-9.2.0.z.eus:thunderbird-debugsource",
+          "rhel-9.4.0.e4s::appstream:firefox-debuginfo",
+          "rhel-9.4.0.e4s::appstream:firefox-debugsource",
+          "rhel-9.4.0.e4s::appstream:thunderbird-debuginfo",
+          "rhel-9.4.0.e4s::appstream:thunderbird-debugsource",
+          "rhel-9.4.z.eus:firefox-debuginfo",
+          "rhel-9.4.z.eus:firefox-debugsource",
+          "rhel-9.4.z.eus:thunderbird-debuginfo",
+          "rhel-9.4.z.eus:thunderbird-debugsource",
+          "rhel-9.6.z.eus::appstream:firefox-debuginfo",
+          "rhel-9.6.z.eus::appstream:firefox-debugsource",
+          "rhel-9.6.z.eus::appstream:thunderbird-debuginfo",
+          "rhel-9.6.z.eus::appstream:thunderbird-debugsource",
+          "rhel-9.6.z.eus:firefox-debuginfo",
+          "rhel-9.6.z.eus:firefox-debugsource",
+          "rhel-9.6.z.eus:thunderbird-debuginfo",
+          "rhel-9.6.z.eus:thunderbird-debugsource",
+          "rhel-9.8.z.eus::appstream:firefox-debuginfo",
+          "rhel-9.8.z.eus::appstream:firefox-debugsource",
+          "rhel-9.8.z.eus::appstream:thunderbird-debuginfo",
+          "rhel-9.8.z.eus::appstream:thunderbird-debugsource",
+          "rhel-9.8.z.eus:firefox-debuginfo",
+          "rhel-9.8.z.eus:firefox-debugsource",
+          "rhel-9.8.z.eus:thunderbird-debuginfo",
+          "rhel-9.8.z.eus:thunderbird-debugsource",
+          "rhel-br-9.4.0.e4s::appstream:firefox-debuginfo",
+          "rhel-br-9.4.0.e4s::appstream:firefox-debugsource",
+          "rhel-br-9.4.0.e4s::appstream:thunderbird-debuginfo",
+          "rhel-br-9.4.0.e4s::appstream:thunderbird-debugsource"
+        ]
+      },
+      "references": [
+        {
+          "category": "self",
+          "summary": "Canonical URL",
+          "url": "https://access.redhat.com/security/cve/CVE-2026-7323"
+        },
+        {
+          "category": "external",
+          "summary": "nvd.nist.gov",
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-7323"
+        },
+        {
+          "category": "external",
+          "summary": "www.cve.org",
+          "url": "https://www.cve.org/CVERecord?id=CVE-2026-7323"
+        }
+      ],
+      "remediations": [
+        {
+          "category": "no_fix_planned",
+          "details": "Will not fix",
+          "product_ids": [
+            "rhel-8.2.0.z.aus:firefox",
+            "rhel-8.2.0.z.aus:firefox.src",
+            "rhel-8.2.0.z.aus:thunderbird",
+            "rhel-8.2.0.z.aus:thunderbird.src",
+            "rhel-9.0.0.z.eus:thunderbird",
+            "rhel-9.0.0.z.eus:thunderbird.src"
+          ]
+        },
+        {
+          "category": "no_fix_planned",
+          "details": "Out of support scope",
+          "product_ids": [
+            "rhel-6-els.els:firefox",
+            "rhel-6-els.els:firefox.src",
+            "rhel-6-els.els:thunderbird",
+            "rhel-6-els.els:thunderbird.src",
+            "rhel-7-els.els:thunderbird",
+            "rhel-7-els.els:thunderbird.src"
+          ]
+        },
+        {
+          "category": "none_available",
+          "details": "Affected",
+          "product_ids": [
+            "rhel-10.0.z.eus:firefox",
+            "rhel-10.0.z.eus:firefox-x11",
+            "rhel-10.0.z.eus:firefox.src",
+            "rhel-10.0.z.eus:thunderbird",
+            "rhel-10.0.z.eus:thunderbird.src",
+            "rhel-10.1.z:firefox",
+            "rhel-10.1.z:firefox.src",
+            "rhel-10.1.z:thunderbird",
+            "rhel-10.1.z:thunderbird.src",
+            "rhel-10.2.z.eus:firefox",
+            "rhel-10.2.z.eus:firefox-x11",
+            "rhel-10.2.z.eus:firefox.src",
+            "rhel-10.2.z.eus:rhel10/firefox-flatpak.src",
+            "rhel-10.2.z.eus:rhel10/thunderbird-flatpak.src",
+            "rhel-10.2.z.eus:thunderbird",
+            "rhel-10.2.z.eus:thunderbird.src",
+            "rhel-7-els.els:firefox",
+            "rhel-7-els.els:firefox.src",
+            "rhel-8.10.z:firefox",
+            "rhel-8.10.z:firefox.src",
+            "rhel-8.10.z:thunderbird",
+            "rhel-8.10.z:thunderbird.src",
+            "rhel-8.4.0.z.eus:firefox",
+            "rhel-8.4.0.z.eus:firefox.src",
+            "rhel-8.4.0.z.eus:thunderbird",
+            "rhel-8.4.0.z.eus:thunderbird.src",
+            "rhel-8.6.0.z.aus:firefox",
+            "rhel-8.6.0.z.aus:firefox.src",
+            "rhel-8.6.0.z.aus:thunderbird",
+            "rhel-8.6.0.z.aus:thunderbird.src",
+            "rhel-8.8.0.z.eus:firefox",
+            "rhel-8.8.0.z.eus:firefox.src",
+            "rhel-8.8.0.z.eus:thunderbird",
+            "rhel-8.8.0.z.eus:thunderbird.src",
+            "rhel-9.0.0.z.eus:firefox",
+            "rhel-9.0.0.z.eus:firefox-x11",
+            "rhel-9.0.0.z.eus:firefox.src",
+            "rhel-9.2.0.z.eus:firefox",
+            "rhel-9.2.0.z.eus:firefox-x11",
+            "rhel-9.2.0.z.eus:firefox.src",
+            "rhel-9.2.0.z.eus:thunderbird",
+            "rhel-9.2.0.z.eus:thunderbird.src",
+            "rhel-9.4.z.eus:firefox",
+            "rhel-9.4.z.eus:firefox-x11",
+            "rhel-9.4.z.eus:firefox.src",
+            "rhel-9.4.z.eus:thunderbird",
+            "rhel-9.4.z.eus:thunderbird.src",
+            "rhel-9.6.z.eus:firefox",
+            "rhel-9.6.z.eus:firefox-x11",
+            "rhel-9.6.z.eus:firefox.src",
+            "rhel-9.6.z.eus:thunderbird",
+            "rhel-9.6.z.eus:thunderbird.src",
+            "rhel-9.7.z:firefox",
+            "rhel-9.7.z:firefox-x11",
+            "rhel-9.7.z:firefox.src",
+            "rhel-9.7.z:thunderbird",
+            "rhel-9.7.z:thunderbird.src",
+            "rhel-9.8.z.eus:firefox",
+            "rhel-9.8.z.eus:firefox-x11",
+            "rhel-9.8.z.eus:firefox.src",
+            "rhel-9.8.z.eus:thunderbird",
+            "rhel-9.8.z.eus:thunderbird.src"
+          ]
+        },
+        {
+          "category": "vendor_fix",
+          "date": "2026-05-19T21:56:43+00:00",
+          "details": "Apply advisory RHSA-2026:19348 as per vendors instructions.",
+          "product_ids": [
+            "rhel-9.8.z.eus::appstream:thunderbird-0:140.10.1-1.el9_8",
+            "rhel-9.8.z.eus::appstream:thunderbird-0:140.10.1-1.el9_8.src"
+          ],
+          "url": "https://access.redhat.com/errata/RHSA-2026:19348"
+        },
+        {
+          "category": "vendor_fix",
+          "date": "2026-05-19T16:23:11+00:00",
+          "details": "Apply advisory RHSA-2026:19153 as per vendors instructions.",
+          "product_ids": [
+            "rhel-10.2.z.eus:thunderbird-0:140.10.1-1.el10_2",
+            "rhel-10.2.z.eus:thunderbird-0:140.10.1-1.el10_2.src"
+          ],
+          "url": "https://access.redhat.com/errata/RHSA-2026:19153"
+        },
+        {
+          "category": "vendor_fix",
+          "date": "2026-05-19T16:15:22+00:00",
+          "details": "Apply advisory RHSA-2026:19157 as per vendors instructions.",
+          "product_ids": [
+            "rhel-10.2.z.eus:firefox-0:140.10.1-1.el10_2",
+            "rhel-10.2.z.eus:firefox-0:140.10.1-1.el10_2.src"
+          ],
+          "url": "https://access.redhat.com/errata/RHSA-2026:19157"
+        },
+        {
+          "category": "vendor_fix",
+          "date": "2026-05-19T21:52:57+00:00",
+          "details": "Apply advisory RHSA-2026:19370 as per vendors instructions.",
+          "product_ids": [
+            "rhel-9.8.z.eus::appstream:firefox-0:140.10.1-1.el9_8",
+            "rhel-9.8.z.eus::appstream:firefox-0:140.10.1-1.el9_8.src",
+            "rhel-9.8.z.eus::appstream:firefox-x11-0:140.10.1-1.el9_8"
+          ],
+          "url": "https://access.redhat.com/errata/RHSA-2026:19370"
+        },
+        {
+          "category": "vendor_fix",
+          "date": "2026-05-20T11:36:31+00:00",
+          "details": "Apply advisory RHSA-2026:19588 as per vendors instructions.",
+          "product_ids": [
+            "rhel-8.10.z::appstream:firefox-0:140.10.1-1.el8_10",
+            "rhel-8.10.z::appstream:firefox-0:140.10.1-1.el8_10.src"
+          ],
+          "url": "https://access.redhat.com/errata/RHSA-2026:19588"
+        },
+        {
+          "category": "vendor_fix",
+          "date": "2026-05-26T05:06:20+00:00",
+          "details": "Apply advisory RHSA-2026:20586 as per vendors instructions.",
+          "product_ids": [
+            "rhel-8.10.z::appstream:thunderbird-0:140.10.1-1.el8_10",
+            "rhel-8.10.z::appstream:thunderbird-0:140.10.1-1.el8_10.src"
+          ],
+          "url": "https://access.redhat.com/errata/RHSA-2026:20586"
+        },
+        {
+          "category": "vendor_fix",
+          "date": "2026-05-28T12:34:39+00:00",
+          "details": "Apply advisory RHSA-2026:21743 as per vendors instructions.",
+          "product_ids": [
+            "rhel-9.0.0.z.e4s::appstream:firefox-0:140.10.1-1.el9_0",
+            "rhel-9.0.0.z.e4s::appstream:firefox-0:140.10.1-1.el9_0.src"
+          ],
+          "url": "https://access.redhat.com/errata/RHSA-2026:21743"
+        },
+        {
+          "category": "vendor_fix",
+          "date": "2026-06-01T15:38:29+00:00",
+          "details": "Apply advisory RHSA-2026:22324 as per vendors instructions.",
+          "product_ids": [
+            "rhel-9.4.0.e4s::appstream:firefox-0:140.10.1-1.el9_4",
+            "rhel-9.4.0.e4s::appstream:firefox-0:140.10.1-1.el9_4.src",
+            "rhel-9.4.0.e4s::appstream:firefox-x11-0:140.10.1-1.el9_4",
+            "rhel-br-9.4.0.e4s::appstream:firefox-0:140.10.1-1.el9_4",
+            "rhel-br-9.4.0.e4s::appstream:firefox-0:140.10.1-1.el9_4.src",
+            "rhel-br-9.4.0.e4s::appstream:firefox-x11-0:140.10.1-1.el9_4"
+          ],
+          "url": "https://access.redhat.com/errata/RHSA-2026:22324"
+        },
+        {
+          "category": "vendor_fix",
+          "date": "2026-06-02T06:56:53+00:00",
+          "details": "Apply advisory RHSA-2026:22410 as per vendors instructions.",
+          "product_ids": [
+            "rhel-9.2.0.z.e4s::appstream:firefox-0:140.10.1-1.el9_2",
+            "rhel-9.2.0.z.e4s::appstream:firefox-0:140.10.1-1.el9_2.src",
+            "rhel-9.2.0.z.e4s::appstream:firefox-x11-0:140.10.1-1.el9_2"
+          ],
+          "url": "https://access.redhat.com/errata/RHSA-2026:22410"
+        },
+        {
+          "category": "vendor_fix",
+          "date": "2026-06-02T07:05:53+00:00",
+          "details": "Apply advisory RHSA-2026:22409 as per vendors instructions.",
+          "product_ids": [
+            "rhel-9.6.z.eus::appstream:firefox-0:140.10.1-1.el9_6",
+            "rhel-9.6.z.eus::appstream:firefox-0:140.10.1-1.el9_6.src",
+            "rhel-9.6.z.eus::appstream:firefox-x11-0:140.10.1-1.el9_6"
+          ],
+          "url": "https://access.redhat.com/errata/RHSA-2026:22409"
+        },
+        {
+          "category": "vendor_fix",
+          "date": "2026-06-02T06:57:17+00:00",
+          "details": "Apply advisory RHSA-2026:22408 as per vendors instructions.",
+          "product_ids": [
+            "rhel-10.0.z.eus:firefox-0:140.10.1-1.el10_0",
+            "rhel-10.0.z.eus:firefox-0:140.10.1-1.el10_0.src"
+          ],
+          "url": "https://access.redhat.com/errata/RHSA-2026:22408"
+        },
+        {
+          "category": "vendor_fix",
+          "date": "2026-06-03T05:56:40+00:00",
+          "details": "Apply advisory RHSA-2026:22708 as per vendors instructions.",
+          "product_ids": [
+            "rhel-7-els.els:firefox-0:140.10.1-1.el7_9",
+            "rhel-7-els.els:firefox-0:140.10.1-1.el7_9.src"
+          ],
+          "url": "https://access.redhat.com/errata/RHSA-2026:22708"
+        },
+        {
+          "category": "vendor_fix",
+          "date": "2026-06-03T07:51:46+00:00",
+          "details": "Apply advisory RHSA-2026:22712 as per vendors instructions.",
+          "product_ids": [
+            "rhel-8.4.0.z.aus::appstream:firefox-0:140.10.1-1.el8_4",
+            "rhel-8.4.0.z.aus::appstream:firefox-0:140.10.1-1.el8_4.src",
+            "rhel-8.4.0.z.eus::appstream:firefox-0:140.10.1-1.el8_4",
+            "rhel-8.4.0.z.eus::appstream:firefox-0:140.10.1-1.el8_4.src"
+          ],
+          "url": "https://access.redhat.com/errata/RHSA-2026:22712"
+        },
+        {
+          "category": "vendor_fix",
+          "date": "2026-06-08T02:57:49+00:00",
+          "details": "Apply advisory RHSA-2026:24345 as per vendors instructions.",
+          "product_ids": [
+            "rhel-8.6.0.z.aus::appstream:firefox-0:140.10.1-1.el8_6",
+            "rhel-8.6.0.z.aus::appstream:firefox-0:140.10.1-1.el8_6.src",
+            "rhel-8.6.0.z.eus::appstream:firefox-0:140.10.1-1.el8_6",
+            "rhel-8.6.0.z.eus::appstream:firefox-0:140.10.1-1.el8_6.src"
+          ],
+          "url": "https://access.redhat.com/errata/RHSA-2026:24345"
+        },
+        {
+          "category": "vendor_fix",
+          "date": "2026-06-03T13:52:37+00:00",
+          "details": "Apply advisory RHSA-2026:22847 as per vendors instructions.",
+          "product_ids": [
+            "rhel-8.8.0.z.e4s::appstream:firefox-0:140.10.1-1.el8_8",
+            "rhel-8.8.0.z.e4s::appstream:firefox-0:140.10.1-1.el8_8.src",
+            "rhel-8.8.0.z.tus::appstream:firefox-0:140.10.1-1.el8_8",
+            "rhel-8.8.0.z.tus::appstream:firefox-0:140.10.1-1.el8_8.src"
+          ],
+          "url": "https://access.redhat.com/errata/RHSA-2026:22847"
+        },
+        {
+          "category": "vendor_fix",
+          "date": "2026-06-09T06:54:10+00:00",
+          "details": "Apply advisory RHSA-2026:24717 as per vendors instructions.",
+          "product_ids": [
+            "rhel-8.8.0.z.e4s::appstream:thunderbird-0:140.10.1-1.el8_8",
+            "rhel-8.8.0.z.e4s::appstream:thunderbird-0:140.10.1-1.el8_8.src",
+            "rhel-8.8.0.z.tus::appstream:thunderbird-0:140.10.1-1.el8_8",
+            "rhel-8.8.0.z.tus::appstream:thunderbird-0:140.10.1-1.el8_8.src"
+          ],
+          "url": "https://access.redhat.com/errata/RHSA-2026:24717"
+        },
+        {
+          "category": "vendor_fix",
+          "date": "2026-06-10T09:07:06+00:00",
+          "details": "Apply advisory RHSA-2026:25014 as per vendors instructions.",
+          "product_ids": [
+            "rhel-8.6.0.z.aus::appstream:thunderbird-0:140.10.1-1.el8_6",
+            "rhel-8.6.0.z.aus::appstream:thunderbird-0:140.10.1-1.el8_6.src",
+            "rhel-8.6.0.z.eus::appstream:thunderbird-0:140.10.1-1.el8_6",
+            "rhel-8.6.0.z.eus::appstream:thunderbird-0:140.10.1-1.el8_6.src"
+          ],
+          "url": "https://access.redhat.com/errata/RHSA-2026:25014"
+        },
+        {
+          "category": "vendor_fix",
+          "date": "2026-06-09T06:47:25+00:00",
+          "details": "Apply advisory RHSA-2026:24718 as per vendors instructions.",
+          "product_ids": [
+            "rhel-8.4.0.z.aus::appstream:thunderbird-0:140.10.1-1.el8_4",
+            "rhel-8.4.0.z.aus::appstream:thunderbird-0:140.10.1-1.el8_4.src",
+            "rhel-8.4.0.z.eus::appstream:thunderbird-0:140.10.1-1.el8_4",
+            "rhel-8.4.0.z.eus::appstream:thunderbird-0:140.10.1-1.el8_4.src"
+          ],
+          "url": "https://access.redhat.com/errata/RHSA-2026:24718"
+        },
+        {
+          "category": "vendor_fix",
+          "date": "2026-06-09T08:16:51+00:00",
+          "details": "Apply advisory RHSA-2026:24721 as per vendors instructions.",
+          "product_ids": [
+            "rhel-9.6.z.eus::appstream:thunderbird-0:140.10.1-1.el9_6",
+            "rhel-9.6.z.eus::appstream:thunderbird-0:140.10.1-1.el9_6.src"
+          ],
+          "url": "https://access.redhat.com/errata/RHSA-2026:24721"
+        },
+        {
+          "category": "vendor_fix",
+          "date": "2026-06-09T06:50:56+00:00",
+          "details": "Apply advisory RHSA-2026:24719 as per vendors instructions.",
+          "product_ids": [
+            "rhel-10.0.z.eus:thunderbird-0:140.10.1-1.el10_0",
+            "rhel-10.0.z.eus:thunderbird-0:140.10.1-1.el10_0.src"
+          ],
+          "url": "https://access.redhat.com/errata/RHSA-2026:24719"
+        },
+        {
+          "category": "vendor_fix",
+          "date": "2026-06-09T15:12:42+00:00",
+          "details": "Apply advisory RHSA-2026:24844 as per vendors instructions.",
+          "product_ids": [
+            "rhel-9.2.0.z.e4s::appstream:thunderbird-0:140.10.1-1.el9_2",
+            "rhel-9.2.0.z.e4s::appstream:thunderbird-0:140.10.1-1.el9_2.src"
+          ],
+          "url": "https://access.redhat.com/errata/RHSA-2026:24844"
+        },
+        {
+          "category": "vendor_fix",
+          "date": "2026-06-09T15:16:22+00:00",
+          "details": "Apply advisory RHSA-2026:24846 as per vendors instructions.",
+          "product_ids": [
+            "rhel-9.4.0.e4s::appstream:thunderbird-0:140.10.1-1.el9_4",
+            "rhel-9.4.0.e4s::appstream:thunderbird-0:140.10.1-1.el9_4.src",
+            "rhel-br-9.4.0.e4s::appstream:thunderbird-0:140.10.1-1.el9_4",
+            "rhel-br-9.4.0.e4s::appstream:thunderbird-0:140.10.1-1.el9_4.src"
+          ],
+          "url": "https://access.redhat.com/errata/RHSA-2026:24846"
+        }
+      ],
+      "scores": [
+        {
+          "cvss_v3": {
+            "version": "3.1",
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H",
+            "baseScore": 7.5,
+            "baseSeverity": "HIGH"
+          },
+          "products": [
+            "rhel-10.0.z.eus:firefox",
+            "rhel-10.0.z.eus:firefox-0:140.10.1-1.el10_0",
+            "rhel-10.0.z.eus:firefox-0:140.10.1-1.el10_0.src",
+            "rhel-10.0.z.eus:firefox-debuginfo",
+            "rhel-10.0.z.eus:firefox-debugsource",
+            "rhel-10.0.z.eus:firefox-x11",
+            "rhel-10.0.z.eus:firefox.src",
+            "rhel-10.0.z.eus:thunderbird",
+            "rhel-10.0.z.eus:thunderbird-0:140.10.1-1.el10_0",
+            "rhel-10.0.z.eus:thunderbird-0:140.10.1-1.el10_0.src",
+            "rhel-10.0.z.eus:thunderbird-debuginfo",
+            "rhel-10.0.z.eus:thunderbird-debugsource",
+            "rhel-10.0.z.eus:thunderbird.src",
+            "rhel-10.1.z:firefox",
+            "rhel-10.1.z:firefox.src",
+            "rhel-10.1.z:thunderbird",
+            "rhel-10.1.z:thunderbird.src",
+            "rhel-10.2.z.eus:firefox",
+            "rhel-10.2.z.eus:firefox-0:140.10.1-1.el10_2",
+            "rhel-10.2.z.eus:firefox-0:140.10.1-1.el10_2.src",
+            "rhel-10.2.z.eus:firefox-debuginfo",
+            "rhel-10.2.z.eus:firefox-debugsource",
+            "rhel-10.2.z.eus:firefox-x11",
+            "rhel-10.2.z.eus:firefox.src",
+            "rhel-10.2.z.eus:rhel10/firefox-flatpak.src",
+            "rhel-10.2.z.eus:rhel10/thunderbird-flatpak.src",
+            "rhel-10.2.z.eus:thunderbird",
+            "rhel-10.2.z.eus:thunderbird-0:140.10.1-1.el10_2",
+            "rhel-10.2.z.eus:thunderbird-0:140.10.1-1.el10_2.src",
+            "rhel-10.2.z.eus:thunderbird-debuginfo",
+            "rhel-10.2.z.eus:thunderbird-debugsource",
+            "rhel-10.2.z.eus:thunderbird.src",
+            "rhel-6-els.els:firefox",
+            "rhel-6-els.els:firefox.src",
+            "rhel-6-els.els:thunderbird",
+            "rhel-6-els.els:thunderbird.src",
+            "rhel-7-els.els:firefox",
+            "rhel-7-els.els:firefox-0:140.10.1-1.el7_9",
+            "rhel-7-els.els:firefox-0:140.10.1-1.el7_9.src",
+            "rhel-7-els.els:firefox-debuginfo",
+            "rhel-7-els.els:firefox.src",
+            "rhel-7-els.els:thunderbird",
+            "rhel-7-els.els:thunderbird.src",
+            "rhel-8.10.z::appstream:firefox-0:140.10.1-1.el8_10",
+            "rhel-8.10.z::appstream:firefox-0:140.10.1-1.el8_10.src",
+            "rhel-8.10.z::appstream:firefox-debuginfo",
+            "rhel-8.10.z::appstream:firefox-debugsource",
+            "rhel-8.10.z::appstream:thunderbird-0:140.10.1-1.el8_10",
+            "rhel-8.10.z::appstream:thunderbird-0:140.10.1-1.el8_10.src",
+            "rhel-8.10.z::appstream:thunderbird-debuginfo",
+            "rhel-8.10.z::appstream:thunderbird-debugsource",
+            "rhel-8.10.z:firefox",
+            "rhel-8.10.z:firefox-debuginfo",
+            "rhel-8.10.z:firefox-debugsource",
+            "rhel-8.10.z:firefox.src",
+            "rhel-8.10.z:thunderbird",
+            "rhel-8.10.z:thunderbird-debuginfo",
+            "rhel-8.10.z:thunderbird-debugsource",
+            "rhel-8.10.z:thunderbird.src",
+            "rhel-8.2.0.z.aus:firefox",
+            "rhel-8.2.0.z.aus:firefox.src",
+            "rhel-8.2.0.z.aus:thunderbird",
+            "rhel-8.2.0.z.aus:thunderbird.src",
+            "rhel-8.4.0.z.aus::appstream:firefox-0:140.10.1-1.el8_4",
+            "rhel-8.4.0.z.aus::appstream:firefox-0:140.10.1-1.el8_4.src",
+            "rhel-8.4.0.z.aus::appstream:firefox-debuginfo",
+            "rhel-8.4.0.z.aus::appstream:firefox-debugsource",
+            "rhel-8.4.0.z.aus::appstream:thunderbird-0:140.10.1-1.el8_4",
+            "rhel-8.4.0.z.aus::appstream:thunderbird-0:140.10.1-1.el8_4.src",
+            "rhel-8.4.0.z.aus::appstream:thunderbird-debuginfo",
+            "rhel-8.4.0.z.aus::appstream:thunderbird-debugsource",
+            "rhel-8.4.0.z.eus::appstream:firefox-0:140.10.1-1.el8_4",
+            "rhel-8.4.0.z.eus::appstream:firefox-0:140.10.1-1.el8_4.src",
+            "rhel-8.4.0.z.eus::appstream:firefox-debuginfo",
+            "rhel-8.4.0.z.eus::appstream:firefox-debugsource",
+            "rhel-8.4.0.z.eus::appstream:thunderbird-0:140.10.1-1.el8_4",
+            "rhel-8.4.0.z.eus::appstream:thunderbird-0:140.10.1-1.el8_4.src",
+            "rhel-8.4.0.z.eus::appstream:thunderbird-debuginfo",
+            "rhel-8.4.0.z.eus::appstream:thunderbird-debugsource",
+            "rhel-8.4.0.z.eus:firefox",
+            "rhel-8.4.0.z.eus:firefox-debuginfo",
+            "rhel-8.4.0.z.eus:firefox-debugsource",
+            "rhel-8.4.0.z.eus:firefox.src",
+            "rhel-8.4.0.z.eus:thunderbird",
+            "rhel-8.4.0.z.eus:thunderbird-debuginfo",
+            "rhel-8.4.0.z.eus:thunderbird-debugsource",
+            "rhel-8.4.0.z.eus:thunderbird.src",
+            "rhel-8.6.0.z.aus::appstream:firefox-0:140.10.1-1.el8_6",
+            "rhel-8.6.0.z.aus::appstream:firefox-0:140.10.1-1.el8_6.src",
+            "rhel-8.6.0.z.aus::appstream:firefox-debuginfo",
+            "rhel-8.6.0.z.aus::appstream:firefox-debugsource",
+            "rhel-8.6.0.z.aus::appstream:thunderbird-0:140.10.1-1.el8_6",
+            "rhel-8.6.0.z.aus::appstream:thunderbird-0:140.10.1-1.el8_6.src",
+            "rhel-8.6.0.z.aus::appstream:thunderbird-debuginfo",
+            "rhel-8.6.0.z.aus::appstream:thunderbird-debugsource",
+            "rhel-8.6.0.z.aus:firefox",
+            "rhel-8.6.0.z.aus:firefox-debuginfo",
+            "rhel-8.6.0.z.aus:firefox-debugsource",
+            "rhel-8.6.0.z.aus:firefox.src",
+            "rhel-8.6.0.z.aus:thunderbird",
+            "rhel-8.6.0.z.aus:thunderbird-debuginfo",
+            "rhel-8.6.0.z.aus:thunderbird-debugsource",
+            "rhel-8.6.0.z.aus:thunderbird.src",
+            "rhel-8.6.0.z.eus::appstream:firefox-0:140.10.1-1.el8_6",
+            "rhel-8.6.0.z.eus::appstream:firefox-0:140.10.1-1.el8_6.src",
+            "rhel-8.6.0.z.eus::appstream:firefox-debuginfo",
+            "rhel-8.6.0.z.eus::appstream:firefox-debugsource",
+            "rhel-8.6.0.z.eus::appstream:thunderbird-0:140.10.1-1.el8_6",
+            "rhel-8.6.0.z.eus::appstream:thunderbird-0:140.10.1-1.el8_6.src",
+            "rhel-8.6.0.z.eus::appstream:thunderbird-debuginfo",
+            "rhel-8.6.0.z.eus::appstream:thunderbird-debugsource",
+            "rhel-8.8.0.z.e4s::appstream:firefox-0:140.10.1-1.el8_8",
+            "rhel-8.8.0.z.e4s::appstream:firefox-0:140.10.1-1.el8_8.src",
+            "rhel-8.8.0.z.e4s::appstream:firefox-debuginfo",
+            "rhel-8.8.0.z.e4s::appstream:firefox-debugsource",
+            "rhel-8.8.0.z.e4s::appstream:thunderbird-0:140.10.1-1.el8_8",
+            "rhel-8.8.0.z.e4s::appstream:thunderbird-0:140.10.1-1.el8_8.src",
+            "rhel-8.8.0.z.e4s::appstream:thunderbird-debuginfo",
+            "rhel-8.8.0.z.e4s::appstream:thunderbird-debugsource",
+            "rhel-8.8.0.z.eus:firefox",
+            "rhel-8.8.0.z.eus:firefox-debuginfo",
+            "rhel-8.8.0.z.eus:firefox-debugsource",
+            "rhel-8.8.0.z.eus:firefox.src",
+            "rhel-8.8.0.z.eus:thunderbird",
+            "rhel-8.8.0.z.eus:thunderbird-debuginfo",
+            "rhel-8.8.0.z.eus:thunderbird-debugsource",
+            "rhel-8.8.0.z.eus:thunderbird.src",
+            "rhel-8.8.0.z.tus::appstream:firefox-0:140.10.1-1.el8_8",
+            "rhel-8.8.0.z.tus::appstream:firefox-0:140.10.1-1.el8_8.src",
+            "rhel-8.8.0.z.tus::appstream:firefox-debuginfo",
+            "rhel-8.8.0.z.tus::appstream:firefox-debugsource",
+            "rhel-8.8.0.z.tus::appstream:thunderbird-0:140.10.1-1.el8_8",
+            "rhel-8.8.0.z.tus::appstream:thunderbird-0:140.10.1-1.el8_8.src",
+            "rhel-8.8.0.z.tus::appstream:thunderbird-debuginfo",
+            "rhel-8.8.0.z.tus::appstream:thunderbird-debugsource",
+            "rhel-9.0.0.z.e4s::appstream:firefox-0:140.10.1-1.el9_0",
+            "rhel-9.0.0.z.e4s::appstream:firefox-0:140.10.1-1.el9_0.src",
+            "rhel-9.0.0.z.e4s::appstream:firefox-debuginfo",
+            "rhel-9.0.0.z.e4s::appstream:firefox-debugsource",
+            "rhel-9.0.0.z.eus:firefox",
+            "rhel-9.0.0.z.eus:firefox-x11",
+            "rhel-9.0.0.z.eus:firefox.src",
+            "rhel-9.0.0.z.eus:thunderbird",
+            "rhel-9.0.0.z.eus:thunderbird.src",
+            "rhel-9.2.0.z.e4s::appstream:firefox-0:140.10.1-1.el9_2",
+            "rhel-9.2.0.z.e4s::appstream:firefox-0:140.10.1-1.el9_2.src",
+            "rhel-9.2.0.z.e4s::appstream:firefox-debuginfo",
+            "rhel-9.2.0.z.e4s::appstream:firefox-debugsource",
+            "rhel-9.2.0.z.e4s::appstream:firefox-x11-0:140.10.1-1.el9_2",
+            "rhel-9.2.0.z.e4s::appstream:thunderbird-0:140.10.1-1.el9_2",
+            "rhel-9.2.0.z.e4s::appstream:thunderbird-0:140.10.1-1.el9_2.src",
+            "rhel-9.2.0.z.e4s::appstream:thunderbird-debuginfo",
+            "rhel-9.2.0.z.e4s::appstream:thunderbird-debugsource",
+            "rhel-9.2.0.z.eus:firefox",
+            "rhel-9.2.0.z.eus:firefox-debuginfo",
+            "rhel-9.2.0.z.eus:firefox-debugsource",
+            "rhel-9.2.0.z.eus:firefox-x11",
+            "rhel-9.2.0.z.eus:firefox.src",
+            "rhel-9.2.0.z.eus:thunderbird",
+            "rhel-9.2.0.z.eus:thunderbird-debuginfo",
+            "rhel-9.2.0.z.eus:thunderbird-debugsource",
+            "rhel-9.2.0.z.eus:thunderbird.src",
+            "rhel-9.4.0.e4s::appstream:firefox-0:140.10.1-1.el9_4",
+            "rhel-9.4.0.e4s::appstream:firefox-0:140.10.1-1.el9_4.src",
+            "rhel-9.4.0.e4s::appstream:firefox-debuginfo",
+            "rhel-9.4.0.e4s::appstream:firefox-debugsource",
+            "rhel-9.4.0.e4s::appstream:firefox-x11-0:140.10.1-1.el9_4",
+            "rhel-9.4.0.e4s::appstream:thunderbird-0:140.10.1-1.el9_4",
+            "rhel-9.4.0.e4s::appstream:thunderbird-0:140.10.1-1.el9_4.src",
+            "rhel-9.4.0.e4s::appstream:thunderbird-debuginfo",
+            "rhel-9.4.0.e4s::appstream:thunderbird-debugsource",
+            "rhel-9.4.z.eus:firefox",
+            "rhel-9.4.z.eus:firefox-debuginfo",
+            "rhel-9.4.z.eus:firefox-debugsource",
+            "rhel-9.4.z.eus:firefox-x11",
+            "rhel-9.4.z.eus:firefox.src",
+            "rhel-9.4.z.eus:thunderbird",
+            "rhel-9.4.z.eus:thunderbird-debuginfo",
+            "rhel-9.4.z.eus:thunderbird-debugsource",
+            "rhel-9.4.z.eus:thunderbird.src",
+            "rhel-9.6.z.eus::appstream:firefox-0:140.10.1-1.el9_6",
+            "rhel-9.6.z.eus::appstream:firefox-0:140.10.1-1.el9_6.src",
+            "rhel-9.6.z.eus::appstream:firefox-debuginfo",
+            "rhel-9.6.z.eus::appstream:firefox-debugsource",
+            "rhel-9.6.z.eus::appstream:firefox-x11-0:140.10.1-1.el9_6",
+            "rhel-9.6.z.eus::appstream:thunderbird-0:140.10.1-1.el9_6",
+            "rhel-9.6.z.eus::appstream:thunderbird-0:140.10.1-1.el9_6.src",
+            "rhel-9.6.z.eus::appstream:thunderbird-debuginfo",
+            "rhel-9.6.z.eus::appstream:thunderbird-debugsource",
+            "rhel-9.6.z.eus:firefox",
+            "rhel-9.6.z.eus:firefox-debuginfo",
+            "rhel-9.6.z.eus:firefox-debugsource",
+            "rhel-9.6.z.eus:firefox-x11",
+            "rhel-9.6.z.eus:firefox.src",
+            "rhel-9.6.z.eus:thunderbird",
+            "rhel-9.6.z.eus:thunderbird-debuginfo",
+            "rhel-9.6.z.eus:thunderbird-debugsource",
+            "rhel-9.6.z.eus:thunderbird.src",
+            "rhel-9.7.z:firefox",
+            "rhel-9.7.z:firefox-x11",
+            "rhel-9.7.z:firefox.src",
+            "rhel-9.7.z:thunderbird",
+            "rhel-9.7.z:thunderbird.src",
+            "rhel-9.8.z.eus::appstream:firefox-0:140.10.1-1.el9_8",
+            "rhel-9.8.z.eus::appstream:firefox-0:140.10.1-1.el9_8.src",
+            "rhel-9.8.z.eus::appstream:firefox-debuginfo",
+            "rhel-9.8.z.eus::appstream:firefox-debugsource",
+            "rhel-9.8.z.eus::appstream:firefox-x11-0:140.10.1-1.el9_8",
+            "rhel-9.8.z.eus::appstream:thunderbird-0:140.10.1-1.el9_8",
+            "rhel-9.8.z.eus::appstream:thunderbird-0:140.10.1-1.el9_8.src",
+            "rhel-9.8.z.eus::appstream:thunderbird-debuginfo",
+            "rhel-9.8.z.eus::appstream:thunderbird-debugsource",
+            "rhel-9.8.z.eus:firefox",
+            "rhel-9.8.z.eus:firefox-debuginfo",
+            "rhel-9.8.z.eus:firefox-debugsource",
+            "rhel-9.8.z.eus:firefox-x11",
+            "rhel-9.8.z.eus:firefox.src",
+            "rhel-9.8.z.eus:thunderbird",
+            "rhel-9.8.z.eus:thunderbird-debuginfo",
+            "rhel-9.8.z.eus:thunderbird-debugsource",
+            "rhel-9.8.z.eus:thunderbird.src",
+            "rhel-br-9.4.0.e4s::appstream:firefox-0:140.10.1-1.el9_4",
+            "rhel-br-9.4.0.e4s::appstream:firefox-0:140.10.1-1.el9_4.src",
+            "rhel-br-9.4.0.e4s::appstream:firefox-debuginfo",
+            "rhel-br-9.4.0.e4s::appstream:firefox-debugsource",
+            "rhel-br-9.4.0.e4s::appstream:firefox-x11-0:140.10.1-1.el9_4",
+            "rhel-br-9.4.0.e4s::appstream:thunderbird-0:140.10.1-1.el9_4",
+            "rhel-br-9.4.0.e4s::appstream:thunderbird-0:140.10.1-1.el9_4.src",
+            "rhel-br-9.4.0.e4s::appstream:thunderbird-debuginfo",
+            "rhel-br-9.4.0.e4s::appstream:thunderbird-debugsource"
+          ]
+        }
+      ],
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Important",
+          "product_ids": [
+            "rhel-10.0.z.eus:firefox",
+            "rhel-10.0.z.eus:firefox-0:140.10.1-1.el10_0",
+            "rhel-10.0.z.eus:firefox-0:140.10.1-1.el10_0.src",
+            "rhel-10.0.z.eus:firefox-debuginfo",
+            "rhel-10.0.z.eus:firefox-debugsource",
+            "rhel-10.0.z.eus:firefox-x11",
+            "rhel-10.0.z.eus:firefox.src",
+            "rhel-10.0.z.eus:thunderbird",
+            "rhel-10.0.z.eus:thunderbird-0:140.10.1-1.el10_0",
+            "rhel-10.0.z.eus:thunderbird-0:140.10.1-1.el10_0.src",
+            "rhel-10.0.z.eus:thunderbird-debuginfo",
+            "rhel-10.0.z.eus:thunderbird-debugsource",
+            "rhel-10.0.z.eus:thunderbird.src",
+            "rhel-10.1.z:firefox",
+            "rhel-10.1.z:firefox.src",
+            "rhel-10.1.z:thunderbird",
+            "rhel-10.1.z:thunderbird.src",
+            "rhel-10.2.z.eus:firefox",
+            "rhel-10.2.z.eus:firefox-0:140.10.1-1.el10_2",
+            "rhel-10.2.z.eus:firefox-0:140.10.1-1.el10_2.src",
+            "rhel-10.2.z.eus:firefox-debuginfo",
+            "rhel-10.2.z.eus:firefox-debugsource",
+            "rhel-10.2.z.eus:firefox-x11",
+            "rhel-10.2.z.eus:firefox.src",
+            "rhel-10.2.z.eus:rhel10/firefox-flatpak.src",
+            "rhel-10.2.z.eus:rhel10/thunderbird-flatpak.src",
+            "rhel-10.2.z.eus:thunderbird",
+            "rhel-10.2.z.eus:thunderbird-0:140.10.1-1.el10_2",
+            "rhel-10.2.z.eus:thunderbird-0:140.10.1-1.el10_2.src",
+            "rhel-10.2.z.eus:thunderbird-debuginfo",
+            "rhel-10.2.z.eus:thunderbird-debugsource",
+            "rhel-10.2.z.eus:thunderbird.src",
+            "rhel-6-els.els:firefox",
+            "rhel-6-els.els:firefox.src",
+            "rhel-6-els.els:thunderbird",
+            "rhel-6-els.els:thunderbird.src",
+            "rhel-7-els.els:firefox",
+            "rhel-7-els.els:firefox-0:140.10.1-1.el7_9",
+            "rhel-7-els.els:firefox-0:140.10.1-1.el7_9.src",
+            "rhel-7-els.els:firefox-debuginfo",
+            "rhel-7-els.els:firefox.src",
+            "rhel-7-els.els:thunderbird",
+            "rhel-7-els.els:thunderbird.src",
+            "rhel-8.10.z::appstream:firefox-0:140.10.1-1.el8_10",
+            "rhel-8.10.z::appstream:firefox-0:140.10.1-1.el8_10.src",
+            "rhel-8.10.z::appstream:firefox-debuginfo",
+            "rhel-8.10.z::appstream:firefox-debugsource",
+            "rhel-8.10.z::appstream:thunderbird-0:140.10.1-1.el8_10",
+            "rhel-8.10.z::appstream:thunderbird-0:140.10.1-1.el8_10.src",
+            "rhel-8.10.z::appstream:thunderbird-debuginfo",
+            "rhel-8.10.z::appstream:thunderbird-debugsource",
+            "rhel-8.10.z:firefox",
+            "rhel-8.10.z:firefox-debuginfo",
+            "rhel-8.10.z:firefox-debugsource",
+            "rhel-8.10.z:firefox.src",
+            "rhel-8.10.z:thunderbird",
+            "rhel-8.10.z:thunderbird-debuginfo",
+            "rhel-8.10.z:thunderbird-debugsource",
+            "rhel-8.10.z:thunderbird.src",
+            "rhel-8.2.0.z.aus:firefox",
+            "rhel-8.2.0.z.aus:firefox.src",
+            "rhel-8.2.0.z.aus:thunderbird",
+            "rhel-8.2.0.z.aus:thunderbird.src",
+            "rhel-8.4.0.z.aus::appstream:firefox-0:140.10.1-1.el8_4",
+            "rhel-8.4.0.z.aus::appstream:firefox-0:140.10.1-1.el8_4.src",
+            "rhel-8.4.0.z.aus::appstream:firefox-debuginfo",
+            "rhel-8.4.0.z.aus::appstream:firefox-debugsource",
+            "rhel-8.4.0.z.aus::appstream:thunderbird-0:140.10.1-1.el8_4",
+            "rhel-8.4.0.z.aus::appstream:thunderbird-0:140.10.1-1.el8_4.src",
+            "rhel-8.4.0.z.aus::appstream:thunderbird-debuginfo",
+            "rhel-8.4.0.z.aus::appstream:thunderbird-debugsource",
+            "rhel-8.4.0.z.eus::appstream:firefox-0:140.10.1-1.el8_4",
+            "rhel-8.4.0.z.eus::appstream:firefox-0:140.10.1-1.el8_4.src",
+            "rhel-8.4.0.z.eus::appstream:firefox-debuginfo",
+            "rhel-8.4.0.z.eus::appstream:firefox-debugsource",
+            "rhel-8.4.0.z.eus::appstream:thunderbird-0:140.10.1-1.el8_4",
+            "rhel-8.4.0.z.eus::appstream:thunderbird-0:140.10.1-1.el8_4.src",
+            "rhel-8.4.0.z.eus::appstream:thunderbird-debuginfo",
+            "rhel-8.4.0.z.eus::appstream:thunderbird-debugsource",
+            "rhel-8.4.0.z.eus:firefox",
+            "rhel-8.4.0.z.eus:firefox-debuginfo",
+            "rhel-8.4.0.z.eus:firefox-debugsource",
+            "rhel-8.4.0.z.eus:firefox.src",
+            "rhel-8.4.0.z.eus:thunderbird",
+            "rhel-8.4.0.z.eus:thunderbird-debuginfo",
+            "rhel-8.4.0.z.eus:thunderbird-debugsource",
+            "rhel-8.4.0.z.eus:thunderbird.src",
+            "rhel-8.6.0.z.aus::appstream:firefox-0:140.10.1-1.el8_6",
+            "rhel-8.6.0.z.aus::appstream:firefox-0:140.10.1-1.el8_6.src",
+            "rhel-8.6.0.z.aus::appstream:firefox-debuginfo",
+            "rhel-8.6.0.z.aus::appstream:firefox-debugsource",
+            "rhel-8.6.0.z.aus::appstream:thunderbird-0:140.10.1-1.el8_6",
+            "rhel-8.6.0.z.aus::appstream:thunderbird-0:140.10.1-1.el8_6.src",
+            "rhel-8.6.0.z.aus::appstream:thunderbird-debuginfo",
+            "rhel-8.6.0.z.aus::appstream:thunderbird-debugsource",
+            "rhel-8.6.0.z.aus:firefox",
+            "rhel-8.6.0.z.aus:firefox-debuginfo",
+            "rhel-8.6.0.z.aus:firefox-debugsource",
+            "rhel-8.6.0.z.aus:firefox.src",
+            "rhel-8.6.0.z.aus:thunderbird",
+            "rhel-8.6.0.z.aus:thunderbird-debuginfo",
+            "rhel-8.6.0.z.aus:thunderbird-debugsource",
+            "rhel-8.6.0.z.aus:thunderbird.src",
+            "rhel-8.6.0.z.eus::appstream:firefox-0:140.10.1-1.el8_6",
+            "rhel-8.6.0.z.eus::appstream:firefox-0:140.10.1-1.el8_6.src",
+            "rhel-8.6.0.z.eus::appstream:firefox-debuginfo",
+            "rhel-8.6.0.z.eus::appstream:firefox-debugsource",
+            "rhel-8.6.0.z.eus::appstream:thunderbird-0:140.10.1-1.el8_6",
+            "rhel-8.6.0.z.eus::appstream:thunderbird-0:140.10.1-1.el8_6.src",
+            "rhel-8.6.0.z.eus::appstream:thunderbird-debuginfo",
+            "rhel-8.6.0.z.eus::appstream:thunderbird-debugsource",
+            "rhel-8.8.0.z.e4s::appstream:firefox-0:140.10.1-1.el8_8",
+            "rhel-8.8.0.z.e4s::appstream:firefox-0:140.10.1-1.el8_8.src",
+            "rhel-8.8.0.z.e4s::appstream:firefox-debuginfo",
+            "rhel-8.8.0.z.e4s::appstream:firefox-debugsource",
+            "rhel-8.8.0.z.e4s::appstream:thunderbird-0:140.10.1-1.el8_8",
+            "rhel-8.8.0.z.e4s::appstream:thunderbird-0:140.10.1-1.el8_8.src",
+            "rhel-8.8.0.z.e4s::appstream:thunderbird-debuginfo",
+            "rhel-8.8.0.z.e4s::appstream:thunderbird-debugsource",
+            "rhel-8.8.0.z.eus:firefox",
+            "rhel-8.8.0.z.eus:firefox-debuginfo",
+            "rhel-8.8.0.z.eus:firefox-debugsource",
+            "rhel-8.8.0.z.eus:firefox.src",
+            "rhel-8.8.0.z.eus:thunderbird",
+            "rhel-8.8.0.z.eus:thunderbird-debuginfo",
+            "rhel-8.8.0.z.eus:thunderbird-debugsource",
+            "rhel-8.8.0.z.eus:thunderbird.src",
+            "rhel-8.8.0.z.tus::appstream:firefox-0:140.10.1-1.el8_8",
+            "rhel-8.8.0.z.tus::appstream:firefox-0:140.10.1-1.el8_8.src",
+            "rhel-8.8.0.z.tus::appstream:firefox-debuginfo",
+            "rhel-8.8.0.z.tus::appstream:firefox-debugsource",
+            "rhel-8.8.0.z.tus::appstream:thunderbird-0:140.10.1-1.el8_8",
+            "rhel-8.8.0.z.tus::appstream:thunderbird-0:140.10.1-1.el8_8.src",
+            "rhel-8.8.0.z.tus::appstream:thunderbird-debuginfo",
+            "rhel-8.8.0.z.tus::appstream:thunderbird-debugsource",
+            "rhel-9.0.0.z.e4s::appstream:firefox-0:140.10.1-1.el9_0",
+            "rhel-9.0.0.z.e4s::appstream:firefox-0:140.10.1-1.el9_0.src",
+            "rhel-9.0.0.z.e4s::appstream:firefox-debuginfo",
+            "rhel-9.0.0.z.e4s::appstream:firefox-debugsource",
+            "rhel-9.0.0.z.eus:firefox",
+            "rhel-9.0.0.z.eus:firefox-x11",
+            "rhel-9.0.0.z.eus:firefox.src",
+            "rhel-9.0.0.z.eus:thunderbird",
+            "rhel-9.0.0.z.eus:thunderbird.src",
+            "rhel-9.2.0.z.e4s::appstream:firefox-0:140.10.1-1.el9_2",
+            "rhel-9.2.0.z.e4s::appstream:firefox-0:140.10.1-1.el9_2.src",
+            "rhel-9.2.0.z.e4s::appstream:firefox-debuginfo",
+            "rhel-9.2.0.z.e4s::appstream:firefox-debugsource",
+            "rhel-9.2.0.z.e4s::appstream:firefox-x11-0:140.10.1-1.el9_2",
+            "rhel-9.2.0.z.e4s::appstream:thunderbird-0:140.10.1-1.el9_2",
+            "rhel-9.2.0.z.e4s::appstream:thunderbird-0:140.10.1-1.el9_2.src",
+            "rhel-9.2.0.z.e4s::appstream:thunderbird-debuginfo",
+            "rhel-9.2.0.z.e4s::appstream:thunderbird-debugsource",
+            "rhel-9.2.0.z.eus:firefox",
+            "rhel-9.2.0.z.eus:firefox-debuginfo",
+            "rhel-9.2.0.z.eus:firefox-debugsource",
+            "rhel-9.2.0.z.eus:firefox-x11",
+            "rhel-9.2.0.z.eus:firefox.src",
+            "rhel-9.2.0.z.eus:thunderbird",
+            "rhel-9.2.0.z.eus:thunderbird-debuginfo",
+            "rhel-9.2.0.z.eus:thunderbird-debugsource",
+            "rhel-9.2.0.z.eus:thunderbird.src",
+            "rhel-9.4.0.e4s::appstream:firefox-0:140.10.1-1.el9_4",
+            "rhel-9.4.0.e4s::appstream:firefox-0:140.10.1-1.el9_4.src",
+            "rhel-9.4.0.e4s::appstream:firefox-debuginfo",
+            "rhel-9.4.0.e4s::appstream:firefox-debugsource",
+            "rhel-9.4.0.e4s::appstream:firefox-x11-0:140.10.1-1.el9_4",
+            "rhel-9.4.0.e4s::appstream:thunderbird-0:140.10.1-1.el9_4",
+            "rhel-9.4.0.e4s::appstream:thunderbird-0:140.10.1-1.el9_4.src",
+            "rhel-9.4.0.e4s::appstream:thunderbird-debuginfo",
+            "rhel-9.4.0.e4s::appstream:thunderbird-debugsource",
+            "rhel-9.4.z.eus:firefox",
+            "rhel-9.4.z.eus:firefox-debuginfo",
+            "rhel-9.4.z.eus:firefox-debugsource",
+            "rhel-9.4.z.eus:firefox-x11",
+            "rhel-9.4.z.eus:firefox.src",
+            "rhel-9.4.z.eus:thunderbird",
+            "rhel-9.4.z.eus:thunderbird-debuginfo",
+            "rhel-9.4.z.eus:thunderbird-debugsource",
+            "rhel-9.4.z.eus:thunderbird.src",
+            "rhel-9.6.z.eus::appstream:firefox-0:140.10.1-1.el9_6",
+            "rhel-9.6.z.eus::appstream:firefox-0:140.10.1-1.el9_6.src",
+            "rhel-9.6.z.eus::appstream:firefox-debuginfo",
+            "rhel-9.6.z.eus::appstream:firefox-debugsource",
+            "rhel-9.6.z.eus::appstream:firefox-x11-0:140.10.1-1.el9_6",
+            "rhel-9.6.z.eus::appstream:thunderbird-0:140.10.1-1.el9_6",
+            "rhel-9.6.z.eus::appstream:thunderbird-0:140.10.1-1.el9_6.src",
+            "rhel-9.6.z.eus::appstream:thunderbird-debuginfo",
+            "rhel-9.6.z.eus::appstream:thunderbird-debugsource",
+            "rhel-9.6.z.eus:firefox",
+            "rhel-9.6.z.eus:firefox-debuginfo",
+            "rhel-9.6.z.eus:firefox-debugsource",
+            "rhel-9.6.z.eus:firefox-x11",
+            "rhel-9.6.z.eus:firefox.src",
+            "rhel-9.6.z.eus:thunderbird",
+            "rhel-9.6.z.eus:thunderbird-debuginfo",
+            "rhel-9.6.z.eus:thunderbird-debugsource",
+            "rhel-9.6.z.eus:thunderbird.src",
+            "rhel-9.7.z:firefox",
+            "rhel-9.7.z:firefox-x11",
+            "rhel-9.7.z:firefox.src",
+            "rhel-9.7.z:thunderbird",
+            "rhel-9.7.z:thunderbird.src",
+            "rhel-9.8.z.eus::appstream:firefox-0:140.10.1-1.el9_8",
+            "rhel-9.8.z.eus::appstream:firefox-0:140.10.1-1.el9_8.src",
+            "rhel-9.8.z.eus::appstream:firefox-debuginfo",
+            "rhel-9.8.z.eus::appstream:firefox-debugsource",
+            "rhel-9.8.z.eus::appstream:firefox-x11-0:140.10.1-1.el9_8",
+            "rhel-9.8.z.eus::appstream:thunderbird-0:140.10.1-1.el9_8",
+            "rhel-9.8.z.eus::appstream:thunderbird-0:140.10.1-1.el9_8.src",
+            "rhel-9.8.z.eus::appstream:thunderbird-debuginfo",
+            "rhel-9.8.z.eus::appstream:thunderbird-debugsource",
+            "rhel-9.8.z.eus:firefox",
+            "rhel-9.8.z.eus:firefox-debuginfo",
+            "rhel-9.8.z.eus:firefox-debugsource",
+            "rhel-9.8.z.eus:firefox-x11",
+            "rhel-9.8.z.eus:firefox.src",
+            "rhel-9.8.z.eus:thunderbird",
+            "rhel-9.8.z.eus:thunderbird-debuginfo",
+            "rhel-9.8.z.eus:thunderbird-debugsource",
+            "rhel-9.8.z.eus:thunderbird.src",
+            "rhel-br-9.4.0.e4s::appstream:firefox-0:140.10.1-1.el9_4",
+            "rhel-br-9.4.0.e4s::appstream:firefox-0:140.10.1-1.el9_4.src",
+            "rhel-br-9.4.0.e4s::appstream:firefox-debuginfo",
+            "rhel-br-9.4.0.e4s::appstream:firefox-debugsource",
+            "rhel-br-9.4.0.e4s::appstream:firefox-x11-0:140.10.1-1.el9_4",
+            "rhel-br-9.4.0.e4s::appstream:thunderbird-0:140.10.1-1.el9_4",
+            "rhel-br-9.4.0.e4s::appstream:thunderbird-0:140.10.1-1.el9_4.src",
+            "rhel-br-9.4.0.e4s::appstream:thunderbird-debuginfo",
+            "rhel-br-9.4.0.e4s::appstream:thunderbird-debugsource"
+          ]
+        }
+      ],
+      "title": "Memory safety bugs fixed in Firefox ESR 140.10.1 and Firefox 150.0.1"
+    }
+  ]
+}


### PR DESCRIPTION
Updated rhel/vex/parser.go to bypass rpm module format errors. 

