### PR TITLE
osv: exclude advisories from non applicable ecosystems

### DIFF
--- a/datastore/postgres/migrations/matcher/20-force-osv-ecosystem-filter.sql
+++ b/datastore/postgres/migrations/matcher/20-force-osv-ecosystem-filter.sql
@@ -2,13 +2,13 @@
 -- affected entries to the dump's ecosystem. Multi-ecosystem advisories
 -- previously produced cross-ecosystem vulnerability rows (e.g. npm ranges
 -- under osv/pypi).
-DELETE FROM update_operation
+--
+-- Clear fingerprints rather than deleting update_operations so matching keeps
+-- serving the existing (possibly imperfect) set until the next successful
+-- update, instead of a vulns → empty → vulns gap. Stale cross-ecosystem rows
+-- drop off once the new update_operation becomes latest; GC removes them later.
+UPDATE update_operation
+SET
+  fingerprint = ''
 WHERE
   updater LIKE 'osv/%';
-
-DELETE FROM vuln v1 USING vuln v2
-LEFT JOIN uo_vuln uvl ON v2.id = uvl.vuln
-WHERE
-  uvl.vuln IS NULL
-  AND v2.updater LIKE 'osv/%'
-  AND v1.id = v2.id;

--- a/datastore/postgres/migrations/matcher/20-force-osv-ecosystem-filter.sql
+++ b/datastore/postgres/migrations/matcher/20-force-osv-ecosystem-filter.sql
@@ -1,0 +1,14 @@
+-- Force per-ecosystem OSV updaters to re-fetch and re-parse after filtering
+-- affected entries to the dump's ecosystem. Multi-ecosystem advisories
+-- previously produced cross-ecosystem vulnerability rows (e.g. npm ranges
+-- under osv/pypi).
+DELETE FROM update_operation
+WHERE
+  updater LIKE 'osv/%';
+
+DELETE FROM vuln v1 USING vuln v2
+LEFT JOIN uo_vuln uvl ON v2.id = uvl.vuln
+WHERE
+  uvl.vuln IS NULL
+  AND v2.updater LIKE 'osv/%'
+  AND v1.id = v2.id;

