### PR TITLE
rhel-vex: don't error on bad module

### DIFF
--- a/rhel/vex/parser.go
+++ b/rhel/vex/parser.go
@@ -708,14 +708,13 @@ func (r *rope[E]) All() iter.Seq[*E] {
 // KnownAffectedVulnerabilities processes the "known_affected" array of products
 // in the VEX object.
 func (c *creator) knownAffectedVulnerabilities(ctx context.Context, v *csaf.Vulnerability, init vulnHook) ([]*claircore.Vulnerability, error) {
+	log := slog.With("link", c.docLink)
 	var backing rope[claircore.Vulnerability]
 	for st, err := range c.Status(ctx, v, csaf.ProductStatusKnownAffected) {
 		if err != nil {
 			return nil, err
 		}
 
-		// This loop never skips returned [status] values, so we can always just
-		// append a new [claircore.Vulnerability].
 		vuln := backing.New()
 
 		if err := init(ctx, vuln); err != nil {
@@ -727,7 +726,9 @@ func (c *creator) knownAffectedVulnerabilities(ctx context.Context, v *csaf.Vuln
 		}
 		modName, err := st.Module()
 		if err != nil {
-			return nil, err
+			log.WarnContext(ctx, "bad purl", "reason", err, "purl", st.PURL, "missing", "ModuleName")
+			backing.Drop()
+			continue
 		}
 		vuln.Package = &claircore.Package{
 			Name:   pkgName,

--- a/rhel/vex/parser_test.go
+++ b/rhel/vex/parser_test.go
@@ -73,6 +73,17 @@ func TestComponentPURLToModuleName(t *testing.T) {
 			},
 			err: true,
 		},
+		{
+			// rpmmod=rhel10 has no stream component — seen in CVE-2026-7323.
+			name: "rpmmod missing stream",
+			in: packageurl.PackageURL{
+				Type:       packageurl.TypeRPM,
+				Namespace:  "redhat",
+				Name:       "firefox-flatpak",
+				Qualifiers: packageurl.QualifiersFromMap(map[string]string{"arch": "src", "rpmmod": "rhel10"}),
+			},
+			err: true,
+		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -412,6 +423,15 @@ func TestParse(t *testing.T) {
 			name:            "cve-2023-38545",
 			filenames:       []string{"testdata/cve-2023-38545.json"},
 			expectedVulns:   269,
+			expectedDeleted: 0,
+		},
+		{
+			// Products with a malformed rpmmod qualifier (e.g. "rhel10" with no
+			// stream component) should be skipped with a warning, not cause the
+			// parser to fail.
+			name:            "bad-rpmmod-is-skipped",
+			filenames:       []string{"testdata/cve-2026-7323-bad-rpmmod.json"},
+			expectedVulns:   1,
 			expectedDeleted: 0,
 		},
 	}

--- a/rhel/vex/testdata/cve-2026-7323-bad-rpmmod.json
+++ b/rhel/vex/testdata/cve-2026-7323-bad-rpmmod.json
@@ -1,0 +1,96 @@
+{
+    "document": {
+        "references": [
+            {
+                "category": "self",
+                "summary": "Canonical URL",
+                "url": "https://security.access.redhat.com/data/csaf/v2/vex-feed/2026/cve-2026-7323.json"
+            }
+        ],
+        "tracking": {
+            "id": "CVE-2026-7323",
+            "status": "final"
+        }
+    },
+    "product_tree": {
+        "branches": [
+            {
+                "branches": [
+                    {
+                        "branches": [
+                            {
+                                "category": "product_name",
+                                "name": "Red Hat Enterprise Linux 10",
+                                "product": {
+                                    "name": "Red Hat Enterprise Linux 10",
+                                    "product_id": "red_hat_enterprise_linux_10",
+                                    "product_identification_helper": {
+                                        "cpe": "cpe:/o:redhat:enterprise_linux:10"
+                                    }
+                                }
+                            }
+                        ],
+                        "category": "product_family",
+                        "name": "Red Hat Enterprise Linux 10"
+                    }
+                ],
+                "category": "vendor",
+                "name": "Red Hat"
+            },
+            {
+                "category": "product_version",
+                "name": "nss-0:3.101.0-1.el10",
+                "product": {
+                    "name": "nss-0:3.101.0-1.el10",
+                    "product_id": "nss-0:3.101.0-1.el10",
+                    "product_identification_helper": {
+                        "purl": "pkg:rpm/redhat/nss@3.101.0-1.el10?arch=src"
+                    }
+                }
+            },
+            {
+                "category": "product_version",
+                "name": "firefox-flatpak",
+                "product": {
+                    "name": "firefox-flatpak",
+                    "product_id": "firefox-flatpak",
+                    "product_identification_helper": {
+                        "purl": "pkg:rpm/redhat/firefox-flatpak?arch=src&rpmmod=rhel10"
+                    }
+                }
+            }
+        ],
+        "relationships": [
+            {
+                "category": "default_component_of",
+                "full_product_name": {
+                    "name": "nss-0:3.101.0-1.el10 as a component of Red Hat Enterprise Linux 10",
+                    "product_id": "red_hat_enterprise_linux_10:nss-0:3.101.0-1.el10"
+                },
+                "product_reference": "nss-0:3.101.0-1.el10",
+                "relates_to_product_reference": "red_hat_enterprise_linux_10"
+            },
+            {
+                "category": "default_component_of",
+                "full_product_name": {
+                    "name": "firefox-flatpak as a component of Red Hat Enterprise Linux 10",
+                    "product_id": "red_hat_enterprise_linux_10:firefox-flatpak"
+                },
+                "product_reference": "firefox-flatpak",
+                "relates_to_product_reference": "red_hat_enterprise_linux_10"
+            }
+        ]
+    },
+    "vulnerabilities": [
+        {
+            "cve": "CVE-2026-7323",
+            "product_status": {
+                "known_affected": [
+                    "red_hat_enterprise_linux_10:nss-0:3.101.0-1.el10",
+                    "red_hat_enterprise_linux_10:firefox-flatpak"
+                ]
+            },
+            "release_date": "2026-07-01T00:00:00+00:00"
+        }
+    ]
+}


### PR DESCRIPTION
This change allows the VEX parser to continue processing after hitting PURL with a badly formatted rpmmod.