### PR TITLE
suse: backport OVAL source URL update to stable-1.5.44

### DIFF
--- a/suse/factory.go
+++ b/suse/factory.go
@@ -19,7 +19,7 @@ import (
 )
 
 //doc:url updater
-const base = `https://support.novell.com/security/oval/`
+const base = `https://ftp.suse.com/pub/projects/security/oval/`
 
 var (
 	reELFile = regexp.MustCompile(`suse.linux.enterprise.server.([1-9][1-9]).xml.gz`)

--- a/suse/factory_test.go
+++ b/suse/factory_test.go
@@ -20,6 +20,9 @@ func TestFactory(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if len(us.Updaters()) == 0 {
+		t.Error("expected at least one updater")
+	}
 	for _, u := range us.Updaters() {
 		t.Log(u.Name())
 	}


### PR DESCRIPTION
Backport of #1600 to `stable-1.5.44` for the ACS 4.9.x v2 vulnerability bundle stream.

Applies cleanly, no adaptation needed.

Context: [ROX-35866](https://redhat.atlassian.net/browse/ROX-35866)
