### PR TITLE
internal/rpm: accept every type in a tag's class when loading package info

### DIFF
--- a/internal/rpm/info.go
+++ b/internal/rpm/info.go
@@ -50,31 +50,36 @@ func (i *Info) Load(ctx context.Context, h *rpmdb.Header) error {
 		}
 		switch e.Tag {
 		case rpmdb.TagName:
-			i.Name = v.(string)
+			i.Name, err = tagString(e, v)
 		case rpmdb.TagEpoch:
-			i.Epoch = int(v.([]int32)[0])
+			i.Epoch, err = tagInt(e, v)
 		case rpmdb.TagVersion:
-			i.Version = v.(string)
+			i.Version, err = tagString(e, v)
 		case rpmdb.TagRelease:
-			i.Release = v.(string)
+			i.Release, err = tagString(e, v)
 		case rpmdb.TagSourceRPM:
-			i.SourceRPM = v.(string)
+			i.SourceRPM, err = tagString(e, v)
 		case rpmdb.TagModularityLabel:
-			i.Module = v.(string)
+			i.Module, err = tagString(e, v)
 		case rpmdb.TagArch:
-			i.Arch = v.(string)
+			i.Arch, err = tagString(e, v)
 		case rpmdb.TagPayloadDigestAlgo:
-			i.DigestAlgo = int(v.([]int32)[0])
+			i.DigestAlgo, err = tagInt(e, v)
 		case rpmdb.TagPayloadDigest:
-			i.Digest = v.([]string)[0]
+			i.Digest, err = tagString(e, v)
 		case rpmdb.TagSigPGP:
-			i.Signature = v.([]byte)
+			b, ok := v.([]byte)
+			if !ok {
+				err = badTagType(e, v)
+				break
+			}
+			i.Signature = b
 		case rpmdb.TagDirnames: // v5-only
-			i.dirname = v.([]string)
+			i.dirname, err = tagStrings(e, v)
 		case rpmdb.TagDirindexes: // v5-only
-			i.dirindex = v.([]int32)
+			i.dirindex, err = tagInt32s(e, v)
 		case rpmdb.TagBasenames: // v5-only
-			i.basename = v.([]string)
+			i.basename, err = tagStrings(e, v)
 		case rpmdb.TagFilenames:
 			// Filenames is the tag used in rpm4 -- this is a best-effort for
 			// supporting it. This should be exclusive with the
@@ -82,7 +87,11 @@ func (i *Info) Load(ctx context.Context, h *rpmdb.Header) error {
 			//
 			// This takes the whole filenames value and splits it into an
 			// rpm5-style dir+base.
-			names := v.([]string)
+			names, nerr := tagStrings(e, v)
+			if nerr != nil {
+				err = nerr
+				break
+			}
 			slices.Sort(names)
 			i.dirname = make([]string, 0)
 			i.dirindex = make([]int32, 0, len(names))
@@ -100,6 +109,9 @@ func (i *Info) Load(ctx context.Context, h *rpmdb.Header) error {
 		default:
 			panic(fmt.Sprintf("programmer error: unhandled tag: %v", e.Tag))
 		}
+		if err != nil {
+			return err
+		}
 	}
 
 	if b, d := len(i.basename), len(i.dirindex); b != d {
@@ -112,6 +124,80 @@ func (i *Info) Load(ctx context.Context, h *rpmdb.Header) error {
 	}
 
 	return nil
+}
+
+// The header verifier accepts an entry whose type merely shares a class with
+// the type named in the tag table, because, as checkTagType says, "Some
+// versions of string are typed incorrectly in a compatible way". ReadData
+// hands back whatever the entry declared, so the helpers below accept every
+// member of the relevant class rather than one concrete Go type. A value
+// outside the class is reported instead of panicking, which lets the caller
+// skip the one package and carry on reading the database.
+
+func badTagType(e *rpmdb.EntryInfo, v any) error {
+	return fmt.Errorf("internal/rpm: Info: tag %v: unexpected type %v (%T)", e.Tag, e.Type, v)
+}
+
+// tagString returns the string value of a string-class entry.
+func tagString(e *rpmdb.EntryInfo, v any) (string, error) {
+	switch v := v.(type) {
+	case string:
+		return v, nil
+	case []string:
+		if len(v) == 0 {
+			return "", fmt.Errorf("internal/rpm: Info: tag %v: empty string array", e.Tag)
+		}
+		return v[0], nil
+	}
+	return "", badTagType(e, v)
+}
+
+// tagStrings returns the string slice of a string-class entry.
+func tagStrings(e *rpmdb.EntryInfo, v any) ([]string, error) {
+	switch v := v.(type) {
+	case string:
+		return []string{v}, nil
+	case []string:
+		return v, nil
+	}
+	return nil, badTagType(e, v)
+}
+
+// tagInt32s returns the int32 slice of a numeric-class entry.
+func tagInt32s(e *rpmdb.EntryInfo, v any) ([]int32, error) {
+	switch v := v.(type) {
+	case []int32:
+		return v, nil
+	case []int16:
+		return widen(v), nil
+	case []int8:
+		return widen(v), nil
+	case []byte:
+		return widen(v), nil
+	case []uint64:
+		return widen(v), nil
+	}
+	return nil, badTagType(e, v)
+}
+
+// tagInt returns the first integer of a numeric-class entry.
+func tagInt(e *rpmdb.EntryInfo, v any) (int, error) {
+	ns, err := tagInt32s(e, v)
+	if err != nil {
+		return 0, err
+	}
+	if len(ns) == 0 {
+		return 0, fmt.Errorf("internal/rpm: Info: tag %v: empty numeric array", e.Tag)
+	}
+	return int(ns[0]), nil
+}
+
+func widen[S ~[]E, E ~int8 | ~int16 | ~uint8 | ~uint64](s S) []int32 {
+	out := make([]int32, len(s))
+	for i, v := range s {
+		out[i] = int32(v)
+	}
+	return out
 }
 
 // Path reconstructs the j-th path.

--- a/internal/rpm/info_test.go
+++ b/internal/rpm/info_test.go
@@ -1,0 +1,79 @@
+package rpm
+
+import (
+	"bytes"
+	"encoding/binary"
+	"os"
+	"testing"
+
+	"github.com/quay/claircore/internal/rpm/rpmdb"
+)
+
+// retypeTag rewrites the Type of the entry for the named tag in a serialized
+// rpm header. The header is a preamble of two uint32s followed by fixed-size
+// entries of tag, type, offset and count, all big-endian.
+func retypeTag(t *testing.T, header []byte, tag rpmdb.Tag, want rpmdb.Kind) []byte {
+	t.Helper()
+	const (
+		preambleSize  = 8
+		entryInfoSize = 16
+	)
+
+	out := bytes.Clone(header)
+	count := binary.BigEndian.Uint32(out[0:])
+	for i := uint32(0); i < count; i++ {
+		off := preambleSize + int(i)*entryInfoSize
+		if rpmdb.Tag(binary.BigEndian.Uint32(out[off:])) != tag {
+			continue
+		}
+		binary.BigEndian.PutUint32(out[off+4:], uint32(want))
+		return out
+	}
+
+	t.Fatalf("tag %v not present in the test header", tag)
+	return nil
+}
+
+// TestInfoLoadClassCompatibleTypes checks that Load tolerates the type
+// substitutions the header verifier deliberately allows.
+//
+// verifyInfo accepts an entry whose Type merely shares a class with the type
+// the tag table names, because, as checkTagType puts it, "Some versions of
+// string are typed incorrectly in a compatible way". ReadData then returns the
+// type that was declared rather than the one the tag table expects, so Load
+// used to assert the wrong concrete type and panic on a header that the
+// verifier had just accepted.
+func TestInfoLoadClassCompatibleTypes(t *testing.T) {
+	ctx := t.Context()
+
+	header, err := os.ReadFile("rpmdb/testdata/package.header")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		tag  rpmdb.Tag
+		kind rpmdb.Kind
+	}{
+		{"name as i18n string", rpmdb.TagName, rpmdb.TypeI18nString},
+		{"name as string array", rpmdb.TagName, rpmdb.TypeStringArray},
+		{"version as string array", rpmdb.TagVersion, rpmdb.TypeStringArray},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mutated := retypeTag(t, header, tc.tag, tc.kind)
+
+			h, err := rpmdb.ParseHeader(ctx, bytes.NewReader(mutated))
+			if err != nil {
+				t.Skipf("header verifier rejected this entry, so Load is unreachable: %v", err)
+			}
+
+			var i Info
+			if err := i.Load(ctx, h); err != nil {
+				t.Logf("Load reported an error, which is fine: %v", err)
+				return
+			}
+			t.Logf("Load succeeded: name=%q version=%q", i.Name, i.Version)
+		})
+	}
+}


