### PR TITLE
cpe: bindfs optimisations

### DIFF
--- a/toolkit/types/cpe/bench_test.go
+++ b/toolkit/types/cpe/bench_test.go
@@ -26,3 +26,21 @@ func BenchmarkUnmarshalFS(b *testing.B) {
 	b.Run("Simple", inner(cpeFS))
 	b.Run("Escape", inner(cpeEscapeFS))
 }
+
+func BenchmarkBindFS(b *testing.B) {
+	inner := func(in string) func(*testing.B) {
+		return func(b *testing.B) {
+			var out WFN
+			if err := out.UnmarshalFS(in); err != nil {
+				b.Fatal(err)
+			}
+			b.ReportAllocs()
+			for b.Loop() {
+				s := out.BindFS()
+				_ = s
+			}
+		}
+	}
+	b.Run("Simple", inner(cpeFS))
+	b.Run("Escape", inner(cpeEscapeFS))
+}

--- a/toolkit/types/cpe/bench_test.go
+++ b/toolkit/types/cpe/bench_test.go
@@ -27,24 +27,6 @@ func BenchmarkUnmarshalFS(b *testing.B) {
 	b.Run("Escape", inner(cpeEscapeFS))
 }
 
-func BenchmarkBindFS(b *testing.B) {
-	inner := func(in string) func(*testing.B) {
-		return func(b *testing.B) {
-			var out WFN
-			if err := out.UnmarshalFS(in); err != nil {
-				b.Fatal(err)
-			}
-			b.ReportAllocs()
-			for b.Loop() {
-				s := out.BindFS()
-				_ = s
-			}
-		}
-	}
-	b.Run("Simple", inner(cpeFS))
-	b.Run("Escape", inner(cpeEscapeFS))
-}
-
 func BenchmarkAppendText(b *testing.B) {
 	inner := func(in string) func(*testing.B) {
 		return func(b *testing.B) {

--- a/toolkit/types/cpe/bench_test.go
+++ b/toolkit/types/cpe/bench_test.go
@@ -44,3 +44,24 @@ func BenchmarkBindFS(b *testing.B) {
 	b.Run("Simple", inner(cpeFS))
 	b.Run("Escape", inner(cpeEscapeFS))
 }
+
+func BenchmarkAppendText(b *testing.B) {
+	inner := func(in string) func(*testing.B) {
+		return func(b *testing.B) {
+			var out WFN
+			if err := out.UnmarshalFS(in); err != nil {
+				b.Fatal(err)
+			}
+			b.ReportAllocs()
+			// Is it cheating to make this properly sized? Dunno.
+			tmp := make([]byte, 0, len(in))
+			for b.Loop() {
+				if _, err := out.AppendText(tmp); err != nil {
+					b.Error(err)
+				}
+			}
+		}
+	}
+	b.Run("Simple", inner(cpeFS))
+	b.Run("Escape", inner(cpeEscapeFS))
+}

--- a/toolkit/types/cpe/bind.go
+++ b/toolkit/types/cpe/bind.go
@@ -3,41 +3,22 @@ package cpe
 import (
 	"encoding"
 	"errors"
-	"strings"
 	"unsafe"
 )
 
 // BindFS returns the WFN bound as CPE 2.3 formatted string.
+//
+// Deprecated: use [WFN.AppendText].
+//
+//go:fix inline
 func (w WFN) BindFS() string {
-	b := strings.Builder{}
-	b.WriteString(`cpe:2.3`)
-	for i := range NumAttr {
-		b.WriteByte(':')
-		w.Attr[i].bind(&b)
+	b := make([]byte, 0, 64)
+	b, err := w.AppendText(b)
+	if err != nil {
+		panic(err)
 	}
-	return b.String()
+	return string(b)
 }
-
-// Bind binds the value to a formatted string, writing it into the provided
-// strings.Builder.
-func (v *Value) bind(b *strings.Builder) (err error) {
-	switch v.Kind {
-	case ValueUnset, ValueAny:
-		_, err = b.WriteRune('*')
-	case ValueNA:
-		_, err = b.WriteRune('-')
-	case ValueSet:
-		_, err = valueString.WriteString(b, v.V)
-	}
-	return err
-}
-
-// ValueString does FS character replacing.
-var valueString = strings.NewReplacer(
-	`\.`, `.`,
-	`\-`, `-`,
-	`\_`, `_`,
-)
 
 var _ encoding.TextAppender = (*WFN)(nil)
 

--- a/toolkit/types/cpe/bind.go
+++ b/toolkit/types/cpe/bind.go
@@ -1,6 +1,11 @@
 package cpe
 
-import "strings"
+import (
+	"encoding"
+	"errors"
+	"strings"
+	"unsafe"
+)
 
 // BindFS returns the WFN bound as CPE 2.3 formatted string.
 func (w WFN) BindFS() string {
@@ -33,3 +38,59 @@ var valueString = strings.NewReplacer(
 	`\-`, `-`,
 	`\_`, `_`,
 )
+
+var _ encoding.TextAppender = (*WFN)(nil)
+
+// AppendText implements [encoding.TextAppender].
+func (w *WFN) AppendText(b []byte) ([]byte, error) {
+	switch err := w.Valid(); {
+	case err == nil:
+	case errors.Is(err, ErrUnset):
+		return b, nil
+	default:
+		return nil, err
+	}
+	b = append(b, 'c', 'p', 'e', ':', '2', '.', '3')
+	for i := range NumAttr {
+		// Cannot error
+		b = (&w.Attr[i]).append(b)
+	}
+	return b, nil
+}
+
+// Append appends a separator and the bound value of the receiver.
+//
+// The [Value.String] representation is meant for display, whereas this is
+// mainly meant for use in [WFN.AppendText].
+//
+// This method does no validation on the receiver.
+func (v *Value) append(b []byte) []byte {
+	b = append(b, ':')
+	switch v.Kind {
+	case ValueUnset, ValueAny:
+		return append(b, '*')
+	case ValueNA:
+		return append(b, '-')
+	case ValueSet:
+	default:
+		panic("unreachable")
+	}
+
+	esc := false
+	// SAFETY: This is all read-only.
+	for _, c := range unsafe.Slice(unsafe.StringData(v.V), len(v.V)) {
+		switch {
+		case !esc && c == '\\':
+			esc = true
+			continue
+		case esc && (c != '.' && c != '-' && c != '_'):
+			b = append(b, '\\')
+			fallthrough
+		case esc:
+			esc = false
+		default:
+		}
+		b = append(b, c)
+	}
+	return b
+}

--- a/toolkit/types/cpe/marshaling.go
+++ b/toolkit/types/cpe/marshaling.go
@@ -9,14 +9,13 @@ import (
 
 // MarshalText implements [encoding.TextMarshaler].
 func (w *WFN) MarshalText() ([]byte, error) {
-	switch err := w.Valid(); {
-	case err == nil:
-	case errors.Is(err, ErrUnset):
-		return []byte{}, nil
-	default:
-		return nil, err
-	}
-	return []byte(w.BindFS()), nil
+	// Guess at a good initial size. Calculated via finding the mean size across
+	// the CPE Name dictionary and then rounding it up.
+	//
+	// 	zcat testdata/dictionary.list.gz | awk '/^#/{next}/^$/{next}{ct++;sum+=length($0)}END{print sum/ct}'
+	// 	55.9444 = 64
+	b := make([]byte, 0, 64)
+	return w.AppendText(b)
 }
 
 // UnmarshalText implements [encoding.TextUnmarshaler].

--- a/toolkit/types/cpe/marshaling_test.go
+++ b/toolkit/types/cpe/marshaling_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestMarshal(t *testing.T) {
 	t.Parallel()
-	var names = []string{
+	names := []string{
 		`cpe:2.3:a:foo\\bar:big\$money:2010:*:*:*:special:ipod_touch:80gb:*`,
 		`cpe:2.3:a:foo\\bar:big\$money_2010:*:*:*:*:special:ipod_touch:80gb:*`,
 		`cpe:2.3:a:hp:insight:7.4.0.1570:-:*:*:online:win2003:x64:*`,
@@ -121,6 +121,25 @@ func TestMarshal(t *testing.T) {
 				t.Error(err)
 			}
 			if got, want := wfn.String(), n; got != want {
+				t.Error(cmp.Diff(got, want))
+			}
+		}
+	})
+	t.Run("Equivalent", func(t *testing.T) {
+		for _, n := range names {
+			if n == "" {
+				continue
+			}
+			var wfn WFN
+			if err := wfn.UnmarshalFS(n); err != nil {
+				t.Error(err)
+			}
+			s := wfn.BindFS()
+			b, err := wfn.AppendText(nil)
+			if err != nil {
+				t.Error(err)
+			}
+			if got, want := string(b), s; got != want {
 				t.Error(cmp.Diff(got, want))
 			}
 		}

--- a/toolkit/types/cpe/wfn.go
+++ b/toolkit/types/cpe/wfn.go
@@ -145,9 +145,7 @@ const (
 
 // String implements [fmt.Stringer].
 func (v *Value) String() string {
-	var b strings.Builder
-	v.bind(&b)
-	return b.String()
+	return string(v.append(nil)[1:]) // Remove leading ":"
 }
 
 // GoString implements [fmt.GoStringer].
@@ -203,7 +201,11 @@ func (w WFN) String() string {
 	case errors.Is(err, ErrUnset):
 		return ""
 	}
-	return w.BindFS()
+	b, _ := w.AppendText(make([]byte, 0, 64))
+	if len(b) == 0 {
+		return ""
+	}
+	return string(b)
 }
 
 // GoString implements [fmt.GoStringer].

--- a/toolkit/types/cpe/wfn_test.go
+++ b/toolkit/types/cpe/wfn_test.go
@@ -2,6 +2,7 @@ package cpe
 
 import (
 	"bufio"
+	"bytes"
 	"compress/gzip"
 	"errors"
 	"fmt"
@@ -451,22 +452,31 @@ func TestDictionary(t *testing.T) {
 	defer gz.Close()
 
 	s := bufio.NewScanner(gz)
+	defer func() {
+		if err := s.Err(); err != nil {
+			t.Error(err)
+		}
+	}()
+	back := make([]byte, 0, 128)
 	for i := 1; s.Scan(); i++ {
 		in := s.Text()
 		if len(in) == 0 || strings.HasPrefix(in, "#") {
 			continue
 		}
-		wfn, err := Unbind(in)
+
+		var wfn WFN
+		if err := wfn.UnmarshalFS(in); err != nil {
+			t.Fatalf("%v: %#q", err, in)
+		}
+		b, err := wfn.AppendText(back[:0])
 		if err != nil {
 			t.Fatalf("%v: %#q", err, in)
 		}
-		if got, want := wfn.BindFS(), s.Text(); got != want {
-			t.Logf(fmt, i, in, got, want)
+
+		if got, want := b, s.Bytes(); !bytes.Equal(got, want) {
+			t.Logf(fmt, i, in, string(got), string(want))
 			t.Logf("wfn: %#v", wfn)
 			t.Fail()
 		}
-	}
-	if err := s.Err(); err != nil {
-		t.Error(err)
 	}
 }


### PR DESCRIPTION
This implements `encoding.AppendText` and then implements binding a WFN to a string on top of it.

Benchmarks:
```
% go test -run none -bench 'Bind|Append' 
goos: linux
goarch: amd64
pkg: github.com/quay/claircore/toolkit/types/cpe
cpu: 11th Gen Intel(R) Core(TM) i7-11850H @ 2.50GHz
BenchmarkBindFS/Simple-16 	 2466998	       495.0 ns/op	     280 B/op	       6 allocs/op
BenchmarkBindFS/Escape-16 	 2515683	       491.7 ns/op	     280 B/op	       6 allocs/op
BenchmarkAppendText/Simple-16         	 3454317	       348.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkAppendText/Escape-16         	 2717823	       453.5 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/quay/claircore/toolkit/types/cpe	4.898s
```