### PR TITLE
vex: warn and skip unparseable entries in knownAffectedVulnerabilities

### DIFF
--- a/rhel/vex/parser.go
+++ b/rhel/vex/parser.go
@@ -708,25 +708,34 @@ func (r *rope[E]) All() iter.Seq[*E] {
 // KnownAffectedVulnerabilities processes the "known_affected" array of products
 // in the VEX object.
 func (c *creator) knownAffectedVulnerabilities(ctx context.Context, v *csaf.Vulnerability, init vulnHook) ([]*claircore.Vulnerability, error) {
+	log := slog.With("link", c.docLink)
 	var backing rope[claircore.Vulnerability]
 	for st, err := range c.Status(ctx, v, csaf.ProductStatusKnownAffected) {
 		if err != nil {
 			return nil, err
 		}
 
-		// This loop never skips returned [status] values, so we can always just
-		// append a new [claircore.Vulnerability].
-		vuln := backing.New()
-
-		if err := init(ctx, vuln); err != nil {
-			return nil, err
-		}
 		pkgName, err := st.PackageName()
 		if err != nil {
-			return nil, err
+			log.WarnContext(ctx, "bad purl", "reason", err, "purl", st.PURL, "missing", "PackageName")
+			continue
 		}
 		modName, err := st.Module()
 		if err != nil {
+			log.WarnContext(ctx, "bad purl", "reason", err, "purl", st.PURL, "missing", "ModuleName")
+			continue
+		}
+		var sev string
+		if sc := st.Score; sc != nil {
+			sev, err = cvssVectorFromScore(sc)
+			if err != nil {
+				log.WarnContext(ctx, "bad score", "reason", err, "found", true)
+				continue
+			}
+		}
+
+		vuln := backing.New()
+		if err := init(ctx, vuln); err != nil {
 			return nil, err
 		}
 		vuln.Package = &claircore.Package{
@@ -734,12 +743,7 @@ func (c *creator) knownAffectedVulnerabilities(ctx context.Context, v *csaf.Vuln
 			Kind:   types.SourcePackage, // Always source?
 			Module: modName,
 		}
-		if sc := st.Score; sc != nil {
-			vuln.Severity, err = cvssVectorFromScore(sc)
-			if err != nil {
-				return nil, fmt.Errorf("could not parse CVSS score: %w, file: %s", err, c.docLink)
-			}
-		}
+		vuln.Severity = sev
 		if t := st.Threat; t != nil {
 			vuln.NormalizedSeverity = common.NormalizeSeverity(t.Details)
 		}

--- a/rhel/vex/parser_test.go
+++ b/rhel/vex/parser_test.go
@@ -414,6 +414,12 @@ func TestParse(t *testing.T) {
 			expectedVulns:   269,
 			expectedDeleted: 0,
 		},
+		{
+			name:            "bad_rpmmod_in_known_affected",
+			filenames:       []string{"testdata/cve-2024-24786-bad-rpmmod.json"},
+			expectedVulns:   2,
+			expectedDeleted: 0,
+		},
 	}
 
 	u := &Updater{url: url, client: http.DefaultClient}
@@ -686,4 +692,3 @@ func TestExtractPackageName(t *testing.T) {
 		})
 	}
 }
-