### PR DESCRIPTION
`Info.Load` asserts one concrete Go type per tag, but the header verifier does not guarantee one. `verifyInfo` accepts an entry whose `Type` merely shares a *class* with the type named in the tag table, and `checkTagType` says why:

```go
// Check the type. Some versions of string are typed incorrectly in a
// compatible way.
return t == typ || t.class() == typ.class()
```

`TypeString`, `TypeStringArray` and `TypeI18nString` are all `classString`. `ReadData` switches on the type the entry declared rather than on the tag, so a `Name` entry declared as an i18n string or a string array comes back as a `[]string` while `Load` does `v.(string)`. The result is a panic on a header the verifier has just accepted:

```
panic: interface conversion: interface {} is []string, not string
```

The same gap covers every numeric tag, since `TypeChar`, `TypeInt8`, `TypeInt16`, `TypeInt32` and `TypeInt64` share `classNumeric` and yield five different slice types against a single `v.([]int32)`. It is wider still for BDB headers, where there is no region, `typecheck` is false and `checkTagType` is skipped entirely.

Worth noting that this is not contained to the one bad package. Nothing on the path recovers, whereas `Load` returning an error is already handled: the iterator in `database.go` yields it and continues to the next package in the database. So a header like this currently takes down more than it needs to.

This adds small helpers that accept any member of the tag's class, widening the numeric variants to `int32`, and report anything genuinely outside the class.

Verification: a new test in `internal/rpm` rewrites the type field of an entry in `rpmdb/testdata/package.header` and runs the result through the real `ParseHeader`, so the header goes through `verifyInfo` on the way in. It panics on main and passes here, recovering `name="crypto-policies" version="20210213"` in all three cases. `go test ./internal/... ./rpm/...` is unchanged against main, 17 packages, no failures either side.
