### PR TITLE
apk: guard against short lines in installed database

### DIFF
--- a/apk/scanner.go
+++ b/apk/scanner.go
@@ -90,6 +90,11 @@ func (*Scanner) Scan(ctx context.Context, layer *claircore.Layer) ([]*claircore.
 		}
 		r := bytes.NewBuffer(entry)
 		for line, err := r.ReadBytes('\n'); err == nil; line, err = r.ReadBytes('\n') {
+			// Every well-formed line is a one byte key, a ":", then the value.
+			// Anything shorter can't be one, so skip it.
+			if len(line) < 2 {
+				continue
+			}
 			l := string(bytes.TrimSpace(line[2:]))
 			switch line[0] {
 			case 'P':

--- a/apk/scanner_test.go
+++ b/apk/scanner_test.go
@@ -1,6 +1,8 @@
 package apk
 
 import (
+	"archive/tar"
+	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -157,5 +159,76 @@ func TestScan(t *testing.T) {
 	t.Logf("found %d packages", len(got))
 	if !cmp.Equal(want, got) {
 		t.Fatal(cmp.Diff(want, got))
+	}
+}
+
+// TestBlankLine checks that an "installed" database with a stray blank line in
+// a record doesn't crash the scanner.
+func TestBlankLine(t *testing.T) {
+	t.Parallel()
+	mod := test.Modtime(t, "scanner_test.go")
+	layerfile := test.GenerateFixture(t, `blankline.layer`, mod, blankLineSetup)
+	ctx := test.Logging(t)
+	var l claircore.Layer
+	var s Scanner
+
+	f, err := os.Open(layerfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if err := l.Init(ctx, &test.AnyDescription, f); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := l.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+
+	got, err := s.Scan(ctx, &l)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []*claircore.Package{
+		{
+			Name:      "foo",
+			Version:   "1.0",
+			Arch:      "x86_64",
+			Kind:      types.BinaryPackage,
+			PackageDB: "lib/apk/db/installed",
+		},
+		{
+			Name:      "bar",
+			Version:   "2.0",
+			Arch:      "x86_64",
+			Kind:      types.BinaryPackage,
+			PackageDB: "lib/apk/db/installed",
+		},
+	}
+	if !cmp.Equal(want, got) {
+		t.Error(cmp.Diff(want, got))
+	}
+}
+
+// BlankLineSetup writes a layer with an "installed" database that has an extra
+// blank line between the two records.
+func blankLineSetup(t testing.TB, f *os.File) {
+	const installed = "P:foo\nV:1.0\nA:x86_64\nF:usr\n\n\nP:bar\nV:2.0\nA:x86_64\nF:usr\n"
+	w := tar.NewWriter(f)
+	defer func() {
+		if err := w.Close(); err != nil {
+			t.Error(err)
+		}
+	}()
+	if err := w.WriteHeader(&tar.Header{
+		Name: "lib/apk/db/installed",
+		Size: int64(len(installed)),
+		Mode: 0o644,
+	}); err != nil {
+		t.Error(err)
+	}
+	if _, err := w.Write([]byte(installed)); err != nil {
+		t.Error(err)
 	}
 }


### PR DESCRIPTION
I do supply-chain security research, mostly on scanners and indexers.

The apk record loop in `apk/scanner.go` slices every line as `line[2:]`. A bare newline is a 1 byte line, so that's `slice bounds out of range [2:1]` and the scan panics.

You get one from a stray blank line inside a record. Splitting on `"\n\n"` leaves the extra newline sitting at the front of the next record, and its first `ReadBytes` hands back just `"\n"`. Layer contents come from whatever image is being indexed, so a malformed or crafted `lib/apk/db/installed` is enough to crash the indexer.

Fix is a length check before the slice. dpkg doesn't have this problem because textproto tolerates the junk for it, which the comment above the loop already explains apk can't use.

Test is `TestBlankLine`, a tarred-up installed database with an extra blank line, run through `Scan` the normal way. Panics on main, passes with the fix, and no network needed. `go test ./apk/` and `go test -race ./apk/` are clean.