--- a/updater/osv/osv.go
+++ b/updater/osv/osv.go
@@ -145,11 +145,7 @@ func (f *Factory) UpdaterSet(ctx context.Context) (s driver.UpdaterSet, err erro
 		scr := bufio.NewScanner(res.Body)
 		for scr.Scan() {
 			k := scr.Text()
-			e := strings.ToLower(k)
-			// Currently, there's some versioned ecosystems. This branch removes the versioning.
-			if idx := strings.Index(e, ":"); idx != -1 {
-				e = e[:idx]
-			}
+			e := normalizeEcosystem(k)
 			// Check for duplicates, removing the version will create some.
 			if _, ok := seen[e]; ok {
 				continue
@@ -521,6 +517,23 @@ const (
 	ecosystemRubyGems = `RubyGems`
 )
 
+// normalizeEcosystem lowercases an OSV ecosystem name and strips any colon
+// suffix (e.g. "Debian:11" → "debian", "Alpine:v3.17" → "alpine").
+//
+// This matches how OSV derives per-ecosystem dump directory names from
+// package.ecosystem values: dumps are keyed by the ecosystem prefix without
+// the ":.*" suffix, and the canonical list is ecosystems.txt. See:
+//   - https://google.github.io/osv.dev/data/#ecosystem-naming
+//   - https://osv-vulnerabilities.storage.googleapis.com/ecosystems.txt
+//   - https://ossf.github.io/osv-schema/#affectedpackage-field
+func normalizeEcosystem(e string) string {
+	e = strings.ToLower(e)
+	if idx := strings.Index(e, ":"); idx != -1 {
+		e = e[:idx]
+	}
+	return e
+}
+
 func newECS(u string) ecs {
 	return ecs{
 		Updater:   u,
@@ -634,8 +647,16 @@ func (e *ecs) Insert(ctx context.Context, log *slog.Logger, skipped *stats, name
 		proto.Aliases = append(proto.Aliases, aka)
 	}
 	proto.Links = b.String()
+	dumpEcosystem := normalizeEcosystem(name)
 	for i := range a.Affected {
 		af := &a.Affected[i]
+		// Per-ecosystem dumps still embed full multi-ecosystem advisories.
+		// Compare normalized package.ecosystem to the dump name (see
+		// normalizeEcosystem) so foreign entries (e.g. npm in a PyPI dump)
+		// are not attached to the wrong repo.
+		if normalizeEcosystem(af.Package.Ecosystem) != dumpEcosystem {
+			continue
+		}
 		for _, r := range af.Ranges {
 			vers := []*rangeVer{}
 			switch r.Type {

--- a/updater/osv/osv_test.go
+++ b/updater/osv/osv_test.go
@@ -159,11 +159,13 @@ var test1Alias = claircore.Alias{Space: unique.Make(`TEST`), Name: `1`}
 
 var insertTestCases = []struct {
 	name          string
+	dump          string
 	ad            *advisory
 	expectedVulns []claircore.Vulnerability
 }{
 	{
 		name: "normal",
+		dump: "go",
 		ad: &advisory{
 			ID: "TEST-1",
 			Affected: []affected{
@@ -203,6 +205,7 @@ var insertTestCases = []struct {
 	},
 	{
 		name: "unfixed",
+		dump: "go",
 		ad: &advisory{
 			ID: "TEST-1",
 			Affected: []affected{
@@ -242,6 +245,7 @@ var insertTestCases = []struct {
 	},
 	{
 		name: "two_affected",
+		dump: "go",
 		ad: &advisory{
 			ID: "TEST-1",
 			Affected: []affected{
@@ -310,6 +314,7 @@ var insertTestCases = []struct {
 	},
 	{
 		name: "three_fixes",
+		dump: "go",
 		ad: &advisory{
 			ID: "TEST-1",
 			Affected: []affected{
@@ -381,6 +386,7 @@ var insertTestCases = []struct {
 	},
 	{
 		name: "two_fixes_one_unfixed",
+		dump: "go",
 		ad: &advisory{
 			ID: "TEST-1",
 			Affected: []affected{
@@ -453,6 +459,7 @@ var insertTestCases = []struct {
 	{
 		// In this situation we're just expecting the last one.
 		name: "two_consecutive_introduced_invalid",
+		dump: "go",
 		ad: &advisory{
 			ID: "TEST-1",
 			Affected: []affected{
@@ -495,6 +502,7 @@ var insertTestCases = []struct {
 	},
 	{
 		name: "ecosystem_multi",
+		dump: "pypi",
 		ad: &advisory{
 			ID: "TEST-1",
 			Affected: []affected{
@@ -544,6 +552,7 @@ var insertTestCases = []struct {
 	},
 	{
 		name: "ecosystem_unfixed",
+		dump: "pypi",
 		ad: &advisory{
 			ID:      "TEST-1",
 			Aliases: []string{"CVE-1970-0001"},
@@ -582,6 +591,7 @@ var insertTestCases = []struct {
 	},
 	{
 		name: "same package different ranges",
+		dump: "maven",
 		ad: &advisory{
 			ID: "TEST-1",
 			Affected: []affected{
@@ -634,6 +644,7 @@ var insertTestCases = []struct {
 	},
 	{
 		name: "npm_ecosystem_range_skipped",
+		dump: "npm",
 		ad: &advisory{
 			ID: "GHSA-test-npm-1",
 			Affected: []affected{
@@ -662,6 +673,7 @@ var insertTestCases = []struct {
 	},
 	{
 		name: "go_ecosystem_range_skipped",
+		dump: "go",
 		ad: &advisory{
 			ID: "GHSA-test-go-1",
 			Affected: []affected{
@@ -688,6 +700,65 @@ var insertTestCases = []struct {
 		},
 		expectedVulns: nil,
 	},
+	{
+		name: "skip_other_ecosystems",
+		dump: "pypi",
+		ad: &advisory{
+			ID: "GHSA-3644-q5cj-c5c7",
+			Affected: []affected{
+				{
+					Package: _package{
+						Ecosystem: "PyPI",
+						Name:      "langsmith",
+					},
+					Ranges: []_range{
+						{
+							Type: "ECOSYSTEM",
+							Events: []rangeEvent{
+								{
+									Introduced: "0",
+								},
+								{
+									Fixed: "0.8.0",
+								},
+							},
+						},
+					},
+				},
+				{
+					Package: _package{
+						Ecosystem: "npm",
+						Name:      "langsmith",
+					},
+					Ranges: []_range{
+						{
+							Type: "SEMVER",
+							Events: []rangeEvent{
+								{
+									Introduced: "0",
+								},
+								{
+									Fixed: "0.6.0",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		expectedVulns: []claircore.Vulnerability{
+			{
+				Name: "GHSA-3644-q5cj-c5c7",
+				Self: claircore.Alias{
+					Space: unique.Make(`GHSA`),
+					Name:  "3644-q5cj-c5c7",
+				},
+				Updater:        "test",
+				Range:          nil,
+				FixedInVersion: "fixed=0.8.0",
+			},
+		},
+	},
 }
 
 // cmpIgnore will ignore everything expect the Name, Updater, Range and FixedInVersion.
@@ -701,7 +772,7 @@ func TestInsert(t *testing.T) {
 			ecs := newECS("test")
 
 			log := slog.Default()
-			err := ecs.Insert(ctx, log, nil, "", tt.ad)
+			err := ecs.Insert(ctx, log, nil, tt.dump, tt.ad)
 			if err != nil {
 				t.Error("got error Inserting advisory", err)
 			}
@@ -859,7 +930,7 @@ func TestSeverityParsing(t *testing.T) {
 			ecs := newECS("test")
 
 			log := slog.Default()
-			err := ecs.Insert(ctx, log, nil, "", tt.a)
+			err := ecs.Insert(ctx, log, nil, "go", tt.a)
 			if err != nil {
 				t.Error("got error Inserting advisory", err)
 			}
@@ -966,7 +1037,7 @@ func TestInsertLinksAliases(t *testing.T) {
 			log := slog.Default()
 			e := newECS("osv")
 			var st stats
-			if err := (&e).Insert(ctx, log, &st, "pkg", &tt.adv); err != nil {
+			if err := (&e).Insert(ctx, log, &st, "go", &tt.adv); err != nil {
 				t.Fatalf("Insert() error: %v", err)
 			}
 			if len(e.Vulnerability) == 0 {


### PR DESCRIPTION
OSV will include advisories in files that cover more ecosystems than the one requested. This could lead to incorrect parsing logic being used to parse advisories resulting in false-positives. This patch avoids parsing advisories that don't match the requested ecosystem.