--- a/rhel/vex/testdata/cve-2024-24786-bad-rpmmod.json
+++ b/rhel/vex/testdata/cve-2024-24786-bad-rpmmod.json
@@ -1,0 +1,216 @@
+{
+    "document": {
+        "aggregate_severity": {
+            "namespace": "https://access.redhat.com/security/updates/classification/",
+            "text": "Moderate"
+        },
+        "category": "csaf_vex",
+        "csaf_version": "2.0",
+        "distribution": {
+            "text": "Copyright © Red Hat, Inc. All rights reserved.",
+            "tlp": {
+                "label": "WHITE",
+                "url": "https://www.first.org/tlp/"
+            }
+        },
+        "lang": "en",
+        "notes": [
+            {
+                "category": "legal_disclaimer",
+                "text": "This content is licensed under the Creative Commons Attribution 4.0 International License.",
+                "title": "Terms of Use"
+            }
+        ],
+        "publisher": {
+            "category": "vendor",
+            "contact_details": "https://access.redhat.com/security/team/contact/",
+            "issuing_authority": "Red Hat Product Security.",
+            "name": "Red Hat Product Security",
+            "namespace": "https://www.redhat.com"
+        },
+        "references": [
+            {
+                "category": "self",
+                "summary": "Canonical URL",
+                "url": "https://security.access.redhat.com/data/csaf/v2/vex/2024/cve-2024-24786.json"
+            }
+        ],
+        "title": "Test advisory with bad rpmmod qualifier",
+        "tracking": {
+            "current_release_date": "2025-08-13T15:14:45+00:00",
+            "generator": {
+                "date": "2025-08-13T15:14:45+00:00",
+                "engine": {
+                    "name": "Red Hat SDEngine",
+                    "version": "4.6.6"
+                }
+            },
+            "id": "CVE-2024-24786",
+            "initial_release_date": "2024-03-05T00:00:00+00:00",
+            "revision_history": [
+                {
+                    "date": "2024-03-05T00:00:00+00:00",
+                    "number": "1",
+                    "summary": "Initial version"
+                }
+            ],
+            "status": "final",
+            "version": "1"
+        }
+    },
+    "product_tree": {
+        "branches": [
+            {
+                "category": "product_version",
+                "name": "cri-tools-0:1.29.0-3.1.el9.aarch64",
+                "product": {
+                    "name": "cri-tools-0:1.29.0-3.1.el9.aarch64",
+                    "product_id": "cri-tools-0:1.29.0-3.1.el9.aarch64",
+                    "product_identification_helper": {
+                        "purl": "pkg:rpm/redhat/cri-tools@1.29.0-3.1.el9?arch=aarch64"
+                    }
+                }
+            },
+            {
+                "category": "product_version",
+                "name": "good-pkg-0:1.0.0-1.el10.x86_64",
+                "product": {
+                    "name": "good-pkg-0:1.0.0-1.el10.x86_64",
+                    "product_id": "good-pkg-0:1.0.0-1.el10.x86_64",
+                    "product_identification_helper": {
+                        "purl": "pkg:rpm/redhat/good-pkg@1.0.0-1.el10?arch=x86_64"
+                    }
+                }
+            },
+            {
+                "category": "product_version",
+                "name": "firefox-flatpak-0:128.0-1.el10.src",
+                "product": {
+                    "name": "firefox-flatpak-0:128.0-1.el10.src",
+                    "product_id": "firefox-flatpak-0:128.0-1.el10.src",
+                    "product_identification_helper": {
+                        "purl": "pkg:rpm/redhat/firefox-flatpak@128.0-1.el10?arch=src&rpmmod=rhel10"
+                    }
+                }
+            },
+            {
+                "category": "product_name",
+                "name": "Red Hat Enterprise Linux 10",
+                "product": {
+                    "name": "Red Hat Enterprise Linux 10",
+                    "product_id": "AppStream-10",
+                    "product_identification_helper": {
+                        "cpe": "cpe:/a:redhat:enterprise_linux:10::appstream"
+                    }
+                }
+            }
+        ],
+        "relationships": [
+            {
+                "category": "default_component_of",
+                "full_product_name": {
+                    "name": "cri-tools as a component of RHEL 10 AppStream",
+                    "product_id": "AppStream-10:cri-tools-0:1.29.0-3.1.el9.aarch64"
+                },
+                "product_reference": "cri-tools-0:1.29.0-3.1.el9.aarch64",
+                "relates_to_product_reference": "AppStream-10"
+            },
+            {
+                "category": "default_component_of",
+                "full_product_name": {
+                    "name": "good-pkg as a component of RHEL 10 AppStream",
+                    "product_id": "AppStream-10:good-pkg-0:1.0.0-1.el10.x86_64"
+                },
+                "product_reference": "good-pkg-0:1.0.0-1.el10.x86_64",
+                "relates_to_product_reference": "AppStream-10"
+            },
+            {
+                "category": "default_component_of",
+                "full_product_name": {
+                    "name": "firefox-flatpak as a component of RHEL 10 AppStream",
+                    "product_id": "AppStream-10:firefox-flatpak-0:128.0-1.el10.src"
+                },
+                "product_reference": "firefox-flatpak-0:128.0-1.el10.src",
+                "relates_to_product_reference": "AppStream-10"
+            }
+        ]
+    },
+    "vulnerabilities": [
+        {
+            "cve": "CVE-2024-24786",
+            "product_status": {
+                "fixed": [
+                    "AppStream-10:cri-tools-0:1.29.0-3.1.el9.aarch64"
+                ],
+                "known_affected": [
+                    "AppStream-10:good-pkg-0:1.0.0-1.el10.x86_64",
+                    "AppStream-10:firefox-flatpak-0:128.0-1.el10.src"
+                ]
+            },
+            "scores": [
+                {
+                    "cvss_v3": {
+                        "attackComplexity": "HIGH",
+                        "attackVector": "NETWORK",
+                        "availabilityImpact": "HIGH",
+                        "baseScore": 5.9,
+                        "baseSeverity": "MEDIUM",
+                        "confidentialityImpact": "NONE",
+                        "integrityImpact": "NONE",
+                        "privilegesRequired": "NONE",
+                        "scope": "UNCHANGED",
+                        "userInteraction": "NONE",
+                        "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                        "version": "3.1"
+                    },
+                    "products": [
+                        "AppStream-10:cri-tools-0:1.29.0-3.1.el9.aarch64",
+                        "AppStream-10:good-pkg-0:1.0.0-1.el10.x86_64",
+                        "AppStream-10:firefox-flatpak-0:128.0-1.el10.src"
+                    ]
+                }
+            ],
+            "notes": [
+                {
+                    "category": "description",
+                    "text": "Test vulnerability description.",
+                    "title": "Vulnerability description"
+                }
+            ],
+            "release_date": "2024-03-05T00:00:00+00:00",
+            "threats": [
+                {
+                    "category": "impact",
+                    "details": "Moderate",
+                    "product_ids": [
+                        "AppStream-10:cri-tools-0:1.29.0-3.1.el9.aarch64",
+                        "AppStream-10:good-pkg-0:1.0.0-1.el10.x86_64",
+                        "AppStream-10:firefox-flatpak-0:128.0-1.el10.src"
+                    ]
+                }
+            ],
+            "remediations": [
+                {
+                    "category": "vendor_fix",
+                    "details": "Update packages.",
+                    "product_ids": [
+                        "AppStream-10:cri-tools-0:1.29.0-3.1.el9.aarch64"
+                    ],
+                    "url": "https://access.redhat.com/errata/RHSA-2024:0000"
+                }
+            ],
+            "references": [
+                {
+                    "category": "self",
+                    "summary": "Canonical URL",
+                    "url": "https://access.redhat.com/security/cve/CVE-2024-24786"
+                },
+                {
+                    "category": "external",
+                    "summary": "RHBZ#2268046",
+                    "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2268046"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
`knownAffectedVulnerabilities` hard-fails on `PackageName()`, `Module()`, and `cvssVectorFromScore()` errors, while its sibling functions `fixedVulnerabilities` and `knownNotAffectedVulnerabilities` warn-and-skip for the same operations. This was introduced in f9fc989e during the iterator migration.

This change moves validation before allocation so `continue` doesn't leave orphaned entries in the backing rope, and aligns the error handling with the other two functions.