### PR TITLE
vex: update Red Hat VEX URL to the new feed

### DIFF
--- a/rhel/vex/parser.go
+++ b/rhel/vex/parser.go
@@ -152,7 +152,7 @@ func docLinkFromBase(base *url.URL, name string) string {
 // NewParser creates a new Parser with initialised caches.
 //
 // The default base URL is [BaseURL]. Callers that ingest a different feed
-// (for example the beta vex-feed) should pass [WithBaseURL].
+// should pass [WithBaseURL].
 func NewParser(opts ...ParserOption) *Parser {
 	base, err := url.Parse(BaseURL)
 	if err != nil {
@@ -1293,13 +1293,12 @@ func (c *creator) checkPURL(purl *packageurl.PackageURL) bool {
 // are skipped because they either do not represent a runnable kernel or are
 // commonly present in userspace images without implying kernel vulnerability.
 //
-// TODO(crozzy): Revisit (and likely remove) this allowlist once claircore
-// switches from the current VEX feed (/vex/) to the new feed (/vex-feed/). The
-// old feed puts packages like kernel-headers and kernel-doc into fixed and
-// known_affected for many CVEs; the new feed largely moves those to
-// known_not_affected (kernel-headers: zero fixed/known_affected in the archive).
-// Until that switch, the allowlist avoids flooding images that ship
-// headers/docs with kernel findings from the old feed.
+// TODO(crozzy): Revisit (and likely remove) this allowlist now that the default
+// feed is /vex-feed/, which largely moves packages like kernel-headers and
+// kernel-doc to known_not_affected (kernel-headers: zero fixed/known_affected
+// in the archive). The allowlist remains for operators still pointing at the
+// legacy /vex/ feed via config, where those packages appear in fixed and
+// known_affected.
 //
 // Operators who need the historical skip-all-kernel behaviour can set
 // ignore_kernel_packages on the rhel-vex updater config.

--- a/rhel/vex/parser_test.go
+++ b/rhel/vex/parser_test.go
@@ -741,28 +741,28 @@ func TestCheckKernelPackage(t *testing.T) {
 
 func TestCreatorDocLink(t *testing.T) {
 	const name = "CVE-2023-4911"
-	selfURL := "https://security.access.redhat.com/data/csaf/v2/vex/2023/cve-2023-4911.json"
-	betaBase, err := url.Parse("https://security.access.redhat.com/data/csaf/v2/vex-feed/")
+	defaultURL := "https://security.access.redhat.com/data/csaf/v2/vex-feed/2023/cve-2023-4911.json"
+	legacyBase, err := url.Parse("https://security.access.redhat.com/data/csaf/v2/vex/")
 	if err != nil {
 		t.Fatal(err)
 	}
-	betaURL := "https://security.access.redhat.com/data/csaf/v2/vex-feed/2023/cve-2023-4911.json"
+	legacyURL := "https://security.access.redhat.com/data/csaf/v2/vex/2023/cve-2023-4911.json"
 
 	t.Run("constructs from default base when self missing", func(t *testing.T) {
 		doc := &csaf.CSAF{}
 		doc.Document.Tracking.ID = name
 		c := NewParser().creator(name, doc)
-		if c.docLink != selfURL {
-			t.Fatalf("got docLink %q, want %q", c.docLink, selfURL)
+		if c.docLink != defaultURL {
+			t.Fatalf("got docLink %q, want %q", c.docLink, defaultURL)
 		}
 	})
 
 	t.Run("constructs from configured base when self missing", func(t *testing.T) {
 		doc := &csaf.CSAF{}
 		doc.Document.Tracking.ID = name
-		c := NewParser(WithBaseURL(betaBase)).creator(name, doc)
-		if c.docLink != betaURL {
-			t.Fatalf("got docLink %q, want %q", c.docLink, betaURL)
+		c := NewParser(WithBaseURL(legacyBase)).creator(name, doc)
+		if c.docLink != legacyURL {
+			t.Fatalf("got docLink %q, want %q", c.docLink, legacyURL)
 		}
 	})
 
@@ -771,11 +771,11 @@ func TestCreatorDocLink(t *testing.T) {
 		doc.Document.Tracking.ID = name
 		doc.Document.References = []csaf.Reference{{
 			Category: "self",
-			URL:      selfURL,
+			URL:      legacyURL,
 		}}
-		c := NewParser(WithBaseURL(betaBase)).creator(name, doc)
-		if c.docLink != selfURL {
-			t.Fatalf("got docLink %q, want %q", c.docLink, selfURL)
+		c := NewParser().creator(name, doc)
+		if c.docLink != legacyURL {
+			t.Fatalf("got docLink %q, want %q", c.docLink, legacyURL)
 		}
 	})
 
@@ -803,7 +803,7 @@ func TestDocLinkFromBase(t *testing.T) {
 		{
 			name: "cve",
 			id:   "CVE-2023-4911",
-			want: "https://security.access.redhat.com/data/csaf/v2/vex/2023/cve-2023-4911.json",
+			want: "https://security.access.redhat.com/data/csaf/v2/vex-feed/2023/cve-2023-4911.json",
 		},
 		{
 			name: "non-cve",

--- a/rhel/vex/updater.go
+++ b/rhel/vex/updater.go
@@ -28,15 +28,15 @@ const (
 	// BaseURL is the base url for the Red Hat VEX security data.
 	//
 	//doc:url updater
-	BaseURL = "https://security.access.redhat.com/data/csaf/v2/vex/"
+	BaseURL = "https://security.access.redhat.com/data/csaf/v2/vex-feed/"
 
-	defaultCompressedFileTimeout = 2 * time.Minute
+	defaultCompressedFileTimeout = 5 * time.Minute
 	latestFile                   = "archive_latest.txt"
 	changesFile                  = "changes.csv"
 	deletionsFile                = "deletions.csv"
 	lookBackToYear               = 2015
 	repoKey                      = "rhel-cpe-repository"
-	updaterVersion               = "6"
+	updaterVersion               = "7"
 )
 
 // Factory creates an Updater to process all of the Red Hat VEX data.


### PR DESCRIPTION
Red Hat Product Security now produces a new security feed with some data improvements. This patch changes the default VEX URL, this URL can be changed via the updater config if desired.