### PR TITLE
osv: backport non-applicable ecosystem advisory filter to stable-1.5.44

### DIFF
--- a/datastore/postgres/migrations/matcher/17-force-osv-ecosystem-filter.sql
+++ b/datastore/postgres/migrations/matcher/17-force-osv-ecosystem-filter.sql
@@ -1,0 +1,14 @@
+-- Force per-ecosystem OSV updaters to re-fetch and re-parse after filtering
+-- affected entries to the dump's ecosystem. Multi-ecosystem advisories
+-- previously produced cross-ecosystem vulnerability rows (e.g. npm ranges
+-- under osv/pypi).
+DELETE FROM update_operation
+WHERE
+  updater LIKE 'osv/%';
+
+DELETE FROM vuln v1 USING vuln v2
+LEFT JOIN uo_vuln uvl ON v2.id = uvl.vuln
+WHERE
+  uvl.vuln IS NULL
+  AND v2.updater LIKE 'osv/%'
+  AND v1.id = v2.id;

--- a/updater/osv/osv.go
+++ b/updater/osv/osv.go
@@ -144,11 +144,7 @@ func (f *Factory) UpdaterSet(ctx context.Context) (s driver.UpdaterSet, err erro
 		scr := bufio.NewScanner(res.Body)
 		for scr.Scan() {
 			k := scr.Text()
-			e := strings.ToLower(k)
-			// Currently, there's some versioned ecosystems. This branch removes the versioning.
-			if idx := strings.Index(e, ":"); idx != -1 {
-				e = e[:idx]
-			}
+			e := normalizeEcosystem(k)
 			// Check for duplicates, removing the version will create some.
 			if _, ok := seen[e]; ok {
 				continue
@@ -487,6 +483,23 @@ const (
 	ecosystemRubyGems = `RubyGems`
 )
 
+// normalizeEcosystem lowercases an OSV ecosystem name and strips any colon
+// suffix (e.g. "Debian:11" → "debian", "Alpine:v3.17" → "alpine").
+//
+// This matches how OSV derives per-ecosystem dump directory names from
+// package.ecosystem values: dumps are keyed by the ecosystem prefix without
+// the ":.*" suffix, and the canonical list is ecosystems.txt. See:
+//   - https://google.github.io/osv.dev/data/#ecosystem-naming
+//   - https://osv-vulnerabilities.storage.googleapis.com/ecosystems.txt
+//   - https://ossf.github.io/osv-schema/#affectedpackage-field
+func normalizeEcosystem(e string) string {
+	e = strings.ToLower(e)
+	if idx := strings.Index(e, ":"); idx != -1 {
+		e = e[:idx]
+	}
+	return e
+}
+
 func newECS(u string) ecs {
 	return ecs{
 		Updater:   u,
@@ -557,8 +570,16 @@ func (e *ecs) Insert(ctx context.Context, skipped *stats, name string, a *adviso
 		b.WriteString(aliasBaseURL + alias)
 	}
 	proto.Links = b.String()
+	dumpEcosystem := normalizeEcosystem(name)
 	for i := range a.Affected {
 		af := &a.Affected[i]
+		// Per-ecosystem dumps still embed full multi-ecosystem advisories.
+		// Compare normalized package.ecosystem to the dump name (see
+		// normalizeEcosystem) so foreign entries (e.g. npm in a PyPI dump)
+		// are not attached to the wrong repo.
+		if normalizeEcosystem(af.Package.Ecosystem) != dumpEcosystem {
+			continue
+		}
 		for _, r := range af.Ranges {
 			vers := []*rangeVer{}
 			switch r.Type {

--- a/updater/osv/osv_test.go
+++ b/updater/osv/osv_test.go
@@ -156,11 +156,13 @@ func TestParse(t *testing.T) {
 
 var insertTestCases = []struct {
 	name          string
+	dump          string
 	ad            *advisory
 	expectedVulns []claircore.Vulnerability
 }{
 	{
 		name: "normal",
+		dump: "go",
 		ad: &advisory{
 			ID: "test1",
 			Affected: []affected{
@@ -199,6 +201,7 @@ var insertTestCases = []struct {
 	},
 	{
 		name: "unfixed",
+		dump: "go",
 		ad: &advisory{
 			ID: "test1",
 			Affected: []affected{
@@ -237,6 +240,7 @@ var insertTestCases = []struct {
 	},
 	{
 		name: "two_affected",
+		dump: "go",
 		ad: &advisory{
 			ID: "test1",
 			Affected: []affected{
@@ -303,6 +307,7 @@ var insertTestCases = []struct {
 	},
 	{
 		name: "three_fixes",
+		dump: "go",
 		ad: &advisory{
 			ID: "test1",
 			Affected: []affected{
@@ -371,6 +376,7 @@ var insertTestCases = []struct {
 	},
 	{
 		name: "two_fixes_one_unfixed",
+		dump: "go",
 		ad: &advisory{
 			ID: "test1",
 			Affected: []affected{
@@ -440,6 +446,7 @@ var insertTestCases = []struct {
 	{
 		// In this situation we're just expecting the last one.
 		name: "two_consecutive_introduced_invalid",
+		dump: "go",
 		ad: &advisory{
 			ID: "test1",
 			Affected: []affected{
@@ -481,6 +488,7 @@ var insertTestCases = []struct {
 	},
 	{
 		name: "ecosystem_multi",
+		dump: "pypi",
 		ad: &advisory{
 			ID: "test1",
 			Affected: []affected{
@@ -528,6 +536,7 @@ var insertTestCases = []struct {
 	},
 	{
 		name: "ecosystem_unfixed",
+		dump: "pypi",
 		ad: &advisory{
 			ID: "test1",
 			Affected: []affected{
@@ -560,6 +569,7 @@ var insertTestCases = []struct {
 	},
 	{
 		name: "same package different ranges",
+		dump: "maven",
 		ad: &advisory{
 			ID: "test1",
 			Affected: []affected{
@@ -610,6 +620,7 @@ var insertTestCases = []struct {
 	},
 	{
 		name: "npm_ecosystem_range_skipped",
+		dump: "npm",
 		ad: &advisory{
 			ID: "GHSA-test-npm-1",
 			Affected: []affected{
@@ -638,6 +649,7 @@ var insertTestCases = []struct {
 	},
 	{
 		name: "go_ecosystem_range_skipped",
+		dump: "go",
 		ad: &advisory{
 			ID: "GHSA-test-go-1",
 			Affected: []affected{
@@ -664,6 +676,61 @@ var insertTestCases = []struct {
 		},
 		expectedVulns: nil,
 	},
+	{
+		name: "skip_other_ecosystems",
+		dump: "pypi",
+		ad: &advisory{
+			ID: "GHSA-3644-q5cj-c5c7",
+			Affected: []affected{
+				{
+					Package: _package{
+						Ecosystem: "PyPI",
+						Name:      "langsmith",
+					},
+					Ranges: []_range{
+						{
+							Type: "ECOSYSTEM",
+							Events: []rangeEvent{
+								{
+									Introduced: "0",
+								},
+								{
+									Fixed: "0.8.0",
+								},
+							},
+						},
+					},
+				},
+				{
+					Package: _package{
+						Ecosystem: "npm",
+						Name:      "langsmith",
+					},
+					Ranges: []_range{
+						{
+							Type: "SEMVER",
+							Events: []rangeEvent{
+								{
+									Introduced: "0",
+								},
+								{
+									Fixed: "0.6.0",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		expectedVulns: []claircore.Vulnerability{
+			{
+				Name:           "GHSA-3644-q5cj-c5c7",
+				Updater:        "test",
+				Range:          nil,
+				FixedInVersion: "fixed=0.8.0",
+			},
+		},
+	},
 }
 
 // cmpIgnore will ignore everything expect the Name, Updater, Range and FixedInVersion.
@@ -677,7 +744,7 @@ func TestInsert(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ecs := newECS("test")
 
-			err := ecs.Insert(ctx, nil, "", tt.ad)
+			err := ecs.Insert(ctx, nil, tt.dump, tt.ad)
 			if err != nil {
 				t.Error("got error Inserting advisory", err)
 			}
@@ -835,7 +902,7 @@ func TestSeverityParsing(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ecs := newECS("test")
 
-			err := ecs.Insert(ctx, nil, "", tt.a)
+			err := ecs.Insert(ctx, nil, "go", tt.a)
 			if err != nil {
 				t.Error("got error Inserting advisory", err)
 			}
@@ -936,7 +1003,7 @@ func TestInsertLinksAliases(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			e := newECS("osv")
 			var st stats
-			if err := (&e).Insert(ctx, &st, "pkg", &tt.adv); err != nil {
+			if err := (&e).Insert(ctx, &st, "go", &tt.adv); err != nil {
 				t.Fatalf("Insert() error: %v", err)
 			}
 			if len(e.Vulnerability) == 0 {


### PR DESCRIPTION
Backports #1958 ("osv: exclude advisories from non applicable ecosystems") to `stable-1.5.44`.

## Problem

OSV publishes per-ecosystem dumps that still embed advisories covering *other* ecosystems. The OSV updater ingested every `affected` entry regardless of `package.ecosystem`, so fix data from a foreign ecosystem leaked into the wrong repo. Concretely, PyPI `langsmith` 0.10.16 was flagged for CVE-2026-45134 (GHSA-3644-q5cj-c5c7) using npm's fix version `0.6.0` (lower than the installed version) instead of PyPI's `0.8.0`, producing a false positive.

## Fix

Cherry-pick of upstream `3f07716d`:
- `updater/osv/osv.go`: skip `affected` entries whose normalized ecosystem doesn't match the dump's ecosystem (`normalizeEcosystem(af.Package.Ecosystem) != dumpEcosystem`).
- matcher migration to force the OSV updaters to re-fetch/re-parse and drop the contaminated rows.
- regression test `TestInsert/skip_other_ecosystems` (PyPI `0.8.0` vs npm `0.6.0`).

## Backport adaptations for `stable-1.5.44`

- Migration renumbered `20-` → `17-`: this branch's matcher migrations top out at `16`, and migrations are applied by readdir position rather than the filename number (`migrations.go`: `id := i + 1`), so this is naming-only — the runtime behavior is unchanged.
- Removed the `Vulnerability.Self` / `claircore.Alias` expectation from the new test case: typed aliases (`unique.Make`, `Self`) don't exist on this branch, and `cmpIgnore` doesn't compare that field. The test still asserts `FixedInVersion="fixed=0.8.0"`, i.e. npm's `0.6.0` no longer leaks into the PyPI record.

## Testing

`go test ./updater/osv/...` passes, including the new `skip_other_ecosystems` case.
