### PR TITLE
ovalutil: guard a test element with no object reference

### DIFF
--- a/pkg/ovalutil/dpkg.go
+++ b/pkg/ovalutil/dpkg.go
@@ -64,6 +64,11 @@ func DpkgDefsToVulns(ctx context.Context, root *oval.Root, protoVulns ProtoVulns
 			//
 			// thus we *should* only need to care about a single dpkginfo_object and optionally a state object providing the package's fixed-in version.
 
+			if len(objRefs) == 0 {
+				stats.Obj++
+				continue
+			}
+
 			objRef := objRefs[0].ObjectRef
 			object, err := dpkgObjectLookup(root, objRef)
 			switch {

--- a/pkg/ovalutil/objectref_test.go
+++ b/pkg/ovalutil/objectref_test.go
@@ -1,0 +1,61 @@
+package ovalutil
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"testing"
+
+	"github.com/quay/claircore"
+	"github.com/quay/goval-parser/oval"
+)
+
+// A test element is only required to carry an object reference; a feed that
+// omits it still parses.
+const missingObjectRef = `<oval_definitions>
+  <definitions>
+    <definition id="oval:com.example:def:1" class="patch">
+      <metadata><title>example</title></metadata>
+      <criteria>
+        <criterion test_ref="oval:com.example:tst:1" comment="package is installed"/>
+      </criteria>
+    </definition>
+  </definitions>
+  <tests>
+    <%s id="oval:com.example:tst:1" check="at least one" comment="package is installed"/>
+  </tests>
+</oval_definitions>`
+
+func protoVuln(oval.Definition) ([]*claircore.Vulnerability, error) {
+	return []*claircore.Vulnerability{{Name: "example"}}, nil
+}
+
+func TestDefsToVulnsWithoutObjectRef(t *testing.T) {
+	for _, kind := range []string{"rpminfo_test", "dpkginfo_test"} {
+		t.Run(kind, func(t *testing.T) {
+			root := &oval.Root{}
+			if err := xml.Unmarshal([]byte(fmt.Sprintf(missingObjectRef, kind)), root); err != nil {
+				t.Fatalf("parsing the oval document: %v", err)
+			}
+
+			var (
+				vulns []*claircore.Vulnerability
+				err   error
+			)
+			switch kind {
+			case "rpminfo_test":
+				vulns, err = RPMDefsToVulns(context.Background(), root, protoVuln)
+			case "dpkginfo_test":
+				vulns, err = DpkgDefsToVulns(context.Background(), root, protoVuln, func(_ oval.Definition, name *oval.DpkgName) []string {
+					return []string{name.Body}
+				})
+			}
+			if err != nil {
+				t.Fatalf("got an error: %v", err)
+			}
+			if len(vulns) != 0 {
+				t.Errorf("expected the criterion to be skipped, got %d vulnerabilities", len(vulns))
+			}
+		})
+	}
+}

--- a/pkg/ovalutil/rpm.go
+++ b/pkg/ovalutil/rpm.go
@@ -89,6 +89,11 @@ func RPMDefsToVulns(ctx context.Context, root *oval.Root, protoVulns ProtoVulnsF
 			//
 			// thus we *should* only need to care about a single rpminfo_object and optionally a state object providing the package's fixed-in version.
 
+			if len(objRefs) == 0 {
+				slog.DebugContext(ctx, "test has no object reference, moving to next criterion", "test_ref", criterion.TestRef)
+				continue
+			}
+
 			objRef := objRefs[0].ObjectRef
 			object, err := rpmObjectLookup(root, objRef)
 			switch {


### PR DESCRIPTION
`RPMDefsToVulns` and `DpkgDefsToVulns` both do this:

```go
objRefs := test.ObjectRef()
stateRefs := test.StateRef()
...
objRef := objRefs[0].ObjectRef
```

and then, a few lines further down, guard the sibling with `if len(stateRefs) > 0`. The comment above explains why the state reference is optional and the object reference is required, but "required by the schema" is not the same as "present in the document": goval-parser does not enforce it, so a test element with no `<object>` child parses fine and then indexes an empty slice.

```
panic: runtime error: index out of range [0] with length 0
```

That happens while unpacking criterions during an update, so a single malformed test element in a fetched OVAL feed takes down the updater rather than costing one vulnerability.

Both call sites now skip the criterion, which is what already happens when the object lookup itself fails. rpm.go logs at debug like the lookup failures around it; dpkg.go increments the existing `stats.Obj` counter, which is reported at the end of the run.

`TestDefsToVulnsWithoutObjectRef` parses a minimal OVAL document with the object reference omitted and runs both entry points over it. On the unmodified tree the rpminfo case panics and takes the test binary with it; with this change both return no vulnerabilities and no error. `go test ./pkg/ovalutil/` passes.
